### PR TITLE
Patch 2 foodon_core.owl and fix to /imports/ path

### DIFF
--- a/ontology/foodon.md
+++ b/ontology/foodon.md
@@ -13,16 +13,17 @@ license:
   label: CC-BY
 products:
   - id: foodon.owl
-  - id: foodon.obo
-    homepage: http://foodontology.github.io/foodon/
+  - id: foodon_core.owl
 title: FOODON
 dependencies:
  - id: uberon
  - id: ro
+ - id: eo
  - id: chebi
  - id: ncbitaxon
  - id: bfo
  - id: envo
+ - id: obi
 tracker: https://github.com/FoodOntology/foodon/issues/
 ---
 

--- a/ontology/foodon.md
+++ b/ontology/foodon.md
@@ -13,7 +13,11 @@ license:
   label: CC-BY
 products:
   - id: foodon.owl
+    title: FoodOn full ontology including 9000 SIREN indexed food products
+    format: owl-rdf/xml
   - id: foodon_core.owl
+    title: FoodOn core ontology (without SIREN)
+    format: owl-rdf/xml
 title: FOODON
 dependencies:
  - id: uberon


### PR DESCRIPTION
At moment /imports/ path is wrong, preventing ontology from being loaded in OLS etc.