### PR TITLE
Created ino.md

### DIFF
--- a/ontology/ino.md
+++ b/ontology/ino.md
@@ -1,0 +1,40 @@
+--
+layout: ontology_detail
+id: ino
+title: Interaction Network Ontology
+description: An ontology of interactions and interaction networks 
+license:
+  url: http://creativecommons.org/licenses/by/3.0/
+  label: CC-BY
+contact:
+  email: Yongqun Oliver He
+  label: yongqunh@med.umich.edu
+homepage: https://github.com/INO-ontology/ino
+tracker: https://github.com/INO-ontology/ino/issues
+products:
+  - id: ino.owl
+--
+
+# Summary
+
+The Interaction Network Ontology (INO) is an ontology in the domain of interactions and interaction networks. INO represents general and species-neutral types of interactions and interaction networks, and their related elements and relations. 
+
+* Home: [https://github.com/INO-ontology/ino]( https://github.com/INO-ontology/ino) 
+
+# Download
+
+Use the following URI to download this ontology
+
+* [http://purl.obolibrary.org/obo/ino.owl](http://purl.obolibrary.org/obo/ino.owl)
+* This should point to: [https://raw.githubusercontent.com/INO-ontology/ino/master/src/ino_merged.owl](https://raw.githubusercontent.com/INO-ontology/ino/master/src/ino_merged.owl)
+
+Note that the source ontology is an OWL file.  
+
+# Browsing
+
+* Default browsing in Ontobee: [http://www.ontobee.org/ontology/ino](http://www.ontobee.org/ontology/ino)
+* Browsing in NCBO BioPortal: [https://bioportal.bioontology.org/ontologies/INO](https://bioportal.bioontology.org/ontologies/INO)
+
+INO can be cited as:
+
+Hur J, Özgür A, Xiang Z, He Y. <b>Development and application of an Interaction Network Ontology for literature mining of vaccine-associated gene-gene interactions</b>. <i>Journal of Biomedical Semantics. 2015, 6:2</i>. <a href="http://www.dx.doi.org/10.1186/2041-1480-6-2">10.1186/2041-1480-6-2</a>

--- a/ontology/ino.md
+++ b/ontology/ino.md
@@ -1,4 +1,4 @@
---
+---
 layout: ontology_detail
 id: ino
 title: Interaction Network Ontology
@@ -13,7 +13,7 @@ homepage: https://github.com/INO-ontology/ino
 tracker: https://github.com/INO-ontology/ino/issues
 products:
   - id: ino.owl
---
+---
 
 # Summary
 


### PR DESCRIPTION
The INO (Interaction Network Ontology) disappeared from OBO Foundry. 
See issue tracker #548: 
https://github.com/OBOFoundry/OBOFoundry.github.io/issues/548

This is to propose the addition of INO back to OBO Foundry ontology library. 
As instructed by @cmungall , here I prepared the INO metadata file ino.md.

Thanks, 
Oliver He