### PR TITLE
Update wbphenotype.md

### DIFF
--- a/ontology/wbphenotype.md
+++ b/ontology/wbphenotype.md
@@ -18,6 +18,9 @@ build:
   source_url: http://tazendra.caltech.edu/~azurebrd/cgi-bin/forms/phenotype_ontology_obo.cgi
   method: obo2owl
   infallible: 0
+  publications:
+  - id: http://www.ncbi.nlm.nih.gov/pubmed/?term=21261995
+  title: "Worm Phenotype Ontology: integrating phenotype data within and beyond the C. elegans community."
 ---
 
 A structured controlled vocabulary of <i>Caenorhabditis elegans</i> phenotypes

--- a/ontology/wbphenotype.md
+++ b/ontology/wbphenotype.md
@@ -20,7 +20,7 @@ build:
   infallible: 0
   publications:
   - id: http://www.ncbi.nlm.nih.gov/pubmed/?term=21261995
-  title: "Worm Phenotype Ontology: integrating phenotype data within and beyond the C. elegans community."
+    title: "Worm Phenotype Ontology: integrating phenotype data within and beyond the C. elegans community."
 ---
 
 A structured controlled vocabulary of <i>Caenorhabditis elegans</i> phenotypes


### PR DESCRIPTION
I received a request from Chris Mungall to add a reference to the wbphenotype page
http://obofoundry.org/ontology/wbphenotype.html
(Chris may be reading this edit request)

I'm not sure I did it correctly...
I forked and then I looked at other pages to see how they added a reference and came up with adding the following to the following lines:
21 publications:
22  - id: http://www.ncbi.nlm.nih.gov/pubmed/?term=21261995
23  title: "Worm Phenotype Ontology: integrating phenotype data within and beyond the C. elegans community."
How this was correct.
Thanks
Gary