### PR TITLE
Add description to metadata and freeform sections for omit

### DIFF
--- a/ontology/omit.md
+++ b/ontology/omit.md
@@ -5,9 +5,11 @@ in_foundry: false
 contact:
   email: huang@southalabama.edu
   label: Huang, Jingshan
+description: Ontology to establish data exchange standards and common data elements in the microRNA (miR) domain
 homepage: http://omit.cis.usouthal.edu/
 page: http://omit.cis.usouthal.edu/
 products:
   - id: omit.owl
 title: Ontology for MIRNA Target
 ---
+The purpose of the OMIT ontology is to establish data exchange standards and common data elements in the microRNA (miR) domain. Biologists (cell biologists in particular) and bioinformaticians can make use of OMIT to leverage emerging semantic technologies in knowledge acquisition and discovery for more effective identification of important roles performed by miRs in humans' various diseases and biological processes (usually through miRs' respective target genes). OMIT has reused and extended a set of well-established concepts from existing bio-ontologies, e.g., Gene Ontology, Sequence Ontology, Protein Ontology, NCBI Organism Taxonomy, Human Disease Ontology, Foundational Model of Anatomy, and so forth.


### PR DESCRIPTION
The [omit ontology](http://obofoundry.org/ontology/omit.html) lacks a description on the OBO Foundry website. Added the description that the ontology contact person entered for the [same ontology](http://bioportal.bioontology.org/ontologies/OMIT) on the BioPortal website.