### PR TITLE
Adding link to tracker for CLO

### DIFF
--- a/ontology/clo.md
+++ b/ontology/clo.md
@@ -9,6 +9,7 @@ homepage: http://www.clo-ontology.org
 products:
   - id: clo.owl
 title: Cell Line Ontology
+tracker: https://github.com/CLO-Ontology/CLO/issues
 dependencies:
  - id: uberon
  - id: cl


### PR DESCRIPTION
Trying to fill in trackers for all active ontologies, see #891