### PR TITLE
Obsolete emap

### DIFF
--- a/ontology/emap.md
+++ b/ontology/emap.md
@@ -22,6 +22,8 @@ build:
 used_by:
  - url: https://www.biosharing.org/biodbcore-000659
    label: GXD
+is_obsolete: true
+replaced_by: emapa
 ---
 
 


### PR DESCRIPTION
coordinating with @graybeal, @tfhayamizu agrees this should be retired. I'm adding a replaced_by link to emapa, which succeeds this