### PR TITLE
Create metadata grid & sort homepage by results

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,6 +96,8 @@ registry/publications.md: util/extract-publications.py registry/ontologies.yml
 
 # generate both a report of the violations and a grid of all results
 # the grid is later used to sort the ontologies on the home page
+validate: reports/metadata-grid.csv reports/metadata-grid.html
+
 RESULTS = reports/metadata-violations.tsv reports/metadata-grid.csv
 reports/metadata-grid.csv: tmp/unsorted-ontologies.yml | extract-metadata reports
 	./util/validate-metadata.py $< $(RESULTS)

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,9 @@ ONTS := $(wildcard ontology/*md)
 # All principles .md file
 PRINCIPLES := $(wildcard principles/*md)
 
+# metadata validation full result file
+GRID = reports/metadata-grid.csv
+
 
 ### Main Tasks
 
@@ -103,7 +106,7 @@ extract-metadata: $(ONTS)
 validate: reports/metadata-violations.tsv
 .PHONY: reports/metadata-violations.tsv
 reports/metadata-violations.tsv: tmp/ontologies.jsonld | extract-metadata reports
-	./util/validate-metadata.py $^ $@ && rm -rf tmp
+	./util/validate-metadata.py $^ $@ $(GRID) && rm -rf tmp
 
 # Uses temporary directory to store builds
 # Without overwriting the actual build files

--- a/Makefile
+++ b/Makefile
@@ -33,9 +33,6 @@ ONTS := $(wildcard ontology/*md)
 # All principles .md file
 PRINCIPLES := $(wildcard principles/*md)
 
-# metadata validation full result file
-GRID = reports/metadata-grid.csv
-
 
 ### Main Tasks
 
@@ -65,9 +62,9 @@ pull:
 _config.yml: _config_header.yml registry/ontologies.yml principles/all.yml
 	cat $^ > $@.tmp && mv $@.tmp $@
 
-# Extract metadata from each ontology .md file and combine into single yaml
-registry/ontologies.yml: $(ONTS)
-	./util/extract-metadata.py concat -o $@.tmp $^  && mv $@.tmp $@
+# Sort ontologies based on the validation (metadata-grid)
+registry/ontologies.yml: tmp/unsorted-ontologies.yml reports/metadata-grid.csv
+	./util/sort-ontologies.py $^ $@ && rm -rf tmp
 
 # Extract the metadata from each principle in the principles/ directory, and concatenate
 # into a single yaml file in that directory
@@ -97,28 +94,29 @@ registry/publications.md: util/extract-publications.py registry/ontologies.yml
 
 ### Validate Configuration Files
 
+# generate both a report of the violations and a grid of all results
+# the grid is later used to sort the ontologies on the home page
+RESULTS = reports/metadata-violations.tsv reports/metadata-grid.csv
+reports/metadata-grid.csv: tmp/unsorted-ontologies.yml | extract-metadata reports
+	./util/validate-metadata.py $< $(RESULTS)
+
+# generate an HTML output of the metadata grid
+# TODO: determine where this output belongs
+reports/metadata-grid.html: reports/metadata-grid.csv
+	./util/create-html-grid.py $< $@
+
+# Extract metadata from each ontology .md file and combine into single yaml
+tmp/unsorted-ontologies.yml: $(ONTS) | tmp
+	./util/extract-metadata.py concat -o $@.tmp $^  && mv $@.tmp $@
+
+tmp:
+	mkdir -p $@
+
 reports:
 	mkdir -p $@
 
 extract-metadata: $(ONTS)
 	./util/extract-metadata.py validate $^
-
-validate: reports/metadata-violations.tsv
-.PHONY: reports/metadata-violations.tsv
-reports/metadata-violations.tsv: tmp/ontologies.jsonld | extract-metadata reports
-	./util/validate-metadata.py $^ $@ $(GRID) && rm -rf tmp
-
-# Uses temporary directory to store builds
-# Without overwriting the actual build files
-
-tmp:
-	mkdir -p $@
-
-tmp/ontologies.yml: $(ONTS) | tmp
-	./util/extract-metadata.py concat -o $@.tmp $^  && mv $@.tmp $@
-
-tmp/ontologies.jsonld: tmp/ontologies.yml
-	./util/yaml2json.py $< > $@.tmp && mv $@.tmp $@
 
 # Note this should *not* be run as part of general travis jobs, it is expensive
 # and may be prone to false positives as it is inherently network-based

--- a/_includes/ontology_table.html
+++ b/_includes/ontology_table.html
@@ -2,7 +2,15 @@ Download table as: [ <a href="/registry/ontologies.yml">YAML</a> | <a href="/reg
 <table class="table">
   <tbody>
     {% for ont in site.ontologies %}
-    <tr class="{% if ont.in_foundry_order %}foundry{% elsif ont.is_obsolete %}obsolete{% endif %}">
+      {% if ont.in_foundry_order %}
+      <tr class="foundry">
+      {% elsif ont.is_obsolete %}
+      <tr class="obsolete">
+      {% elsif ont.activity_status == "orphaned" %}
+      <tr class="obsolete">
+      {% elsif ont.activity_status == "inactive" %}
+      <tr class="obsolete">
+      {% endif %}
       <td>
          <a href="ontology/{{ ont.id }}.html" >
            {% if ont.is_obsolete %}
@@ -32,6 +40,9 @@ Download table as: [ <a href="/registry/ontologies.yml">YAML</a> | <a href="/reg
           {{ ont.description }}
         </s>
         <mark>obsolete</mark>
+        {% elsif ont.activity_status == "inactive" %}
+        {{ ont.description }}
+        <mark>inactive</mark>
         {% else %}
         {{ ont.description }}
         {% endif %}

--- a/util/create-html-grid.py
+++ b/util/create-html-grid.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+
+import csv, sys
+
+headers = []
+
+def main(args):
+	'''Usage: create-html-grid.py <tsv-or-csv-grid> <output-html>'''
+	input_grid = args[1]
+	html_grid = args[2]
+	lines = get_html(parse_table(input_grid))
+
+	with open(html_grid, 'w') as f:
+		for line in lines:
+			f.write(line + '\n')
+
+def parse_table(input_grid):
+	'''Given an input grid in TSV or CSV, get the data as a dictionary. Also set 
+	the headers for the HTML grid.'''
+	global headers
+
+	data = {}
+	if '.tsv' in input_grid:
+		delim = '\t'
+	elif '.csv' in input_grid:
+		delim = ','
+	else:
+		print("Invalid file format: %s" % input_grid)
+		sys.exit(1)
+	reader = csv.reader(open(input_grid), delimiter=delim)
+	headers = next(reader)
+	for row in reader:
+		ont_id = row.pop(0)
+		fields = row
+		data[ont_id] = fields
+	return data
+
+def get_html(data):
+	'''Given the data from the grid, return an array of lines to generate an 
+	HTML table.'''
+	global headers
+
+	lines = []
+	lines.append('<table>')
+	lines.append('\t<tr>')
+	for h in headers:
+		lines.append('\t\t<td><b>%s</b></td>' % h)
+	lines.append('\t</tr>')
+	for ont, fields in data.items():
+		lines.append('\t<tr>')
+		bg_color = '#FFFFFF'
+		lines.append('\t\t<td bgcolor="%s">%s</td>' % (bg_color, ont))
+		for f in fields:
+			if f == 'PASS':
+				bg_color = '#97E595'
+			elif f == 'info' or f == 'inactive':
+				bg_color = '#DDDDDD'
+			elif f == 'warning' or f == 'WARN':
+				bg_color = '#F7F585'
+			elif f == 'error' or f == 'FAIL':
+				bg_color = '#F4A8A8'
+			else:
+				bg_color = '#FFFFFF'
+			lines.append('\t\t<td bgcolor="%s">%s</td>' % (bg_color, f))
+		lines.append('\t</tr>')
+	lines.append('</table>')
+	return lines
+
+if __name__ == '__main__':
+	main(sys.argv)

--- a/util/schema/activity_status.json
+++ b/util/schema/activity_status.json
@@ -1,6 +1,8 @@
 {
 	"title": "activity_status",
 	"level": "error",
+	"principle": "http://obofoundry.org/principles/fp-016-maintenance.html",
+	"description": "'activity_status' is a required property that must have a value of 'active', 'inactive', or 'orphaned'. Active ontologies have a contact and are currently in development. Orphaned ontologies are still in development, but do not have a contact. Inactive ontologies are no longer in development.",
 	"properties": {
 		"activity_status": { "enum": ["active", "inactive", "orphaned"] },
 		"errors": {

--- a/util/schema/contact.json
+++ b/util/schema/contact.json
@@ -1,6 +1,8 @@
 {
 	"title": "contact",
 	"level": "error",
+	"principle": "http://obofoundry.org/principles/fp-011-locus-of-authority.html",
+	"description": "'contact' is a required property. This object must include an email and a label (the name of the contact). The contact is the person responsible for communications between the community and the ontology developers.",
 	"properties": {
 		"contact": {
 			"type": "object",

--- a/util/schema/description.json
+++ b/util/schema/description.json
@@ -1,7 +1,7 @@
 {
 	"title": "description",
 	"level": "warning",
-	"description": "'description' is a recommended property. The value is a a string that breifly describes the ontology project.",
+	"description": "'description' is a recommended property. The value is a a string that briefly describes the ontology project.",
 	"properties": {
 		"description": { "type": "string" }
 	},

--- a/util/schema/description.json
+++ b/util/schema/description.json
@@ -1,6 +1,7 @@
 {
 	"title": "description",
 	"level": "warning",
+	"description": "'description' is a recommended property. The value is a a string that breifly describes the ontology project.",
 	"properties": {
 		"description": { "type": "string" }
 	},

--- a/util/schema/homepage.json
+++ b/util/schema/homepage.json
@@ -1,6 +1,7 @@
 {
 	"title": "homepage",
 	"level": "warning",
+	"description": "'homepage' is a recommended property. The value is the full URL to the homepage.",
 	"properties": {
 		"homepage": { "type": "string", "format": "uri" }
 	},

--- a/util/schema/id.json
+++ b/util/schema/id.json
@@ -1,6 +1,8 @@
 {
 	"title": "id",
 	"level": "error",
+	"principle": "http://obofoundry.org/principles/fp-003-uris.html",
+	"description": "'id' is a required property. The value is a string with no numeric or lowercase characters. This is typically an abbreviation or acronym of the ontology title.",
 	"properties": {
 		"id": { "type": "string", "pattern": "^[0-9a-z_]+$" }
 	},

--- a/util/schema/license-lite.json
+++ b/util/schema/license-lite.json
@@ -1,6 +1,8 @@
 {
 	"title": "license",
 	"level": "error",
+	"principle": "http://obofoundry.org/principles/fp-001-open.html",
+	"description": "'license' is a required property. The value is an object with a 'url' and 'label' field. The 'url' must be the full URL of the license, and the 'label' is the name of the license.",
 	"properties": {
 		"license": {
 			"type": "object",

--- a/util/schema/license-lite.json
+++ b/util/schema/license-lite.json
@@ -1,5 +1,5 @@
 {
-	"title": "license",
+	"title": "license-lite",
 	"level": "error",
 	"principle": "http://obofoundry.org/principles/fp-001-open.html",
 	"description": "'license' is a required property. The value is an object with a 'url' and 'label' field. The 'url' must be the full URL of the license, and the 'label' is the name of the license.",

--- a/util/schema/license.json
+++ b/util/schema/license.json
@@ -1,6 +1,8 @@
 {
 	"title": "license",
 	"level": "warning",
+	"principle": "http://obofoundry.org/principles/fp-001-open.html",
+	"description": "It is recommended that the 'license' value is CC0 or CC-BY.",
 	"properties": {
 		"license": {
 			"type": "object",

--- a/util/schema/products.json
+++ b/util/schema/products.json
@@ -1,6 +1,7 @@
 {
 	"title": "products",
 	"level": "info",
+	"description": "'products' is a recommended field. The value is a list of resources, each with an ID. The resources should be in one of the following formats: OWL, OBO, JSON, OFN, OWX, TTL, or g-zipped OWL.",
 	"properties": {
 		"products": {
 			"type": "array",

--- a/util/schema/title.json
+++ b/util/schema/title.json
@@ -1,6 +1,7 @@
 {
 	"title": "title",
 	"level": "error",
+	"description": "'title' is a required field. The value is the full name of the ontology project.",
 	"properties": {
 		"title": { "type": "string" }
 	},

--- a/util/sort-ontologies.py
+++ b/util/sort-ontologies.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+
+import csv, sys, yaml
+
+def main(args):
+	'''Usage: sort-ontologies.py <unsorted-yaml> <metdata-grid> <output-yaml>'''
+	data_file = args[1]
+	grid = args[2]
+	output = args[3]
+
+	sort_order = get_sort_order(grid)
+	data = load_data(data_file)
+	data = sort_ontologies(data, sort_order)
+	write_data(data, output)
+
+def get_sort_order(grid):
+	'''Given the path to the metadata grid (CSV or TSV), extract the order of 
+	ontologies from the grid. Return the list of ontology IDs in that order.'''
+	sort_order = []
+	if '.csv' in grid:
+		separator = ','
+	elif '.tsv' or '.txt' in grid:
+		separator = '\t'
+	else:
+		print('%s must be tab- or comma-separated.')
+		sys.exit(1)
+	with open(grid, 'r') as f:
+		reader = csv.reader(f, delimiter=separator)
+		next(reader)
+		for row in reader:
+			sort_order.append(row[0])
+	return sort_order
+
+def load_data(data_file):
+	'''Given a YAML file, load the data into a dictionary.'''
+	stream = open(data_file, 'r')
+	data = yaml.load(stream)
+	return data
+
+def sort_ontologies(data, sort_order):
+	'''Given the ontologies data as a dictionary and the list of ontologies in 
+	proper sort order, return the sorted data.'''
+	mapped = {}
+	for item in data['ontologies']:
+		ont_id = item['id']
+		mapped[ont_id] = item
+	ontologies = []
+	for ont_id in sort_order:
+		ontologies.append(mapped[ont_id])
+	data['ontologies'] = ontologies
+	return data
+
+def write_data(data, output):
+	'''Given the ontologies data as a dictionary and an output YAML file to 
+	write to, write the data to the file. '''
+	yaml_str = yaml.dump(data)
+	with open(output, 'w') as f:
+		f.write(yaml_str)
+
+if __name__ == '__main__':
+	main(sys.argv)

--- a/util/validate-metadata.py
+++ b/util/validate-metadata.py
@@ -1,15 +1,15 @@
 #!/usr/bin/env python3
 
-import ast, json, jsonschema, os, re, sys
+import ast, json, jsonschema, os, re, sys, yaml
 
 # file paths
 schema_dir = 'util/schema'
 
 def validate(args):
-	"""
+	'''
 	Validate registry metadata.
 	Usage: ./validate-metadata.py <data file> <output file> <grid file>
-	"""
+	'''
 	global metadata_grid
 
 	data_file = args[1]
@@ -26,9 +26,16 @@ def validate(args):
 	for item in data["ontologies"]:
 		add = validate_metadata(item, schemas)
 		results = update_results(results, add)
+
+	# save the metadata-grid with ALL results
+	headers = []
+	for s in schemas:
+		headers.append(s['title'])
+	save_grid(metadata_grid, headers, grid_file)
+
+	# print and save the results that did not pass
 	print_results(results)
 	save_results(results, output_file)
-	save_grid(metadata_grid, grid_file)
 	if results['error']:
 		print('Metadata validation failed with %d errors - see %s for details'\
 		      % (len(results['error']), output_file))
@@ -37,165 +44,14 @@ def validate(args):
 		print('Metadata validation passed - see %s for warnings' % output_file)
 		sys.exit(0)
 
-def update_results(results, add):
-	"""Given a map of results for all ontologies and a map of results to add, 
-	append the results to the lists in the map."""
-	res_errors = results['error']
-	res_warns = results['warn']
-	res_infos = results['info']
-	results['error'] = res_errors + add['error']
-	results['warn'] = res_warns + add['warn']
-	results['info'] = res_infos + add['info']
-	return results
-
-def print_results(results):
-	"""Given a map of results, log results on the console."""
-	for level, messages in results.items():
-		for m in messages:
-			print('%s\t%s' % (level.upper(), m))
-
-def save_results(results, output_file):
-	"""Given a map of results and an output file to write to, write each result 
-	on a line."""
-	if '.csv' in output_file:
-		separator = ','
-	elif '.tsv' or '.txt' in output_file:
-		separator = '\t'
-	else:
-		print('Output file must be CSV, TSV, or TXT')
-		return
-	with open(output_file, 'w') as f:
-		f.write('Level%sMessage\n' % separator)
-		for level, messages in results.items():
-			for m in messages:
-				f.write('%s%s%s\n' % (level.upper(), separator, m))
-
-def save_grid(metadata_grid, grid_file):
-	"""Given a metadata grid of all results and a grid file to write to, create 
-	a sorted table of the full results."""
-	if '.csv' in grid_file:
-		separator = ','
-	elif '.tsv' or '.txt' in grid_file:
-		separator = '\t'
-	else:
-		print('Grid file must be CSV, TSV, or TXT')
-		return
-
-	sort = sort_grid(metadata_grid)
-	header = 'Ontology{0}Activity Status{0}Validation Status{0}activity_status{0}contact{0}description{0}homepage{0}id{0}license{0}products{0}title\n'.format(separator)
-
-	with open(grid_file, 'w') as f:
-		f.write(header)
-		for ont_id in sort:
-			results = metadata_grid[ont_id]
-			s = '{1}{0}{2}{0}{3}{0}{4}{0}{5}{0}{6}{0}{7}{0}{8}{0}{9}{0}{10}{0}{11}\n'\
-				.format(separator,
-					    ont_id, 
-					    results['ontology_status'], 
-					    results['validation_status'], 
-					    results['activity_status'],
-					    results['contact'],
-					    results['description'],
-					    results['homepage'],
-					    results['id'],
-					    results['license'],
-					    results['products'],
-					    results['title'])
-			f.write(s)
-	print('Full validation results written to %s' % grid_file)
-
-def sort_grid(metadata_grid):
-	"""Given a metadata grid as a map, sort the grid based on:
-	   1. Foundry status
-	   2. Ontology activity status
-	   3. Validation status
-	   4. Alphabetical
-	Return a sorted list of IDs."""
-	pass_foundry = []
-	info_foundry = []
-	warn_foundry = []
-	fail_foundry = []
-	pass_active = []
-	info_active = []
-	warn_active = []
-	fail_active = []
-	pass_orphaned = []
-	info_orphaned = []
-	warn_orphaned = []
-	fail_orphaned = []
-	pass_inactive = []
-	info_inactive = []
-	warn_inactive = []
-	fail_inactive = []
-
-	for ont_id, results in metadata_grid.items():
-		# get the info about the ontology to sort on
-		foundry = results['foundry']
-		ontology_status = results['ontology_status']
-		validation_status = results['validation_status']
-
-		if foundry:
-			if validation_status == 'PASS':
-				pass_foundry.append(ont_id)
-			elif validation_status == 'INFO':
-				info_foundry.append(ont_id)
-			elif validation_status == 'WARN':
-				warn_foundry.append(ont_id)
-			elif validation_status == 'FAIL':
-				fail_foundry.append(ont_id)
-			continue
-
-		if ontology_status == 'active':
-			if validation_status == 'PASS':
-				pass_active.append(ont_id)
-			elif validation_status == 'INFO':
-				info_active.append(ont_id)
-			elif validation_status == 'WARN':
-				warn_active.append(ont_id)
-			elif validation_status == 'FAIL':
-				fail_active.append(ont_id)
-
-		elif ontology_status == 'orphaned':
-			if validation_status == 'PASS':
-				pass_orphaned.append(ont_id)
-			elif validation_status == 'INFO':
-				info_orphaned.append(ont_id)
-			elif validation_status == 'WARN':
-				warn_orphaned.append(ont_id)
-			elif validation_status == 'FAIL':
-				fail_orphaned.append(ont_id)
-
-		elif ontology_status == 'inactive':
-			if validation_status == 'PASS':
-				pass_inactive.append(ont_id)
-			elif validation_status == 'INFO':
-				info_inactive.append(ont_id)
-			elif validation_status == 'WARN':
-				warn_inactive.append(ont_id)
-			elif validation_status == 'FAIL':
-				fail_inactive.append(ont_id)
-
-	sort = sort_list(pass_foundry) + sort_list(info_foundry) \
-	       + sort_list(warn_foundry) + sort_list(fail_foundry) \
-	       + sort_list(pass_active) + sort_list(info_active) \
-	       + sort_list(warn_active) + sort_list(fail_active) \
-	       + sort_list(pass_orphaned) + sort_list(info_orphaned) \
-	       + sort_list(warn_orphaned) + sort_list(fail_orphaned) \
-	       + sort_list(pass_inactive) + sort_list(info_inactive) \
-	       + sort_list(warn_inactive) + sort_list(fail_inactive)
-
-	return sort
-
-def sort_list(arr):
-	"""Given an array, sort the list. If the list is empty, return an empty list 
-	(instead of None)."""
-	arr.sort(key=str.lower)
-	if not arr:
-		return []
-	return arr
+def load_data(data_file):
+	'''Given a YAML data file, load the data to validate.'''
+	stream = open(data_file, 'r')
+	data = yaml.load(stream)
+	return data
 
 def get_schemas():
-	"""Return a set of schemas from the master schema directory."""
+	'''Return a set of schemas from the master schema directory.'''
 	schemas = []
 	for f in os.listdir(schema_dir):
 		if '.json' not in f:
@@ -210,9 +66,9 @@ def get_schemas():
 	return schemas
 
 def validate_metadata(item, schemas):
-	"""Given an item and a set of schemas, validate the item against the 
+	'''Given an item and a set of schemas, validate the item against the 
 	schemas. Add the full results to the metadata_grid and return a map of 
-	errors, warnings, and infos for any active ontologies."""
+	errors, warnings, and infos for any active ontologies.'''
 	global metadata_grid
 
 	ont_id = item['id']
@@ -230,6 +86,11 @@ def validate_metadata(item, schemas):
 		results['foundry'] = True
 	else:
 		results['foundry'] = False
+
+	if 'is_obsolete' in item and item['is_obsolete'] == True:
+		results['obsolete'] = True
+	else:
+		results['obsolete'] = False
 
 	if 'activity_status' in item:
 		results['ontology_status'] = item['activity_status']
@@ -318,19 +179,195 @@ def validate_metadata(item, schemas):
 	return {'error': errors, 'warn': warnings, 'info': infos}
 
 def format_license_msg(substr):
-	"""Format an exception message for a license issue."""
+	'''Format an exception message for a license issue.'''
 	# process to dict
 	d = json.loads(substr.replace('\'', '"'))
 	url = d['url']
 	label = d['label']
 	return '\'{0}\' <{1}> is not a recommended license'.format(label, url)
 
-def load_data(data_file):
-	"""Load the data to validate."""
-	# read the JSON-LD data
-	with open(data_file) as f:
-		data = json.load(f)
-	return data
+def update_results(results, add):
+	'''Given a map of results for all ontologies and a map of results to add, 
+	append the results to the lists in the map.'''
+	res_errors = results['error']
+	res_warns = results['warn']
+	res_infos = results['info']
+	results['error'] = res_errors + add['error']
+	results['warn'] = res_warns + add['warn']
+	results['info'] = res_infos + add['info']
+	return results
+
+def sort_grid(metadata_grid):
+	'''Given a metadata grid as a map, sort the grid based on:
+	   1. Foundry status
+	   2. Ontology activity status
+	   3. Validation status
+	   4. Alphabetical
+	Return a sorted list of IDs.'''
+	pass_foundry = []
+	info_foundry = []
+	warn_foundry = []
+	fail_foundry = []
+	pass_active = []
+	info_active = []
+	warn_active = []
+	fail_active = []
+	pass_orphaned = []
+	info_orphaned = []
+	warn_orphaned = []
+	fail_orphaned = []
+	pass_inactive = []
+	info_inactive = []
+	warn_inactive = []
+	fail_inactive = []
+	pass_obsolete = []
+	info_obsolete = []
+	warn_obsolete = []
+	fail_obsolete = []
+
+	for ont_id, results in metadata_grid.items():
+		# get the info about the ontology to sort on
+		foundry = results['foundry']
+		obsolete = results['obsolete']
+		ontology_status = results['ontology_status']
+		validation_status = results['validation_status']
+
+		# foundry ontologies are displayed first
+		# they must be active
+		if foundry:
+			if validation_status == 'PASS':
+				pass_foundry.append(ont_id)
+			elif validation_status == 'INFO':
+				info_foundry.append(ont_id)
+			elif validation_status == 'WARN':
+				warn_foundry.append(ont_id)
+			elif validation_status == 'FAIL':
+				fail_foundry.append(ont_id)
+			continue
+
+		# obsolete ontologies are displayed last
+		# they are always inactive
+		# (inactive does not mean obsolete)
+		if obsolete:
+			if validation_status == 'PASS':
+				pass_obsolete.append(ont_id)
+			elif validation_status == 'INFO':
+				info_obsolete.append(ont_id)
+			elif validation_status == 'WARN':
+				warn_obsolete.append(ont_id)
+			elif validation_status == 'FAIL':
+				fail_obsolete.append(ont_id)
+			continue
+
+		# finally, sort by: active, orphaned, inactive
+		if ontology_status == 'active':
+			if validation_status == 'PASS':
+				pass_active.append(ont_id)
+			elif validation_status == 'INFO':
+				info_active.append(ont_id)
+			elif validation_status == 'WARN':
+				warn_active.append(ont_id)
+			elif validation_status == 'FAIL':
+				fail_active.append(ont_id)
+		elif ontology_status == 'orphaned':
+			if validation_status == 'PASS':
+				pass_orphaned.append(ont_id)
+			elif validation_status == 'INFO':
+				info_orphaned.append(ont_id)
+			elif validation_status == 'WARN':
+				warn_orphaned.append(ont_id)
+			elif validation_status == 'FAIL':
+				fail_orphaned.append(ont_id)
+		elif ontology_status == 'inactive':
+			if validation_status == 'PASS':
+				pass_inactive.append(ont_id)
+			elif validation_status == 'INFO':
+				info_inactive.append(ont_id)
+			elif validation_status == 'WARN':
+				warn_inactive.append(ont_id)
+			elif validation_status == 'FAIL':
+				fail_inactive.append(ont_id)
+
+	# concat a sorted list
+	sort = sort_list(pass_foundry) + sort_list(info_foundry) \
+	       + sort_list(warn_foundry) + sort_list(fail_foundry) \
+	       + sort_list(pass_active) + sort_list(info_active) \
+	       + sort_list(warn_active) + sort_list(fail_active) \
+	       + sort_list(pass_orphaned) + sort_list(info_orphaned) \
+	       + sort_list(warn_orphaned) + sort_list(fail_orphaned) \
+	       + sort_list(pass_inactive) + sort_list(info_inactive) \
+	       + sort_list(warn_inactive) + sort_list(fail_inactive) \
+	       + sort_list(pass_obsolete) + sort_list(info_obsolete) \
+	       + sort_list(warn_obsolete) + sort_list(fail_obsolete)
+
+	return sort
+
+def sort_list(arr):
+	'''Given an array, sort the list. If the list is empty, return an empty list 
+	(instead of None).'''
+	arr.sort(key=str.lower)
+	if not arr:
+		return []
+	return arr
+
+def save_grid(metadata_grid, headers, grid_file):
+	'''Given a metadata grid of all results and a grid file to write to, create 
+	a sorted table of the full results.'''
+	if '.csv' in grid_file:
+		separator = ','
+	elif '.tsv' or '.txt' in grid_file:
+		separator = '\t'
+	else:
+		print('Grid file must be CSV, TSV, or TXT')
+		return
+
+	# Determine order of ontologies based on statuses
+	sort_order = sort_grid(metadata_grid)
+
+	# First three help to see overall details
+	header = 'Ontology{0}Activity Status{0}Validation Status'.format(separator)
+	# After that, we show the results of each check
+	for h in headers:
+		header += separator + h
+	header += '\n'
+
+	with open(grid_file, 'w') as f:
+		f.write(header)
+		for ont_id in sort_order:
+			results = metadata_grid[ont_id]
+			s = '{1}{0}{2}{0}{3}'.format(
+				separator, 
+				ont_id, 
+				results['ontology_status'], 
+				results['validation_status'])
+			for h in headers:
+				s += separator + results[h]
+			s += '\n'
+			f.write(s)
+
+	print('Full validation results written to %s' % grid_file)
+
+def print_results(results):
+	'''Given a map of results, log results on the console.'''
+	for level, messages in results.items():
+		for m in messages:
+			print('%s\t%s' % (level.upper(), m))
+
+def save_results(results, output_file):
+	'''Given a map of results and an output file to write to, write each result 
+	on a line.'''
+	if '.csv' in output_file:
+		separator = ','
+	elif '.tsv' or '.txt' in output_file:
+		separator = '\t'
+	else:
+		print('Output file must be CSV, TSV, or TXT')
+		return
+	with open(output_file, 'w') as f:
+		f.write('Level%sMessage\n' % separator)
+		for level, messages in results.items():
+			for m in messages:
+				f.write('%s%s%s\n' % (level.upper(), separator, m))
 
 # run the process!
 if __name__ == '__main__':

--- a/util/validate-metadata.py
+++ b/util/validate-metadata.py
@@ -129,7 +129,7 @@ def validate_metadata(item, schemas):
 			# - ontology annotated with `validate: false`
 			if 'activity_status' in item \
 			    and item['activity_status'] == 'orphaned':
-			    if title == 'contact' or title == 'license':
+			    if title == 'contact' or title == 'license' or title == 'license-lite':
 			    	continue
 			if ('is_obsolete' in item and item['is_obsolete'] is True) \
 			or ('activity_status' in item \
@@ -139,7 +139,7 @@ def validate_metadata(item, schemas):
 
 			# get a message for displaying on terminal
 			msg = ve.message
-			if title == 'license':
+			if title == 'license' or title == 'license-lite':
 				# license error message can show up in a few different ways
 				search = re.search('\'(.+?)\' is not one of', msg)
 				if search:
@@ -327,6 +327,7 @@ def save_grid(metadata_grid, headers, grid_file):
 	# First three help to see overall details
 	header = 'Ontology{0}Activity Status{0}Validation Status'.format(separator)
 	# After that, we show the results of each check
+	headers.remove('license-lite')
 	for h in headers:
 		header += separator + h
 	header += '\n'
@@ -340,7 +341,23 @@ def save_grid(metadata_grid, headers, grid_file):
 				ont_id, 
 				results['ontology_status'], 
 				results['validation_status'])
+			if ont_id == 'vario':
+				print(headers)
+				print(results)
 			for h in headers:
+				if h == 'license':
+					# license has two checks
+					# so the license entry will be the more severe violation
+					all_res = [results['license'], results['license-lite']]
+					if 'error' in all_res:
+						s += separator + 'error'
+					elif 'warning' in all_res:
+						s += separator + 'warning'
+					elif 'info' in all_res:
+						s += separator + 'info'
+					else:
+						s += separator + 'pass'
+					continue
 				s += separator + results[h]
 			s += '\n'
 			f.write(s)

--- a/util/validate-metadata.py
+++ b/util/validate-metadata.py
@@ -8,34 +8,38 @@ schema_dir = 'util/schema'
 def validate(args):
 	"""
 	Validate registry metadata.
+	Usage: ./validate-metadata.py <data file> <output file> <grid file>
 	"""
+	global metadata_grid
+
 	data_file = args[1]
 	output_file = args[2]
+	grid_file = args[3]
+
 	data = load_data(data_file)
 	schemas = get_schemas()
-	# validate each object
+	
 	results = {'error': [], 'warn': [], 'info': []}
+	metadata_grid = {}
+
+	# validate each object
 	for item in data["ontologies"]:
-		if 'validate' in item and item['validate'] is False:
-			continue
-		if 'is_obsolete' in item and item["is_obsolete"] is True:
-			continue
-		if 'activity_status' in item and item['activity_status'] == 'inactive':
-			continue
 		add = validate_metadata(item, schemas)
 		results = update_results(results, add)
 	print_results(results)
 	save_results(results, output_file)
+	save_grid(metadata_grid, grid_file)
 	if results['error']:
-		print('\nMetadata validation failed with %d errors - see %s for details'\
+		print('Metadata validation failed with %d errors - see %s for details'\
 		      % (len(results['error']), output_file))
 		sys.exit(1)
 	else:
-		print('\nMetadata validation passed - see %s for details' % output_file)
+		print('Metadata validation passed - see %s for details' % output_file)
 		sys.exit(0)
 
 def update_results(results, add):
-	""""""
+	"""Given a map of results for all ontologies and a map of results to add, 
+	append the results to the lists in the map."""
 	res_errors = results['error']
 	res_warns = results['warn']
 	res_infos = results['info']
@@ -45,13 +49,14 @@ def update_results(results, add):
 	return results
 
 def print_results(results):
-	""""""
+	"""Given a map of results, log results on the console."""
 	for level, messages in results.items():
 		for m in messages:
 			print('%s\t%s' % (level.upper(), m))
 
 def save_results(results, output_file):
-	""""""
+	"""Given a map of results and an output file to write to, write each result 
+	on a line."""
 	if '.csv' in output_file:
 		separator = ','
 	elif '.tsv' or '.txt' in output_file:
@@ -65,9 +70,132 @@ def save_results(results, output_file):
 			for m in messages:
 				f.write('%s%s%s\n' % (level.upper(), separator, m))
 
+def save_grid(metadata_grid, grid_file):
+	"""Given a metadata grid of all results and a grid file to write to, create 
+	a sorted table of the full results."""
+	if '.csv' in grid_file:
+		separator = ','
+	elif '.tsv' or '.txt' in grid_file:
+		separator = '\t'
+	else:
+		print('Grid file must be CSV, TSV, or TXT')
+		return
+
+	sort = sort_grid(metadata_grid)
+	header = 'Ontology{0}Activity Status{0}Validation Status{0}activity_status{0}contact{0}description{0}homepage{0}id{0}license{0}products{0}title\n'.format(separator)
+
+	with open(grid_file, 'w') as f:
+		f.write(header)
+		for ont_id in sort:
+			results = metadata_grid[ont_id]
+			s = '{1}{0}{2}{0}{3}{0}{4}{0}{5}{0}{6}{0}{7}{0}{8}{0}{9}{0}{10}{0}{11}\n'\
+				.format(separator,
+					    ont_id, 
+					    results['ontology_status'], 
+					    results['validation_status'], 
+					    results['activity_status'],
+					    results['contact'],
+					    results['description'],
+					    results['homepage'],
+					    results['id'],
+					    results['license'],
+					    results['products'],
+					    results['title'])
+			f.write(s)
+	print('Full validation results written to %s' % grid_file)
+
+def sort_grid(metadata_grid):
+	"""Given a metadata grid as a map, sort the grid based on:
+	   1. Foundry status
+	   2. Ontology activity status
+	   3. Validation status
+	   4. Alphabetical
+	Return a sorted list of IDs."""
+	pass_foundry = []
+	info_foundry = []
+	warn_foundry = []
+	fail_foundry = []
+	pass_active = []
+	info_active = []
+	warn_active = []
+	fail_active = []
+	pass_orphaned = []
+	info_orphaned = []
+	warn_orphaned = []
+	fail_orphaned = []
+	pass_inactive = []
+	info_inactive = []
+	warn_inactive = []
+	fail_inactive = []
+
+	for ont_id, results in metadata_grid.items():
+		# get the info about the ontology to sort on
+		foundry = results['foundry']
+		ontology_status = results['ontology_status']
+		validation_status = results['validation_status']
+
+		if foundry:
+			if validation_status == 'PASS':
+				pass_foundry.append(ont_id)
+			elif validation_status == 'INFO':
+				info_foundry.append(ont_id)
+			elif validation_status == 'WARN':
+				warn_foundry.append(ont_id)
+			elif validation_status == 'FAIL':
+				fail_foundry.append(ont_id)
+			continue
+
+		if ontology_status == 'active':
+			if validation_status == 'PASS':
+				pass_active.append(ont_id)
+			elif validation_status == 'INFO':
+				info_active.append(ont_id)
+			elif validation_status == 'WARN':
+				warn_active.append(ont_id)
+			elif validation_status == 'FAIL':
+				fail_active.append(ont_id)
+
+		elif ontology_status == 'orphaned':
+			if validation_status == 'PASS':
+				pass_orphaned.append(ont_id)
+			elif validation_status == 'INFO':
+				info_orphaned.append(ont_id)
+			elif validation_status == 'WARN':
+				warn_orphaned.append(ont_id)
+			elif validation_status == 'FAIL':
+				fail_orphaned.append(ont_id)
+
+		elif ontology_status == 'inactive':
+			if validation_status == 'PASS':
+				pass_inactive.append(ont_id)
+			elif validation_status == 'INFO':
+				info_inactive.append(ont_id)
+			elif validation_status == 'WARN':
+				warn_inactive.append(ont_id)
+			elif validation_status == 'FAIL':
+				fail_inactive.append(ont_id)
+
+	sort = sort_list(pass_foundry) + sort_list(info_foundry) \
+	       + sort_list(warn_foundry) + sort_list(fail_foundry) \
+	       + sort_list(pass_active) + sort_list(info_active) \
+	       + sort_list(warn_active) + sort_list(fail_active) \
+	       + sort_list(pass_orphaned) + sort_list(info_orphaned) \
+	       + sort_list(warn_orphaned) + sort_list(fail_orphaned) \
+	       + sort_list(pass_inactive) + sort_list(info_inactive) \
+	       + sort_list(warn_inactive) + sort_list(fail_inactive)
+
+	return sort
+
+def sort_list(arr):
+	"""Given an array, sort the list. If the list is empty, return an empty list 
+	(instead of None)."""
+	arr.sort(key=str.lower)
+	if not arr:
+		return []
+	return arr
+
 def get_schemas():
-	"""
-	"""
+	"""Return a set of schemas from the master schema directory."""
 	schemas = []
 	for f in os.listdir(schema_dir):
 		if '.json' not in f:
@@ -82,22 +210,72 @@ def get_schemas():
 	return schemas
 
 def validate_metadata(item, schemas):
-	"""
-	"""
+	"""Given an item and a set of schemas, validate the item against the 
+	schemas. Add the full results to the metadata_grid and return a map of 
+	errors, warnings, and infos for any active ontologies."""
+	global metadata_grid
+
+	ont_id = item['id']
+
 	# these lists will be displayed on the console
 	errors = []
 	warnings = []
 	infos = []
-	ont_id = item['id']
+	
+	# results are put into the metadata grid
+	results = {}
+
+	# determine how to sort this item in the grid
+	if 'in_foundry_order' in item and item['in_foundry_order'] == 1:
+		results['foundry'] = True
+	else:
+		results['foundry'] = False
+
+	if 'activity_status' in item:
+		results['ontology_status'] = item['activity_status']
+	else:
+		# if there is no status, put them at the bottom with inactive
+		results['ontology_status'] = 'inactive'
+
+	has_error = False
+	has_warn = False
+	has_info = False
 	for s in schemas:
 		title = s['title']
-		if 'activity_status' in item and item['activity_status'] == 'orphaned':
-			if title == 'contact' or title == 'license':
-				continue
 		try:
 			jsonschema.validate(item, s)
+			results[title] = 'pass'
 		except jsonschema.exceptions.ValidationError as ve:
 			level = s['level']
+
+			# add to the results map
+			results[title] = level
+
+			# flag for errors, warnings, and infos
+			# without adding results to the lists that are logged
+			if level == 'error':
+				has_error = True
+			elif level == 'warning':
+				has_warn = True
+			elif level == 'info':
+				has_info = True
+
+			# these cases will not cause test failure and will not be logged
+			# the results are just added to the metadata grid:
+			# - orphaned ontology on contact or license chekck
+			# - inactive ontology
+			# - obsolete ontology
+			# - ontology annotated with `validate: false`
+			if (('activity_status' in item \
+			    and item['activity_status'] == 'orphaned') \
+			and (title == 'contact' or title == 'license')) \
+			and ('is_obsolete' in item and item['is_obsolete'] is True) \
+			or ('activity_status' in item \
+				and item['activity_status'] == 'inactive') \
+			or ('validate' in item and item['validate'] is False):
+				continue
+
+			# get a message for displaying on terminal
 			msg = ve.message
 			if title == 'license':
 				# license error message can show up in a few different ways
@@ -110,8 +288,10 @@ def validate_metadata(item, schemas):
 				search = re.search('({\'url\'.+?\'label\'.+?}) is not valid', msg)
 				if search:
 					format_license_msg(search.group(1))
+
 			# format the message with the ontology ID
 			msg = '%s %s: %s' % (ont_id.upper(), title, msg)
+
 			# append to correct set of warnings
 			if level == 'error':
 				errors.append(msg)
@@ -123,12 +303,21 @@ def validate_metadata(item, schemas):
 			elif level == 'info':
 				infos.append(msg)
 
+	# add an overall validation status to the grid entry
+	if has_error:
+		results['validation_status'] = 'FAIL'
+	elif has_warn:
+		results['validation_status'] = 'WARN'
+	elif has_info:
+		results['validation_status'] = 'INFO'
+	else:
+		results['validation_status'] = 'PASS'
+	metadata_grid[ont_id] = results
+
 	return {'error': errors, 'warn': warnings, 'info': infos}
 
 def format_license_msg(substr):
-	"""
-	Format an exception message for a license issue.
-	"""
+	"""Format an exception message for a license issue."""
 	# process to dict
 	d = json.loads(substr.replace('\'', '"'))
 	url = d['url']
@@ -136,9 +325,7 @@ def format_license_msg(substr):
 	return '\'{0}\' <{1}> is not a recommended license'.format(label, url)
 
 def load_data(data_file):
-	"""
-	Load the data to validate.
-	"""
+	"""Load the data to validate."""
 	# read the JSON-LD data
 	with open(data_file) as f:
 		data = json.load(f)

--- a/util/validate-metadata.py
+++ b/util/validate-metadata.py
@@ -34,7 +34,7 @@ def validate(args):
 		      % (len(results['error']), output_file))
 		sys.exit(1)
 	else:
-		print('Metadata validation passed - see %s for details' % output_file)
+		print('Metadata validation passed - see %s for warnings' % output_file)
 		sys.exit(0)
 
 def update_results(results, add):
@@ -266,10 +266,11 @@ def validate_metadata(item, schemas):
 			# - inactive ontology
 			# - obsolete ontology
 			# - ontology annotated with `validate: false`
-			if (('activity_status' in item \
-			    and item['activity_status'] == 'orphaned') \
-			and (title == 'contact' or title == 'license')) \
-			and ('is_obsolete' in item and item['is_obsolete'] is True) \
+			if 'activity_status' in item \
+			    and item['activity_status'] == 'orphaned':
+			    if title == 'contact' or title == 'license':
+			    	continue
+			if ('is_obsolete' in item and item['is_obsolete'] is True) \
 			or ('activity_status' in item \
 				and item['activity_status'] == 'inactive') \
 			or ('validate' in item and item['validate'] is False):


### PR DESCRIPTION
Includes a new validation product, for #779. This is found at `reports/metadata-grid.csv` after running validation locally (`make validate`, or just `make` if you want to do the full build). There is also an HTML output (`reports/metadata-grid.html`) that we can potentially use later.

When building `registry/ontologies.yml`, this grid is now used to sort the ontologies in the following order:
1. foundry
2. active
3. orphan
4. inactive
5. obsolete

Within each of those categories, the ontologies are sorted in order of their validation results:
1. pass
2. info
3. warn
4. fail (no items on the master branch should be failing, though)

Finally, they are sorted alphabetically within those sections (see #830).

Orphaned and inactive ontologies appear right about the obsolete ontologies with a grey background. Inactive ontologies are marked with 'inactive':

![image](https://user-images.githubusercontent.com/16750150/54241965-13f99e80-44e0-11e9-800a-eced6896ca23.png)
