### PR TITLE
Updated obofoundry.github.io entry for HANCESTRO 

### DIFF
--- a/ontology/hancestro.md
+++ b/ontology/hancestro.md
@@ -6,12 +6,14 @@ contact:
   label: Danielle Welter
 description: The Human Ancestry Ontology (HANCESTRO) provides a systematic description of the ancestry concepts used in the NHGRI-EBI Catalog of published genome-wide association studies. 
 homepage: https://github.com/EBISPOT/ancestro
+tracker: https://github.com/EBISPOT/ancestro/issues
+domain: ancestry
 products:
   - id: hancestro.owl
 title: Human Ancestry Ontology
 license:
   url: https://creativecommons.org/licenses/by/4.0/
-  label: Creative Commons CC-BY, version 4.0
+  label: CC-BY 4.0
 
 ---
 
@@ -28,8 +30,14 @@ Use the following URI to download this ontology
 * [http://purl.obolibrary.org/obo/hancestro.owl](http://purl.obolibrary.org/obo/hancestro.owl)
 * This should point to: [https://raw.githubusercontent.com/EBISPOT/ancestro/master/hancestro.owl](https://raw.githubusercontent.com/EBISPOT/ancestro/master/hancestro.owl) 
 
+A pre-reasoned version of the ontology is available at [https://raw.githubusercontent.com/EBISPOT/ancestro/master/hancestro_inferred.owl](https://raw.githubusercontent.com/EBISPOT/ancestro/master/hancestro_inferred.owl)
+
+A version of HANCESTRO with BFO upper classes is available at [https://raw.githubusercontent.com/EBISPOT/ancestro/master/hancestro_bfo.owl](https://raw.githubusercontent.com/EBISPOT/ancestro/master/hancestro_bfo.owl)
+
 
 # Browsing
 
 * Default browsing in Ontobee: [http://www.ontobee.org/ontology/hancestro](http://www.ontobee.org/ontology/hancestro)
+* Browsing in OLS:
+[https://www.ebi.ac.uk/ols/ontologies/hancestro](https://www.ebi.ac.uk/ols/ontologies/hancestro)
 * Browsing in NCBO BioPortal: [https://bioportal.bioontology.org/ontologies/HANCESTRO](https://bioportal.bioontology.org/ontologies/HANCESTRO)  

--- a/ontology/hancestro.md
+++ b/ontology/hancestro.md
@@ -28,9 +28,9 @@ The Human Ancestry Ontology (HANCESTRO) provides a systematic description of the
 Use the following URI to download this ontology
 
 * [http://purl.obolibrary.org/obo/hancestro.owl](http://purl.obolibrary.org/obo/hancestro.owl)
-* This should point to: [https://raw.githubusercontent.com/EBISPOT/ancestro/master/hancestro.owl](https://raw.githubusercontent.com/EBISPOT/ancestro/master/hancestro.owl) 
+* This should point to: [https://raw.githubusercontent.com/EBISPOT/ancestro/master/hancestro_inferred.owl](https://raw.githubusercontent.com/EBISPOT/ancestro/master/hancestro_inferred.owl) 
 
-A pre-reasoned version of the ontology is available at [https://raw.githubusercontent.com/EBISPOT/ancestro/master/hancestro_inferred.owl](https://raw.githubusercontent.com/EBISPOT/ancestro/master/hancestro_inferred.owl)
+A non-reasoned version of the ontology is available at [https://raw.githubusercontent.com/EBISPOT/ancestro/master/hancestro.owl](https://raw.githubusercontent.com/EBISPOT/ancestro/master/hancestro.owl)
 
 A version of HANCESTRO with BFO upper classes is available at [https://raw.githubusercontent.com/EBISPOT/ancestro/master/hancestro_bfo.owl](https://raw.githubusercontent.com/EBISPOT/ancestro/master/hancestro_bfo.owl)
 


### PR DESCRIPTION
The file now includes a link to the HANCESTRO tracker and alternative versions of ontology (pre-reasoned and including BFO upper)