### PR TITLE
DO NOT MERGE YET: Create new entry for unipathway (upa)

### DIFF
--- a/ontology/upa.md
+++ b/ontology/upa.md
@@ -1,0 +1,35 @@
+---
+layout: ontology_detail
+id: upa
+title: Unipathway
+jobs:
+  - id: https://travis-ci.org/geneontology/unipathway
+    type: travis-ci
+build:
+  checkout: git clone https://github.com/geneontology/unipathway.git
+  system: git
+  path: "."
+publications:
+  - id: http://www.ncbi.nlm.nih.gov/pubmed/22102589
+    title: "UniPathway: a resource for the exploration and annotation of metabolic pathways"
+contact:
+  email: "Anne.Morgat@sib.swiss"
+  label: "Anne Morgat"
+  github: amorgat
+description: "A manually curated resource for the representation and annotation of metabolic pathways"
+domain: pathways
+homepage: https://github.com/geneontology/unipathway
+products:
+  - id: upa.owl
+  - id: upa.obo
+activity_status: inactive
+dependencies:
+- id: ro
+tracker: https://github.com/geneontology/unipathway/issues
+license:
+  url: http://creativecommons.org/licenses/by/3.0/
+  label: CC-BY
+---
+
+UniPathway (http://www.unipathway.org) is a fully manually curated resource for the representation and annotation of metabolic pathways. UniPathway provides explicit representations of enzyme-catalyzed and spontaneous chemical reactions, as well as a hierarchical representation of metabolic pathways. This hierarchy uses linear subpathways as the basic building block for the assembly of larger and more complex pathways, including species-specific pathway variants. All of the pathway data in UniPathway has been extensively cross-linked to existing pathway resources such as KEGG and MetaCyc, as well as sequence resources such as the UniProt KnowledgeBase (UniProtKB), for which UniPathway provides a controlled vocabulary for pathway annotation. We introduce here the basic concepts underlying the UniPathway resource, with the aim of allowing users to fully exploit the information provided by UniPathway.
+


### PR DESCRIPTION
@OBOFoundry/community @OBOFoundry/obo-admin please comment - should this be registered in OBO, or registered directly in OLS, without an OBO entry

Unipathway is a fully manually curated resource for the representation and annotation of metabolic pathways, natively represented as an obo format ontology. See: https://www.ncbi.nlm.nih.gov/pubmed/22102589

This resource is now inactive, see the note on the home page: http://www.unipathway.org/

I would like to see the resource "rescued", with the permission of the creator @amorgat I have created a github repository with the ontology: https://github.com/geneontology/unipathway

We would like to have the ontology visible on OLS and OntoBee, as currently the URLs for IDs do not resolve, and these IDs are used in many prokaryotic gene annotations.

Note that this ontology is *not* orthogonal to the GO and CHEBI, it creates new IDs and xrefs GO/CHEBI/RHEA etc. However, I would still like to register this via the OBO registry. Note that eventually UPA will be integrated entirely into GO in which case the status would be switched to obsolete. Do we think this is appropriate for an OBO entry? I could instead register separately with OLS and OntoBee but I prefer to register in OBO so that metadata is fully tracked.

Note that I am using the inactive status in the metadata entry here

See https://github.com/geneontology/go-ontology/issues/16787

