### PR TITLE
Add metadata validation script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,8 @@ registry/publications.md: util/extract-publications.py registry/ontologies.yml
 ### Validate Configuration Files
 
 validate: $(ONTS)
-	./util/extract-metadata.py validate $^
+	./util/extract-metadata.py validate $^ && \
+	cd util && python validate-metadata.py
 
 # Note this should *not* be run as part of general travis jobs, it is expensive
 # and may be prone to false positives as it is inherently network-based

--- a/ontology/chmo.md
+++ b/ontology/chmo.md
@@ -2,7 +2,7 @@
 layout: ontology_detail
 id: chmo
 license:
-  url: http://creativecommons.org/licenses/by/4.0
+  url: http://creativecommons.org/licenses/by/4.0/
   label: CC-BY
 contact:
   email: batchelorc@rsc.org

--- a/ontology/cmf.md
+++ b/ontology/cmf.md
@@ -6,6 +6,7 @@ contact:
   email: grovmi@ohsu.edu
   label: Michael Grove
 homepage: https://code.google.com/p/craniomaxillofacial-ontology/
+validate: false
 ---
 
 Ontology for oral & maxillofacial surgical procedures.

--- a/ontology/epo.md
+++ b/ontology/epo.md
@@ -10,6 +10,7 @@ title: Epidemiology Ontology
 build:
   source_url: http://purl.obolibrary.org/obo/epo.owl
   method: owl2obo
+validate: false
 ---
 
 The Epidemiology Ontology is an ontology designed to support the semantic annotation of epidemiology resources. It is being developed under the EU-funded EPIWORK project, a multidisciplinary research effort which aims at increasing the amount of epidemiological data available, improving disease surveillance systems, and promoting the collaboration among epidemiological researchers. The EO is integrated into NERO (Network of Epidemiology Related Ontologies), a collection of existing ontologies that supports the semantic annotation of epidemiology resources contained in the Epidemic Marketplace (EM), a platform for sharing resources and knowledge within the Epidemiology community. NERO currently includes thirteen external ontologies (the majority are OBO or OBO candidate ontologies) which already provide a high coverage of most epidemiology related areas. As such, the EPO focuses on neglected/highly specific areas of epidemiology and will articulate with other OBO ontologies as needed.

--- a/ontology/hsapdv.md
+++ b/ontology/hsapdv.md
@@ -15,6 +15,7 @@ license:
 products:
   - id: hsapdv.owl
   - id: hsapdv.obo
+validate: false
 ---
 
 <img alt="HumanEmbryogenesis" src="https://upload.wikimedia.org/wikipedia/commons/thumb/0/06/HumanEmbryogenesis.svg/500px-HumanEmbryogenesis.svg.png"/>

--- a/ontology/mmusdv.md
+++ b/ontology/mmusdv.md
@@ -14,6 +14,7 @@ license:
 products:
   - id: mmusdv.owl
   - id: mmusdv.obo
+validate: false
 ---
 
 MmusDv was developed by the Bgee group with assistance from the core Uberon developers and the Mouse anatomy ontology developers.

--- a/ontology/ogi.md
+++ b/ontology/ogi.md
@@ -7,6 +7,7 @@ products:
   - id: ogi.owl
 title: Ontology for genetic interval
 tracker: https://code.google.com/p/ontology-for-genetic-interval/issues/list
+validate: false
 ---
 
 Using BFO as its framwork, OGI formalized the genomic element by defining an upper class 'genetic interval'. The definition of 'genetic interval' is "the spatial continuous physical entity which contains ordered genomic sets(DNA, RNA, Allele, Marker,etc.) between and including two points (Nucleic_Acid_Base_Residue) on a chromosome or RNA molecule which must have a liner primary sequence structure.

--- a/ontology/olatdv.md
+++ b/ontology/olatdv.md
@@ -14,6 +14,7 @@ products:
 license:
   url: http://creativecommons.org/licenses/by/3.0/
   label: CC-BY
+validate: false
 ---
 
 

--- a/ontology/pdumdv.md
+++ b/ontology/pdumdv.md
@@ -14,6 +14,7 @@ products:
 license:
   url: http://creativecommons.org/licenses/by/3.0/
   label: CC-BY
+validate: false
 ---
 
 

--- a/ontology/vario.md
+++ b/ontology/vario.md
@@ -9,6 +9,7 @@ title: Variation Ontology
 build:
   source_url: http://variationontology.org/vario_download/vario.obo
   method: obo2owl
+validate: false
 ---
 
 Variation Ontology, VariO, is an ontology for standardized, systematic description of effects, consequences and mechanisms of variations.

--- a/registry/ontologies.jsonld
+++ b/registry/ontologies.jsonld
@@ -897,7 +897,7 @@
             "in_foundry": false,
             "layout": "ontology_detail",
             "license": {
-                "label": "CC-BY 1.0",
+                "label": "CC-0",
                 "logo": "http://mirrors.creativecommons.org/presskit/buttons/80x15/png/cc-zero.png",
                 "url": "https://creativecommons.org/publicdomain/zero/1.0/"
             },
@@ -1133,7 +1133,7 @@
             "license": {
                 "label": "CC-BY",
                 "logo": "http://mirrors.creativecommons.org/presskit/buttons/80x15/png/by.png",
-                "url": "http://creativecommons.org/licenses/by/4.0"
+                "url": "http://creativecommons.org/licenses/by/4.0/"
             },
             "mailing_list": "chemistry-ontologies@googlegroups.com",
             "ontology_purl": "http://purl.obolibrary.org/obo/chmo.owl",
@@ -1326,13 +1326,14 @@
         },
         {
             "contact": {
-                "email": "Michael Grove",
-                "label": "grovmi@ohsu.edu"
+                "email": "grovmi@ohsu.edu",
+                "label": "Michael Grove"
             },
             "homepage": "https://code.google.com/p/craniomaxillofacial-ontology/",
             "id": "cmf",
             "layout": "ontology_detail",
-            "title": "CranioMaxilloFacial ontology"
+            "title": "CranioMaxilloFacial ontology",
+            "validate": false
         },
         {
             "browsers": [
@@ -1803,12 +1804,6 @@
                 {
                     "id": "eco.obo",
                     "ontology_purl": "http://purl.obolibrary.org/obo/eco.obo"
-                },
-                {
-                    "id": "eco/gaf-eco-mapping.txt",
-                    "ontology_purl": "http://purl.obolibrary.org/obo/eco/gaf-eco-mapping.txt",
-                    "title": "Mapping between ECO classes and Gene Ontology codes",
-                    "type": "Mapping"
                 }
             ],
             "publications": [
@@ -2125,7 +2120,8 @@
                     "ontology_purl": "http://purl.obolibrary.org/obo/epo.owl"
                 }
             ],
-            "title": "Epidemiology Ontology"
+            "title": "Epidemiology Ontology",
+            "validate": false
         },
         {
             "build": {
@@ -2859,7 +2855,7 @@
             "id": "hancestro",
             "layout": "ontology_detail",
             "license": {
-                "label": "Creative Commons CC-BY, version 4.0",
+                "label": "CC-BY 4.0",
                 "logo": "http://mirrors.creativecommons.org/presskit/buttons/80x15/png/by.png",
                 "url": "https://creativecommons.org/licenses/by/4.0/"
             },
@@ -3041,7 +3037,8 @@
                     "ontology_purl": "http://purl.obolibrary.org/obo/hsapdv.obo"
                 }
             ],
-            "title": "Human Developmental Stages"
+            "title": "Human Developmental Stages",
+            "validate": false
         },
         {
             "build": {
@@ -3097,9 +3094,9 @@
         },
         {
             "contact": {
-                "email": "Yongqun Oliver He",
+                "email": "yongqunh@med.umich.edu",
                 "github": "yongqunh",
-                "label": "yongqunh@med.umich.edu"
+                "label": "Yongqun Oliver He"
             },
             "description": "An ontology of clinical informed consents",
             "homepage": "https://github.com/ICO-ontology/ICO",
@@ -3638,7 +3635,8 @@
                     "ontology_purl": "http://purl.obolibrary.org/obo/mmusdv.obo"
                 }
             ],
-            "title": "Mouse Developmental Stages"
+            "title": "Mouse Developmental Stages",
+            "validate": false
         },
         {
             "build": {
@@ -4138,7 +4136,7 @@
             "id": "ncro",
             "layout": "ontology_detail",
             "license": {
-                "label": "CC-BY 4",
+                "label": "CC-BY 4.0",
                 "logo": "http://mirrors.creativecommons.org/presskit/buttons/80x15/png/by.png",
                 "url": "https://creativecommons.org/licenses/by/4.0/"
             },
@@ -4342,7 +4340,8 @@
                 }
             ],
             "title": "Ontology for genetic interval",
-            "tracker": "https://code.google.com/p/ontology-for-genetic-interval/issues/list"
+            "tracker": "https://code.google.com/p/ontology-for-genetic-interval/issues/list",
+            "validate": false
         },
         {
             "contact": {
@@ -4483,7 +4482,8 @@
                     "ontology_purl": "http://purl.obolibrary.org/obo/olatdv.owl"
                 }
             ],
-            "title": "Medaka Developmental Stages"
+            "title": "Medaka Developmental Stages",
+            "validate": false
         },
         {
             "contact": {
@@ -4828,7 +4828,8 @@
                     "ontology_purl": "http://purl.obolibrary.org/obo/pdumdv.obo"
                 }
             ],
-            "title": "Platynereis Developmental Stages"
+            "title": "Platynereis Developmental Stages",
+            "validate": false
         },
         {
             "contact": {
@@ -5088,7 +5089,7 @@
             "id": "rnao",
             "layout": "ontology_detail",
             "license": {
-                "label": "CC-BY 1.0",
+                "label": "CC-0",
                 "logo": "http://mirrors.creativecommons.org/presskit/buttons/80x15/png/cc-zero.png",
                 "url": "https://creativecommons.org/publicdomain/zero/1.0/"
             },
@@ -6180,7 +6181,8 @@
                     "ontology_purl": "http://purl.obolibrary.org/obo/vario.owl"
                 }
             ],
-            "title": "Variation Ontology"
+            "title": "Variation Ontology",
+            "validate": false
         },
         {
             "build": {

--- a/registry/ontologies.ttl
+++ b/registry/ontologies.ttl
@@ -58,9 +58,7 @@ _:b1    <http://obofoundry.github.io/vocabulary/method>  "obo2owl" ;
         <http://schema.org/logo>  <http://mirrors.creativecommons.org/presskit/buttons/80x15/png/by.png> ;
         <http://www.w3.org/2000/01/rdf-schema#label>  "CC-BY 4.0" ;
         <http://www.w3.org/2000/01/rdf-schema#label>  "CC-BY" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>  "CC BY 4.0" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>  "Creative Commons CC-BY, version 4.0" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>  "CC-BY 4" .
+        <http://www.w3.org/2000/01/rdf-schema#label>  "CC BY 4.0" .
 
 <http://www.ebi.ac.uk/chebi/chebiOntology.do?treeView=true&chebiId=CHEBI:24431#graphView>
         <http://purl.org/dc/elements/1.1/title>  "EBI CHEBI Browser" ;
@@ -114,7 +112,6 @@ _:b3    <http://obofoundry.github.io/vocabulary/method>  "obo2owl" ;
 <https://creativecommons.org/publicdomain/zero/1.0/>
         <http://schema.org/logo>  <http://mirrors.creativecommons.org/presskit/buttons/80x15/png/cc-zero.png> ;
         <http://www.w3.org/2000/01/rdf-schema#label>  "CC0 1.0 Universal" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>  "CC-BY 1.0" ;
         <http://www.w3.org/2000/01/rdf-schema#label>  "CC-0" ;
         <http://www.w3.org/2000/01/rdf-schema#label>  "CC0" .
 
@@ -902,7 +899,7 @@ _:b52   <http://www.w3.org/2000/01/rdf-schema#label>  "Egon Willighagen" ;
 <http://purl.obolibrary.org/obo/chmo>
         <http://purl.org/dc/elements/1.1/description>  "CHMO, the chemical methods ontology, describes methods used to" ;
         <http://purl.org/dc/elements/1.1/title>  "Chemical Methods Ontology" ;
-        <http://purl.org/dc/terms/1.1/license>  <http://creativecommons.org/licenses/by/4.0> ;
+        <http://purl.org/dc/terms/1.1/license>  <http://creativecommons.org/licenses/by/4.0/> ;
         <http://purl.org/dc/terms/1.1/theme>  "health" ;
         <http://usefulinc.com/ns/doap#bug-database>  "https://github.com/rsc-ontologies/rsc-cmo/issues" ;
         <http://usefulinc.com/ns/doap#mailing-list>  "chemistry-ontologies@googlegroups.com" ;
@@ -910,10 +907,6 @@ _:b52   <http://www.w3.org/2000/01/rdf-schema#label>  "Egon Willighagen" ;
         <http://www.w3.org/ns/dcat#contactPoint>  _:b53 ;
         <http://www.w3.org/ns/dcat#distribution>  <http://purl.obolibrary.org/obo/chmo.owl> ;
         <http://xmlns.com/foaf/0.1/homepage>  <https://github.com/rsc-ontologies/rsc-cmo> .
-
-<http://creativecommons.org/licenses/by/4.0>
-        <http://schema.org/logo>  <http://mirrors.creativecommons.org/presskit/buttons/80x15/png/by.png> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>  "CC-BY" .
 
 _:b53   <http://www.w3.org/2000/01/rdf-schema#label>  "Colin Batchelor" ;
         <http://xmlns.com/foaf/0.1/mbox>  "batchelorc@rsc.org" .
@@ -995,8 +988,8 @@ _:b55   <http://www.w3.org/2000/01/rdf-schema#label>  "Sirarat Sarntivijai" ;
         <http://www.w3.org/ns/dcat#contactPoint>  _:b56 ;
         <http://xmlns.com/foaf/0.1/homepage>  <https://code.google.com/p/craniomaxillofacial-ontology/> .
 
-_:b56   <http://www.w3.org/2000/01/rdf-schema#label>  "grovmi@ohsu.edu" ;
-        <http://xmlns.com/foaf/0.1/mbox>  "Michael Grove" .
+_:b56   <http://www.w3.org/2000/01/rdf-schema#label>  "Michael Grove" ;
+        <http://xmlns.com/foaf/0.1/mbox>  "grovmi@ohsu.edu" .
 
 <http://purl.obolibrary.org/obo/cmo>
         <http://obofoundry.github.io/vocabulary/has_build_information>  _:b57 ;
@@ -1311,7 +1304,6 @@ _:b78   <http://www.w3.org/2000/01/rdf-schema#label>  "Melanie Courtot" ;
         <http://www.w3.org/ns/dcat#contactPoint>  _:b80 ;
         <http://www.w3.org/ns/dcat#distribution>  <http://purl.obolibrary.org/obo/eco.owl> ;
         <http://www.w3.org/ns/dcat#distribution>  <http://purl.obolibrary.org/obo/eco.obo> ;
-        <http://www.w3.org/ns/dcat#distribution>  <http://purl.obolibrary.org/obo/eco/gaf-eco-mapping.txt> ;
         <http://xmlns.com/foaf/0.1/homepage>  <https://github.com/evidenceontology/evidenceontology/> .
 
 _:b79   <http://obofoundry.github.io/vocabulary/method>  "obo2owl" ;
@@ -1328,11 +1320,6 @@ _:b80   <http://www.w3.org/2000/01/rdf-schema#label>  "Michelle Giglio" ;
 
 <http://purl.obolibrary.org/obo/eco.obo>
         <http://www.w3.org/ns/dcat#accessURL>  "http://purl.obolibrary.org/obo/eco.obo" .
-
-<http://purl.obolibrary.org/obo/eco/gaf-eco-mapping.txt>
-        <http://purl.org/dc/elements/1.1/title>  "Mapping between ECO classes and Gene Ontology codes" ;
-        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>  <http://purl.obolibrary.org/obo/Mapping> ;
-        <http://www.w3.org/ns/dcat#accessURL>  "http://purl.obolibrary.org/obo/eco/gaf-eco-mapping.txt" .
 
 <http://purl.obolibrary.org/obo/ecocore>
         <http://obofoundry.github.io/vocabulary/depends_on>  <http://purl.obolibrary.org/obo/pco> ;
@@ -2130,8 +2117,8 @@ _:b128  <http://www.w3.org/2000/01/rdf-schema#label>  "Mathias Brochhausen" ;
         <http://www.w3.org/ns/dcat#distribution>  <http://purl.obolibrary.org/obo/ico.owl> ;
         <http://xmlns.com/foaf/0.1/homepage>  <https://github.com/ICO-ontology/ICO> .
 
-_:b129  <http://www.w3.org/2000/01/rdf-schema#label>  "yongqunh@med.umich.edu" ;
-        <http://xmlns.com/foaf/0.1/mbox>  "Yongqun Oliver He" .
+_:b129  <http://www.w3.org/2000/01/rdf-schema#label>  "Yongqun Oliver He" ;
+        <http://xmlns.com/foaf/0.1/mbox>  "yongqunh@med.umich.edu" .
 
 <http://purl.obolibrary.org/obo/ico.owl>
         <http://www.w3.org/ns/dcat#accessURL>  "http://purl.obolibrary.org/obo/ico.owl" .

--- a/registry/ontologies.yml
+++ b/registry/ontologies.yml
@@ -424,7 +424,7 @@ ontologies:
   id: bco
   in_foundry: false
   layout: ontology_detail
-  license: {label: CC-BY 1.0, logo: 'http://mirrors.creativecommons.org/presskit/buttons/80x15/png/cc-zero.png',
+  license: {label: CC-0, logo: 'http://mirrors.creativecommons.org/presskit/buttons/80x15/png/cc-zero.png',
     url: 'https://creativecommons.org/publicdomain/zero/1.0/'}
   ontology_purl: http://purl.obolibrary.org/obo/bco.owl
   products:
@@ -539,7 +539,7 @@ ontologies:
   id: chmo
   layout: ontology_detail
   license: {label: CC-BY, logo: 'http://mirrors.creativecommons.org/presskit/buttons/80x15/png/by.png',
-    url: 'http://creativecommons.org/licenses/by/4.0'}
+    url: 'http://creativecommons.org/licenses/by/4.0/'}
   mailing_list: chemistry-ontologies@googlegroups.com
   ontology_purl: http://purl.obolibrary.org/obo/chmo.owl
   products:
@@ -632,11 +632,12 @@ ontologies:
   products:
   - {id: clo.owl, ontology_purl: 'http://purl.obolibrary.org/obo/clo.owl'}
   title: Cell Line Ontology
-- contact: {email: Michael Grove, label: grovmi@ohsu.edu}
+- contact: {email: grovmi@ohsu.edu, label: Michael Grove}
   homepage: https://code.google.com/p/craniomaxillofacial-ontology/
   id: cmf
   layout: ontology_detail
   title: CranioMaxilloFacial ontology
+  validate: false
 - browsers:
   - {label: RGD, title: RGD Ontology Browser, url: 'http://rgd.mcw.edu/rgdweb/ontology/view.html?acc_id=CMO:0000000'}
   build: {method: obo2owl, source_url: 'ftp://ftp.rgd.mcw.edu/pub/ontology/clinical_measurement/clinical_measurement.obo'}
@@ -854,8 +855,6 @@ ontologies:
   products:
   - {id: eco.owl, ontology_purl: 'http://purl.obolibrary.org/obo/eco.owl'}
   - {id: eco.obo, ontology_purl: 'http://purl.obolibrary.org/obo/eco.obo'}
-  - {id: eco/gaf-eco-mapping.txt, ontology_purl: 'http://purl.obolibrary.org/obo/eco/gaf-eco-mapping.txt',
-    title: Mapping between ECO classes and Gene Ontology codes, type: Mapping}
   publications:
   - {id: 'http://www.ncbi.nlm.nih.gov/pubmed/25052702', title: Standardized description
       of scientific evidence using the Evidence Ontology (ECO)}
@@ -997,6 +996,7 @@ ontologies:
   products:
   - {id: epo.owl, ontology_purl: 'http://purl.obolibrary.org/obo/epo.owl'}
   title: Epidemiology Ontology
+  validate: false
 - build: {method: owl2obo, source_url: 'http://purl.obolibrary.org/obo/ero.owl'}
   contact: {email: tenille_johnson@hms.harvard.edu, label: Tenille Johnson}
   description: An ontology of research resources such as instruments. protocols, reagents,
@@ -1336,7 +1336,7 @@ ontologies:
   homepage: https://github.com/EBISPOT/ancestro
   id: hancestro
   layout: ontology_detail
-  license: {label: 'Creative Commons CC-BY, version 4.0', logo: 'http://mirrors.creativecommons.org/presskit/buttons/80x15/png/by.png',
+  license: {label: CC-BY 4.0, logo: 'http://mirrors.creativecommons.org/presskit/buttons/80x15/png/by.png',
     url: 'https://creativecommons.org/licenses/by/4.0/'}
   ontology_purl: http://purl.obolibrary.org/obo/hancestro.owl
   products:
@@ -1419,6 +1419,7 @@ ontologies:
   - {id: hsapdv.owl, ontology_purl: 'http://purl.obolibrary.org/obo/hsapdv.owl'}
   - {id: hsapdv.obo, ontology_purl: 'http://purl.obolibrary.org/obo/hsapdv.obo'}
   title: Human Developmental Stages
+  validate: false
 - build: {method: owl2obo, source_url: 'http://purl.obolibrary.org/obo/iao.owl'}
   contact: {email: jiezheng@pennmedicine.upenn.edu, github: zhengj2007, label: Jie
       Zheng}
@@ -1446,7 +1447,8 @@ ontologies:
     title: ontology of document acts
   title: Information Artifact Ontology
   tracker: https://github.com/information-artifact-ontology/IAO/issues
-- contact: {email: Yongqun Oliver He, github: yongqunh, label: yongqunh@med.umich.edu}
+- contact: {email: yongqunh@med.umich.edu, github: yongqunh, label: Yongqun Oliver
+      He}
   description: An ontology of clinical informed consents
   homepage: https://github.com/ICO-ontology/ICO
   id: ico
@@ -1717,6 +1719,7 @@ ontologies:
   - {id: mmusdv.owl, ontology_purl: 'http://purl.obolibrary.org/obo/mmusdv.owl'}
   - {id: mmusdv.obo, ontology_purl: 'http://purl.obolibrary.org/obo/mmusdv.obo'}
   title: Mouse Developmental Stages
+  validate: false
 - build: {insert_ontology_id: true, method: obo2owl, source_url: 'https://raw.githubusercontent.com/MICommunity/psidev/master/psi/mod/data/PSI-MOD.obo'}
   contact: {email: hhe@ebi.ac.uk, label: Henning Hermjakob}
   description: PSI-MOD is an ontology consisting of terms that describe protein chemical
@@ -1958,7 +1961,7 @@ ontologies:
   homepage: http://omnisearch.soc.southalabama.edu/w/index.php/Ontology
   id: ncro
   layout: ontology_detail
-  license: {label: CC-BY 4, logo: 'http://mirrors.creativecommons.org/presskit/buttons/80x15/png/by.png',
+  license: {label: CC-BY 4.0, logo: 'http://mirrors.creativecommons.org/presskit/buttons/80x15/png/by.png',
     url: 'https://creativecommons.org/licenses/by/4.0/'}
   mailing_list: ncro-devel@googlegroups.com, ncro-discuss@googlegroups.com
   ontology_purl: http://purl.obolibrary.org/obo/ncro.owl
@@ -2065,6 +2068,7 @@ ontologies:
   - {id: ogi.owl, ontology_purl: 'http://purl.obolibrary.org/obo/ogi.owl'}
   title: Ontology for genetic interval
   tracker: https://code.google.com/p/ontology-for-genetic-interval/issues/list
+  validate: false
 - contact: {email: baeverma@jcvi.org, label: Brian Aevermann}
   depicted_by: https://avatars2.githubusercontent.com/u/12973154?s=200&v=4
   description: An ontology for representing treatment of disease and diagnosis and
@@ -2140,6 +2144,7 @@ ontologies:
   - {id: olatdv.obo, ontology_purl: 'http://purl.obolibrary.org/obo/olatdv.obo'}
   - {id: olatdv.owl, ontology_purl: 'http://purl.obolibrary.org/obo/olatdv.owl'}
   title: Medaka Developmental Stages
+  validate: false
 - contact: {email: mbrochhausen@gmail.com, label: Mathias Brochhausen}
   description: An ontological version of MIABIS (Minimum Information About BIobank
     data Sharing)
@@ -2310,6 +2315,7 @@ ontologies:
   - {id: pdumdv.owl, ontology_purl: 'http://purl.obolibrary.org/obo/pdumdv.owl'}
   - {id: pdumdv.obo, ontology_purl: 'http://purl.obolibrary.org/obo/pdumdv.obo'}
   title: Platynereis Developmental Stages
+  validate: false
 - contact: {email: jaiswalp@science.oregonstate.edu, label: Pankaj Jaiswal}
   description: A structured, controlled vocabulary which describes the treatments,
     growing conditions, and/or study types used in plant biology experiments.
@@ -2432,7 +2438,7 @@ ontologies:
   homepage: https://github.com/bgsu-rna/rnao
   id: rnao
   layout: ontology_detail
-  license: {label: CC-BY 1.0, logo: 'http://mirrors.creativecommons.org/presskit/buttons/80x15/png/cc-zero.png',
+  license: {label: CC-0, logo: 'http://mirrors.creativecommons.org/presskit/buttons/80x15/png/cc-zero.png',
     url: 'https://creativecommons.org/publicdomain/zero/1.0/'}
   ontology_purl: http://purl.obolibrary.org/obo/rnao.owl
   products:
@@ -2958,6 +2964,7 @@ ontologies:
   products:
   - {id: vario.owl, ontology_purl: 'http://purl.obolibrary.org/obo/vario.owl'}
   title: Variation Ontology
+  validate: false
 - build: {source_url: 'https://raw.githubusercontent.com/vaccineontology/VO/master/src/VO_merged.owl'}
   contact: {email: yongqunh@med.umich.edu, label: Yongqunh He}
   description: VO is a biomedical ontology in the domain of vaccine and vaccination.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 cachier==1.1.8
 pyyaml
 SPARQLWrapper
+jsonschema

--- a/util/metadata-schema.json
+++ b/util/metadata-schema.json
@@ -1,0 +1,86 @@
+{
+	"properties": {
+		"id": { "type": "string", "pattern": "^[0-9a-z_]+$" },
+		"contact": {
+			"type": "object",
+			"properties": {
+				"github": { "type": "string", "pattern": "^[^@]+$"},
+				"email": { "type": "string", "format": "email" },
+				"label": { "type": "string", "pattern": "^[^@]+$" }
+			},
+			"required": ["email", "label"]
+		},
+		"description": { "type": "string" },
+		"homepage": { "type": "string", "format": "uri" },
+		"products": {
+			"type": "array",
+			"items": {
+				"type": "object",
+				"properties": {
+					"id": { "type": "string", "pattern": "^[0-9A-Za-z-_\\/]+\\.(owl|obo|json|omn|ofn|owx|ttl|owl\\.gz)$" }
+				},
+				"required": ["id"]
+			}
+		},
+		"license": {
+			"type": "object",
+			"properties": {
+				"url": { "type": "string", "format": "uri" },
+				"label": { "type": "string" }
+			},
+			"required": ["url", "label"],
+			"oneOf": [
+				{
+					"properties": {
+						"url": { "enum": ["http://creativecommons.org/licenses/by/4.0/", "https://creativecommons.org/licenses/by/4.0/"] },
+						"label": { "enum": ["CC-BY", "CC BY 4.0", "CC-BY 4.0"] }
+					}
+				},
+				{
+					"properties": {
+						"url": { "enum": ["http://creativecommons.org/publicdomain/zero/1.0/", "https://creativecommons.org/publicdomain/zero/1.0/"] },
+						"label": { "enum": ["CC-0", "CC0", "CC0 1.0 Universal", "CC0 1.0"] }
+					}	
+				},
+				{
+					"properties": {
+						"url": { "enum": ["http://creativecommons.org/licenses/by/3.0/", "https://creativecommons.org/licenses/by/3.0/"] },
+						"label": { "enum": ["CC-BY", "CC-BY 3.0", "CC BY 3.0"] }	
+					}
+				},
+				{
+					"properties": {
+						"url": { "enum": ["http://creativecommons.org/licenses/by-nd/4.0/", "https://creativecommons.org/licenses/by-nd/4.0/"] },
+						"label": { "enum": ["CC BY-ND 4.0"] }	
+					}
+				},
+				{
+					"properties": {
+						"url": { "enum": ["http://www.gnu.org/licenses/gpl-3.0.en.html", "https://www.gnu.org/licenses/gpl-3.0.en.html"] },
+						"label": { "enum": ["GNU GPL 3.0"] }
+					}
+				},
+				{
+					"properties": {
+						"url": { "enum": ["http://creativecommons.org/licenses/by-sa/2.0/", "https://creativecommons.org/licenses/by-sa/2.0/"] },
+						"label": { "enum": ["CC-BY-SA", "CC BY-SA 2.0"] }
+					}
+				},
+				{
+					"properties": {
+						"url": { "enum": ["http://creativecommons.org/licenses/by/2.0/", "https://creativecommons.org/licenses/by/2.0/"] },
+						"label": { "enum": ["CC-BY", "CC BY 2.0", "CC-BY 2.0"] }
+					}
+				},
+				{
+					"properties": {
+						"url": { "enum": ["http://opensource.org/licenses/Artistic-2.0", "https://opensource.org/licenses/Artistic-2.0"] },
+						"label": { "enum": ["Artistic License 2.0"] }
+					}
+				}
+			]
+		},
+		"title": { "type": "string" }
+	},
+	"required": ["id", "contact", "title", "description"]
+}

--- a/util/validate-metadata.py
+++ b/util/validate-metadata.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+
+import ast
+import sys
+import json
+import jsonschema
+import re
+
+# file paths
+data_file = "../registry/ontologies.jsonld"
+schema_file = "metadata-schema.json"
+schema_lite_file = "metadata-schema-lite.json"
+report_file = "reports/metadata-violations.csv"
+
+# ultra-escaped regex strings
+email_sub = 'does not match \'\\^\\[\\^@\\]\\+\\$\''
+fmt_sub = ('does not match \'\\^\\[0\\-9A\\-Za\\-z\\-_\\\\\\\\/\\]\\+'
+          '\\\\\\\\.\\(owl\\|obo\\|json\\|omn\\|ofn\\|owx\\|ttl\\|owl'
+          '\\\\\\\\.gz\\)\\$\'')
+
+def validate():
+	"""
+	Validate registry metadata.
+	"""
+	print("--- validating metadata against {0} ---".format(schema_file))
+	data = load_data()
+	schema = load_schema()
+	# validate each object
+	errors = {}
+	for item in data["ontologies"]:
+		if 'is_obsolete' in item and item["is_obsolete"] is True:
+			continue
+		# skip any 'validate: false' ontologies
+		if 'validate' in item and item["validate"] is False:
+			continue
+		ont_id = item["id"]
+		try:
+			jsonschema.validate(item, schema)
+		except jsonschema.exceptions.ValidationError as ve:
+			print("ERROR in {0}".format(ont_id))
+			errors[ont_id] = format_msg(ve)
+	if errors:
+		write_errors(errors)
+	else:
+		print("SUCCESS - no errors found in metadata")
+		sys.exit(0)
+
+def format_msg(ve):
+	"""
+	Format exception message from jsonchema.validate(...).
+	"""
+	# replace u characters
+	replace_u = re.sub('u\'', '\'', ve.message)
+	# replace scary regex strings
+	replace_email = re.sub(
+		email_sub, 'is not valid for \'contact.label\'', replace_u)
+	msg = re.sub(fmt_sub, 'is not valid for \'products.id\'', replace_email)
+
+	# check if output is for license error
+	is_license = re.search('({\'url\'.+?\'label\'.+?})', msg)
+	if is_license:
+		return format_license_msg(is_license.group(1))
+
+	# check if output is for list error
+	is_list = re.search('(\\[.+?\\]) is not of type \'string\'', msg)
+	if is_list:
+		return format_list_msg(is_list.group(1), ve)
+
+	# otherwise return the message
+	return msg
+
+def format_license_msg(substr):
+	"""
+	Format an exception message for a license issue.
+	"""
+	# process to dict
+	d = json.loads(substr.replace('\'', '"'))
+	url = d['url']
+	label = d['label']
+	return '\'{0}\' <{1}> is not valid for \'license\''.format(label, url)
+
+def format_list_msg(substr, ve):
+	"""
+	Format an exception for an unexpected list.
+	"""
+	l = json.loads(substr.replace('\'', '"'))
+	# use the full message to find the violating property
+	prop_find = re.search('On instance\\[(\'.+?\')\\]', str(ve))
+	if prop_find:
+		prop = prop_find.group(1)
+		return '{0} expects one value, got {1}'.format(prop, len(l))
+	else:
+		return substr
+
+def load_schema():
+	"""
+	Load the schema to validate against.
+	"""
+	# read the schema
+	with open(schema_file) as f:
+		schema = json.load(f)
+	return schema
+
+def load_data():
+	"""
+	Load the data to validate.
+	"""
+	# read the JSON-LD data
+	with open(data_file) as f:
+		data = json.load(f)
+	return data
+
+def write_errors(errors):
+	"""
+	Write validation errors to a user-friendly report.
+	"""
+	with open(report_file, 'w+') as f:
+		f.write("ID,ERROR\n")
+		for ont_id, msg in errors.items():
+			f.write('"' + ont_id + '","' + msg + '"\n')
+	print(
+		"VALIDATION FAILED: {0} errors - see {1} for details".format(
+			len(errors), report_file))
+	sys.exit(1)
+
+# run the process!
+if __name__ == '__main__':
+	validate()


### PR DESCRIPTION
See #710 (old version)
This includes re-built registry files.

Right now, there are 8 ontologies with missing contact information. We discussed doing a "lite" version of the metadata, but contact details were still included in that version. I annotated these with `validate: false` to skip them for now, but we can always change that.

Additionally, once #173 is done, we can add `"github"` to the required list.