### PR TITLE
Change license of SEPIO to CC-BY as presumably intended

### DIFF
--- a/ontology/sepio.md
+++ b/ontology/sepio.md
@@ -10,8 +10,8 @@ contact:
   email: mhb120@gmail.com
   label: Matthew Brush
 license:
-  url: https://creativecommons.org/licenses/by-sa/2.0/
-  label: CC-BY-SA
+  url: https://creativecommons.org/licenses/by/3.0/
+  label: CC-BY
 build:
   checkout: git clone https://github.com/monarch-initiative/SEPIO-ontology.git
   system: git


### PR DESCRIPTION
https://github.com/monarch-initiative/SEPIO-ontology/blob/master/README.md#license

Says
_The SEPIO Ontology and Framework is an open source project, free to re-use and re-mix under a Creative Commons 3.0 BY license._

I assume therefore that the current assignment as share-alike 2.0 was wrong