### PR TITLE
modify license choice language

### DIFF
--- a/principles/fp-001-open.md
+++ b/principles/fp-001-open.md
@@ -32,7 +32,7 @@ OBO Foundry ontologies are resources for the entire biological and biomedical co
 
 3. If an individual term is reused without change to the definition, the original term IRI should be used. If the definition of a term (either text or logical) is changed, the original term IRI should not be reused. Suggestions for changes or improvements to term definitions should be submitted to the appropriate ontology issue tracker.
 
-4. Regardless of which license an ontology uses, we strongly request and recommend that any reuse of an ontology attributes the source in accordance with scientific norms.
+4. Regardless of which license an ontology uses, we strongly request and recommend that any reuse of an ontology attributes the source in accordance with scientific norms and the [OBO Citation and Attribution Policy](http://www.obofoundry.org/docs/Citation.html).
 
 ### Remark
 

--- a/principles/fp-001-open.md
+++ b/principles/fp-001-open.md
@@ -24,6 +24,8 @@ OBO Foundry ontologies are resources for the entire biological and biomedical co
 
 2. We recommend that new ontologies carefully consider the choice of license. For example, [Creative Commons](https://creativecommons.org/) licenses like [CC0](https://creativecommons.org/publicdomain/zero/1.0/) and [CC-BY](https://creativecommons.org/licenses/by/4.0/) are popular open and understandable licenses. Many pros and cons of each license are laid out in [this discussion](https://github.com/OBOFoundry/OBOFoundry.github.io/issues/285).
 
+Regardless of which license is chosen, it should be clearly stated in the ontology file.
+
 ### For ontology re-use
 
 1. The original source of an ontology must be credited according to the terms specified in the comment annotation of the ontology.

--- a/principles/fp-001-open.md
+++ b/principles/fp-001-open.md
@@ -22,7 +22,7 @@ OBO Foundry ontologies are resources for the entire biological and biomedical co
 
     OR released into the public domain under [CC0](https://creativecommons.org/publicdomain/zero/1.0/) (which is not a license). Note that CC0 specifies that the creators of an ontology waive, to the extent that they legally can be, all rights and place the ontology in the public domain. It does not prevent them from requesting that the ontology be properly credited and cited, but prevents any legal recourse if it is not credited.
 
-2. We recommend that new ontologies carefully consider the choice of license.  Many pros and cons of each license are laid out in [this discussion](https://github.com/OBOFoundry/OBOFoundry.github.io/issues/285). 
+2. We recommend that new ontologies carefully consider the choice of license. For example, [Creative Commons](https://creativecommons.org/) licenses like [CC0](https://creativecommons.org/publicdomain/zero/1.0/) and [CC-BY](https://creativecommons.org/licenses/by/4.0/) are popular open and understandable licenses. Many pros and cons of each license are laid out in [this discussion](https://github.com/OBOFoundry/OBOFoundry.github.io/issues/285).
 
 ### For ontology re-use
 

--- a/principles/fp-001-open.md
+++ b/principles/fp-001-open.md
@@ -22,7 +22,7 @@ OBO Foundry ontologies are resources for the entire biological and biomedical co
 
     OR released into the public domain under [CC0](https://creativecommons.org/publicdomain/zero/1.0/) (which is not a license). Note that CC0 specifies that the creators of an ontology waive, to the extent that they legally can be, all rights and place the ontology in the public domain. It does not prevent them from requesting that the ontology be properly credited and cited, but prevents any legal recourse if it is not credited.
 
-2. We recommend that new ontologies choose a CC-BY license because a CC-BY license can be converted into a more permissive CC0, while the reverse is not true. That is, if you develop and license your work under CC0 you will not be able to later update it to CC-BY.
+2. We recommend that new ontologies carefully consider the choice of license.  Many pros and cons of each license are laid out in [this discussion](https://github.com/OBOFoundry/OBOFoundry.github.io/issues/285). 
 
 ### For ontology re-use
 
@@ -31,6 +31,8 @@ OBO Foundry ontologies are resources for the entire biological and biomedical co
 2. After any external alterations to an ontology, the ontology must not be redistributed under the same name or with the same ontology IRI.
 
 3. If an individual term is reused without change to the definition, the original term IRI should be used. If the definition of a term (either text or logical) is changed, the original term IRI should not be reused. Suggestions for changes or improvements to term definitions should be submitted to the appropriate ontology issue tracker.
+
+4. Regardless of which license an ontology uses, we strongly request and recommend that any reuse of an ontology attributes the source in accordance with scientific norms.
 
 ### Remark
 


### PR DESCRIPTION
Given that the choice between CC0 and CC-BY is a nuanced one with many pros and cons on both sides of the issue, I offer three suggestions for this document:

1. linking to https://github.com/OBOFoundry/OBOFoundry.github.io/issues/285 where many issues are explicitly discussed
2. removing the explicit recommendation of CC-BY
3. adding a request for attribution in all cases regardless of license (following [this pattern](http://www.dancohen.org/2013/11/26/cc0-by/))

I of course understand that this policy is ultimately under the purview of the Editorial WG, but I've formulated this as a pull request just to propose something specific.