### PR TITLE
Reflect GitHub's advice in fork & PR notice

### DIFF
--- a/_layouts/community.html
+++ b/_layouts/community.html
@@ -201,7 +201,7 @@ layout: default
         <footer class="footer">
           <div class="container">
             <p class="text-muted">
-              Edit the metadata for this page: <a href="https://github.com/OBOFoundry/OBOFoundry.github.io/edit/master/community/{{page.id}}.md">{{page.id}}.md</a> (remember to make a fork and pull request!)
+              Edit the metadata for this page: <a href="https://github.com/OBOFoundry/OBOFoundry.github.io/edit/master/community/{{page.id}}.md">{{page.id}}.md</a> (GitHub will help you create a fork and pull request.)
 
             </p>
           </div>

--- a/_layouts/ontology_detail.html
+++ b/_layouts/ontology_detail.html
@@ -292,7 +292,7 @@ layout: default
         <footer class="footer">
           <div class="container">
             <p class="text-muted">
-              Edit the metadata for this page: <a href="https://github.com/OBOFoundry/OBOFoundry.github.io/edit/master/ontology/{{page.id}}.md">{{page.id}}.md</a> (remember to make a fork and pull request!)
+              Edit the metadata for this page: <a href="https://github.com/OBOFoundry/OBOFoundry.github.io/edit/master/ontology/{{page.id}}.md">{{page.id}}.md</a> (GitHub will help you create a fork and pull request.)
 
             </p>
           </div>


### PR DESCRIPTION
Using the direct edit link is supported by GitHub's own advice banners and [help.GitHub.com/articles/editing-files-in-another-user-s-repository](https://help.github.com/articles/editing-files-in-another-user-s-repository/), so there is no need for contributors to manually fork. I considered including that link, but since it doesn't show the actual banners, so it might be confusing, although describing the process itself correctly.