### PR TITLE
Do not merge yet: Remove DO browser from list of sanctioned browsers

### DIFF
--- a/ontology/doid.md
+++ b/ontology/doid.md
@@ -16,10 +16,6 @@ products:
     title: Disease Ontology inferred hierarchy that includes anatomy, cell of origin, infectious agent and phenotype axioms
   - id: doid.obo  
     title: Disease Ontology asserted is_a hierarchy (this file is equivalent to DO's previous HumanDO.obo file)
-browsers:
-  - label: DO
-    title: DO Browser
-    url: http://www.disease-ontology.org/
 taxon:
   id: NCBITaxon:9606 
   label: Homo sapiens


### PR DESCRIPTION
The DO browser gives incomplete results that are inconsistent with OBO-sanctioned browsers such as OLS and OntoBee.

For full details, see: https://github.com/DiseaseOntology/HumanDiseaseOntology/issues/364

This PR is on the doid metadata file so it should only be merged when approved by @lschriml 

