### PR TITLE
Update sep.md make obsolete

### DIFF
--- a/ontology/sep.md
+++ b/ontology/sep.md
@@ -15,8 +15,8 @@ build:
   source_url: https://raw.githubusercontent.com/HUPO-PSI/gelml/master/CV/sep.obo
   method: obo2owl
   insert_ontology_id: true
-activity_status: active
-validate: false
+activity_status: inactive
+is_obsolete: true
 ---
 
 A structured controlled vocabulary for the annotation of sample processing and separation techniques in scientific experiments, such as, and including, gel electrophoresis, column chromatography, capillary electrophoresis, centrifugation and so on. Developed jointly by the HUPO Proteomics Standards Initiative and The Metabolomics Standards Initiative.


### PR DESCRIPTION
As part of the OBO Services metadata clean up and per email from Andy Jones (Andrew.Jones@liverpool.ac.uk) who states that sep is not actively maintained and can be moved to deprecated at your side, sep was deemed obsolete.