### PR TITLE
Add PHIPO metadata for OBO Library

### DIFF
--- a/ontology/phipo.md
+++ b/ontology/phipo.md
@@ -1,0 +1,29 @@
+---
+layout: ontology_detail
+id: phipo
+title: Pathogen Host Interaction Phenotype Ontology
+jobs:
+  - id: https://travis-ci.org/PHI-base/phipo
+    type: travis-ci
+build:
+  checkout: git clone https://github.com/PHI-base/phipo.git
+  system: git
+  path: "."
+contact:
+  email: alayne.cuzick@rothamsted.ac.uk
+  label: Alayne Cuzick
+description: PHIPO is a formal ontology of species-neutral phenotypes observed in pathogen-host interactions.
+domain: phenotype
+homepage: https://github.com/PHI-base/phipo
+products:
+  - id: phipo.owl
+  - id: phipo.obo
+dependencies:
+ - id: pato
+tracker: https://github.com/PHI-base/phipo/issues
+license:
+  url: http://creativecommons.org/licenses/by/3.0/
+  label: CC-BY
+---
+
+PHIPO is being developed to support the comprehensive and detailed representation of phenotypes in PHI-base, the multi-species Pathogen-Host Interactions database available online at <http://www.phi-base.org>. PHIPO is pre-composed and logically defined.


### PR DESCRIPTION
This adds OBO Library configuration for the Pathogen Host Interaction Phenotype Ontology (PHIPO).

The homepage for PHIPO is on GitHub: https://github.com/PHI-base/phipo

There is a request for the ontology on the issue tracker here: https://github.com/OBOFoundry/OBOFoundry.github.io/issues/681