### PR TITLE
update ehdaa2.md license

### DIFF
--- a/ontology/ehdaa2.md
+++ b/ontology/ehdaa2.md
@@ -10,7 +10,7 @@ license:
 description: A structured controlled vocabulary of stage-specific anatomical structures of the developing human.
 tracker: https://github.com/obophenotype/human-developmental-anatomy-ontology/issues
 domain: anatomy
-homepage: none
+homepage: https://github.com/obophenotype/human-developmental-anatomy-ontology
 products:
   - id: ehdaa2.owl
   - id: ehdaa2.obo

--- a/ontology/ehdaa2.md
+++ b/ontology/ehdaa2.md
@@ -4,10 +4,13 @@ id: ehdaa2
 contact:
   email: J.Bard@ed.ac.uk
   label: Jonathan Bard
+license:
+  url: https://creativecommons.org/licenses/by/4.0/
+  label: CC-BY 4.0
 description: A structured controlled vocabulary of stage-specific anatomical structures of the developing human.
 tracker: https://github.com/obophenotype/human-developmental-anatomy-ontology/issues
 domain: anatomy
-homepage: http://genex.hgu.mrc.ac.uk/
+homepage: none
 products:
   - id: ehdaa2.owl
   - id: ehdaa2.obo


### PR DESCRIPTION
per OBO service grant & Jonathan Bard added license info, but there is no working homepage, changed to none. ontology is inactive, but not orphaned.