### PR TITLE
add URL for tracker and creative commons license

### DIFF
--- a/ontology/omp.md
+++ b/ontology/omp.md
@@ -14,6 +14,10 @@ title: Ontology of Microbial Phenotypes
 build:
   source_url: https://raw.githubusercontent.com/microbialphenotypes/OMP-ontology-files/master/omp.obo
   method: obo2owl
+license:
+  url: http://creativecommons.org/licenses/by/3.0/
+  label: CC-BY
+tracker: https://github.com/microbialphenotypes/OMP-ontology/issues
 
 
 ---


### PR DESCRIPTION
I added the URL for the OMP ontology tracker and a CC-BY license to the OMP listing on obofoundry.org