### PR TITLE
Adds license to CDAO metadata

### DIFF
--- a/ontology/cdao.md
+++ b/ontology/cdao.md
@@ -12,6 +12,9 @@ title: Comparative Data Analysis Ontology
 build:
   source_url: http://purl.obolibrary.org/obo/cdao.owl
   method: owl2obo
+license:
+  url: https://creativecommons.org/publicdomain/zero/1.0/
+  label: CC0 1.0 Universal
 ---
 
-a formalization of concepts and relations relevant to evolutionary comparative analysis, such as phylogenetic trees, OTUs (operational taxonomic units) and compared characters (including molecular characters as well as other types). CDAO is being developed by scientists in biology, evolution, and computer science
+A formalization of concepts and relations relevant to evolutionary comparative analysis, such as phylogenetic trees, OTUs (operational taxonomic units) and compared characters (including molecular characters as well as other types). CDAO is being developed by scientists in biology, evolution, and computer science


### PR DESCRIPTION
The license (more specifically, the CC0 public domain waiver) under which CDAO is released actually always has been explicitly stated in the OWL file, but apparently the metadata extractor doesn't pick that up.