### PR TITLE
Update kisao.md

### DIFF
--- a/ontology/kisao.md
+++ b/ontology/kisao.md
@@ -11,8 +11,11 @@ products:
   - id: kisao.owl
 title: Kinetic Simulation Algorithm Ontology
 build:
-  source_url: http://biomodels.net/kisao/KISAO
+  source_url: http://svn.code.sf.net/p/kisao/code/tags/kisao-owl-latest/kisao.owl
   method: owl2obo
+license:
+  url: http://opensource.org/licenses/Artistic-2.0
+  label: Artistic License 2.0
 ---
 
 The Kinetic Simulation Algorithm Ontology (KiSAO) classifies algorithms available for the simulation of models in biology, and their characteristics and the parameters required for their use.


### PR DESCRIPTION
Updated the build url to have a direct link to the file as the redirection present in http://biomodels.net/kisao/KISAO did not seem to work (the current http://purl.obolibrary.org/obo/kisao.owl goes to http://www.berkeleybop.org/ontologies/kisao.owl which give a file not found error).

Added the license information as well.