### PR TITLE
Add missing `poro.obo` product to PORO page

### DIFF
--- a/ontology/poro.md
+++ b/ontology/poro.md
@@ -9,6 +9,7 @@ domain: anatomy
 homepage: https://github.com/obophenotype/porifera-ontology
 products:
   - id: poro.owl
+  - id: poro.obo
 taxon:
   id: NCBITaxon:6040
   label: Porifera


### PR DESCRIPTION
PORO is not listed as having an OBO product even though it does.
cc @cmungall 