### PR TITLE
Update aero.md

### DIFF
--- a/ontology/aero.md
+++ b/ontology/aero.md
@@ -10,6 +10,7 @@ license:
   label: CC-BY
 domain: health
 homepage: http://purl.obolibrary.org/obo/aero
+is_obsolete: true
 products:
   - id: aero.owl
 title: Adverse Event Reporting Ontology


### PR DESCRIPTION
marked as obsolete
The ontology hasn't been maintained and coverage is not enough to be useful to efficiently represent the domain of application. It should be marked as obsolete to not confuse users.