### PR TITLE
Update TechnicalWG.md

### DIFF
--- a/docs/TechnicalWG.md
+++ b/docs/TechnicalWG.md
@@ -39,6 +39,6 @@ See <a href='TechnicalWGMeetings.html'>here</a>
 
 <h1>Contact Us</h1>
 
-The best way to contact the OBO Foundry Technical Working Group is through the <a href='http://code.google.com/p/obo-foundry-operations-committee/issues/list'>issue tracker</a>. Select the Technical group template or the Prefix/domain request template.<br>
+The best way to contact the OBO Foundry Technical Working Group is through the <a href='https://github.com/OBOFoundry/OBOFoundry.github.io/issues'>issue tracker</a>. Select the Technical group template or the Prefix/domain request template.<br>
 <br>
-The mailing list for the OBO Foundry Technical Working Group is <a href='mailto:obo-foundry-editorial-working-group@googlegroups.com'>obo-foundry-editorial-working-group@googlegroups.com</a>. This is currently a closed list, but non-members can post to the list.
+The mailing list for the OBO Foundry Technical Working Group is <a href='mailto:obo-foundry-technical-working-group@googlegroups.com'>obo-foundry-technical-working-group@googlegroups.com</a>. This is currently a closed list, but non-members can post to the list.


### PR DESCRIPTION
1) fixed link to email
2) fixed link to tracker

Note 1: I am unsure if the instructions written for the googlecode tracker also apply to the github tracker. Specifically, "Select the Technical group template..."

The tracker link needs fixing on the Editorial WG page as well, but until I'm sure these changes are correct I'll leave that page alone.