### PR TITLE
Update Membership.md

### DIFF
--- a/docs/Membership.md
+++ b/docs/Membership.md
@@ -6,30 +6,36 @@ title: Membership
 
 # Introduction #
 
-Initial members of the OBO Foundry Operations Committee were invited by the OBO coordinators. Additional experts were later also invited by the individual working groups. In order to consolidate our memberships across the whole group, and it was adopted on July 30th 2014 that anyone who is active in a working group (active being based on both attendance at WG meetings and actual work done for working groups) be considered a member of the operations committee.
+The OBO Foundry Operations Committee discusses, oversees, and ensures the completion of the fundamental day-to-day activities of the Foundry. The Committee is composed of three working groups. Anyone who is active in a working group (active being based on both attendance at WG meetings and actual work done for working groups) is considered a member of the Operations Committee.
 
 # Details #
 Membership in working groups: T=technical working group, O=outreach working group, E=editorial working group
 
 Current members of the OBO Foundry Operations Committee are: (in alphabetical order of surname)
 
- * Colin Batchelor (E), Royal Society of Chemistry, UK
- * Mathias Brochhausen (O), Department of Biomedical Informatics, University of Arkansas for Medical Sciences, Little Rock, AR, USA
- * [Melanie Courtot](http://purl.org/net/mcourtot) (O, T),  EMBL-EBI, Cambridge, UK 
+  * Mathias Brochhausen (O), Department of Biomedical Informatics, University of Arkansas for Medical Sciences, Little Rock, AR, USA
+ * [Melanie Courtot](http://purl.org/net/mcourtot) (O, T), EMBL-EBI, Cambridge, UK 
  * [Melissa Haendel](http://www.ohsu.edu/xd/education/library/about/staff-directory/melissa-haendel.cfm) (O, OBO coordinator), Oregon Health & Science University, Portland, OR
- * Janna Hastings (E, O)
  * [Simon Jupp](http://www.ebi.ac.uk/about/people/simon-jupp) (T), European Bioinformatics Institute, Cambridge, UK 
- * [Suzi Lewis](https://github.com/selewis), (O, T, OBO coordinator) Lawrence Berkeley Laboratory, Berkeley, USA
+ * [Suzi Lewis](https://github.com/selewis), (O, T) Lawrence Berkeley Laboratory, Berkeley, USA
  * James Malone, FactBio, Cambridge, UK
- * [Chris Mungall](https://github.com/cmungall/), (T, OBO coordinator) Lawrence Berkeley Laboratory, Berkeley, USA
- * Darren Natale (E)
+ * [Chris Mungall](https://github.com/cmungall/), (T) Lawrence Berkeley Laboratory, Berkeley, USA
+ * [Darren Natale](http://pir.georgetown.edu/pirwww/aboutpir/natalebio.shtml) (E) Georgetown University Medical Center, Washington DC, USA
  * [James A. Overton](http://james.overton.ca) (T), [Knocean Inc.](http://knocean.com), Toronto, Canada
  * Bjoern Peters (E)
  * [Philippe Rocca-Serra](https://www.oerc.ox.ac.uk/people/philippe-rocca-serra) (E, O), University of Oxford e-Research Centre, Department of Engineering Science, Oxford, UK.
- * [Alan Ruttenberg](http://sciencecommons.org/about/whoweare/ruttenberg/) (O, T, OBO coordinator), University at Buffalo, Buffalo, USA
- * [Richard Scheuermann](http://www.jcvi.org/cms/about/bios/rscheuermann/) (O, OBO coordinator), J. Craig Venter Institute, La Jolla, CA, USA
- * [Lynn Schriml](http://www.medschool.umaryland.edu/profiles/Schriml-Lynn/) (E,O), University of Maryland School of Medicine
- * Barry Smith (O, OBO coordinator)
- * Chris Stoeckert (E,O), University of Pennsylvania, Philadelphia, PA, USA
+ * [Alan Ruttenberg](http://sciencecommons.org/about/whoweare/ruttenberg/) (O, T), University at Buffalo, Buffalo, USA
+ * [Richard Scheuermann](http://www.jcvi.org/cms/about/bios/rscheuermann/) (O), J. Craig Venter Institute, La Jolla, CA, USA
+ * [Lynn Schriml](http://www.medschool.umaryland.edu/profiles/Schriml-Lynn/) (E, O), University of Maryland School of Medicine
+ * Barry Smith (O)
+ * Chris Stoeckert (E, O), University of Pennsylvania, Philadelphia, PA, USA
+ * Randi Vita (E, T)
  * [Ramona Walls](http://www.cyverse.org/ramona-walls) (E, T), CyVerse, University of Arizona, Tucson, AZ, USA
  * [Jie Zheng](http://cbil.upenn.edu/profile-staff_bio/39) (T, O), University of Pennsylvania, Philadelphia, USA
+
+Alumni:
+
+ * Michael Ashburner
+ * Colin Batchelor (E), Royal Society of Chemistry, UK
+ * Janna Hastings (E, O)
+ * Susanna-Assunta Sansone


### PR DESCRIPTION
1) Removed "OBO Coordinator" from affiliated group for relevant individuals
2) Added "Alumni" section
3) Moved Colin and Janna to Alumni
4) Added Michael Ashburner and Susanna-Assunta Sansone to Alumni
5) Added a space after comma where missing ("E,O" to "E, O") for uniformity of presentation
6) Added affiliation for DN
7) Revised Introduction to OFOC-discussed and approved version
8) Added Randi Vita to member list