### PR TITLE
Remove TermGenie metadata

### DIFF
--- a/_layouts/ontology_detail.html
+++ b/_layouts/ontology_detail.html
@@ -181,13 +181,6 @@ layout: default
           </dd>
           {% endif %}
 
-          {% if page.termgenie %}
-          <dt>TermGenie</dt>
-          <dd>
-            <a href="{{page.termgenie}}">{{page.termgenie}}</a>
-          </dd>
-          {% endif %}
-
           {% if page.taxon %}
           <dt>Taxon</dt>
           <dd>

--- a/faq/how-do-i-edit-metadata.md
+++ b/faq/how-do-i-edit-metadata.md
@@ -39,7 +39,6 @@ taxon:
   label: Metazoa
 domain: cells
 tracker: https://code.google.com/p/cell-ontology/issues/list
-termgenie: http://cl.termgenie.org
 mailing_list: https://lists.sourceforge.net/lists/listinfo/obo-cell-type
 dependencies:
  - id: uberon

--- a/ontology/cl.md
+++ b/ontology/cl.md
@@ -27,7 +27,6 @@ taxon:
   label: Metazoa
 domain: cells
 tracker: https://github.com/obophenotype/cell-ontology/issues
-termgenie: http://cl.termgenie.org
 mailing_list: https://lists.sourceforge.net/lists/listinfo/obo-cell-type
 dependencies:
  - id: uberon

--- a/ontology/go.md
+++ b/ontology/go.md
@@ -16,7 +16,6 @@ homepage: http://geneontology.org/
 twitter: news4go
 facebook: https://www.facebook.com/Gene-Ontology-305908656519/ 
 tracker: https://github.com/geneontology/go-ontology/issues/
-termgenie: http://go.termgenie.org
 taxon:
   id: NCBITaxon:1
   label: All life

--- a/ontology/hp.md
+++ b/ontology/hp.md
@@ -29,7 +29,6 @@ build:
   method: archive
   infallible: 1
 tracker: https://github.com/obophenotype/human-phenotype-ontology/issues/
-termgenie: http://hp.termgenie.org
 mailing_list: https://groups.google.com/forum/#!forum/phenotype-ontologies-editors
 browsers:
   - label: HPO


### PR DESCRIPTION
Resolves #1045

I did not run `make` to compile the metadata, but can if needed.