### PR TITLE
Add source info for imr

### DIFF
--- a/ontology/imr.md
+++ b/ontology/imr.md
@@ -7,6 +7,10 @@ contact:
   label: curator@inoh.org
 homepage: http://www.inoh.org
 is_obsolete: true
+build:
+  source_url: https://web.archive.org/web/20131127090937/http://www.inoh.org/ontologies/MoleculeRoleOntology.obo
+  method: obo2owl
+  insert_ontology_id: true
 ---
 
 A structured controlled vocabulary of concrete protein names and generic (abstract) protein names. This ontology is a INOH pathway annotation ontology, one of a set of ontologies intended to be used in pathway data annotation to ease data integration. This ontology is used to annotate protein names, protein family names, generic/concrete protein names in the INOH pathway data.<br>INOH is part of the BioPAX working group.


### PR DESCRIPTION
even though this ontology is deprecated we would like the latest version of obo and owl to be resolvable via purls for people who have dependencies, based on https://github.com/OBOFoundry/purl.obolibrary.org/issues/353 we can use the internet archive to get a source version to compile. Ultimately it would be better to have a dedicated github repo, e.g. using ontology-starter-kit