### PR TITLE
Fix title for RO

### DIFF
--- a/ontology/ro.md
+++ b/ontology/ro.md
@@ -1,7 +1,7 @@
 ---
 layout: ontology_detail
 id: ro
-title: Relations Ontology
+title: Relation Ontology
 build:
   checkout:  git clone https://github.com/oborel/obo-relations.git
   system: git


### PR DESCRIPTION
From @phismith:

The title at 

http://www.obofoundry.org/ontology/ro.html 

has 'Relations Ontology'. Lower down on that page, correctly, I believe, you have 'Relation Ontology'.
Can you fix?
BS