### PR TITLE
Add optional separate aberowl_id for an ontology.

### DIFF
--- a/_layouts/ontology_detail.html
+++ b/_layouts/ontology_detail.html
@@ -53,7 +53,7 @@ layout: default
     </div>
   </div>
   {% endif %}
-  
+
   <div class="col-md-12">
 
     <div class="row">
@@ -62,9 +62,15 @@ layout: default
         <a href="http://www.ontobee.org/browser/index.php?o={{page.id}}">
           <button type="button" class="btn btn-default">OntoBee</button>
         </a>
+        {% if page.aberowl_id %}
+        <a href="http://aber-owl.net/ontology/{{page.aberowl_id | upcase}}">
+          <button type="button" class="btn btn-default">AberOWL</button>
+        </a>
+        {% else %}
         <a href="http://aber-owl.net/ontology/{{page.id | upcase}}">
           <button type="button" class="btn btn-default">AberOWL</button>
         </a>
+        {% endif %}
         <a href="http://www.ebi.ac.uk/ols/ontologies/{{page.id}}">
           <button type="button" class="btn btn-default">OLS</button>
         </a>

--- a/faq/how-do-i-edit-metadata.md
+++ b/faq/how-do-i-edit-metadata.md
@@ -38,7 +38,6 @@ taxon:
   id: NCBITaxon:33208
   label: Metazoa
 domain: cells
-aberowl_id: ab
 tracker: https://code.google.com/p/cell-ontology/issues/list
 termgenie: http://cl.termgenie.org
 mailing_list: https://lists.sourceforge.net/lists/listinfo/obo-cell-type

--- a/faq/how-do-i-edit-metadata.md
+++ b/faq/how-do-i-edit-metadata.md
@@ -38,6 +38,7 @@ taxon:
   id: NCBITaxon:33208
   label: Metazoa
 domain: cells
+aberowl_id: ab
 tracker: https://code.google.com/p/cell-ontology/issues/list
 termgenie: http://cl.termgenie.org
 mailing_list: https://lists.sourceforge.net/lists/listinfo/obo-cell-type

--- a/ontology/ro.md
+++ b/ontology/ro.md
@@ -8,6 +8,7 @@ build:
   method: vcs
   infallible: 1
 canonical: ro.owl
+aberowl_id: relo
 description: Relationship types shared across multiple ontologies
 homepage: https://github.com/oborel/obo-relations/
 documentation: https://github.com/oborel/obo-relations/wiki/ROGuide

--- a/util/schema/aberowl_id.json
+++ b/util/schema/aberowl_id.json
@@ -1,0 +1,8 @@
+{
+	"title": "aberowl_id",
+	"level": "error",
+	"description": "'aberowl_id' is an optional property, used only when AberOWL requires a special exception for this ontology's 'id'.",
+	"properties": {
+		"aberowl_id": { "type": "string", "pattern": "^[0-9a-z_]+$" }
+	}
+}


### PR DESCRIPTION
NOTES: in the case of the Relations Ontology, the OBO id is 'RO' but the AberOWL
id is 'RELO'. Using the OBO id of 'RO' to link to the AberOWL page, sends the
user to the Radiomics Ontology page of AberOWL. This change allows a contributor
to request a particular AberOWL id/redirect link.

Resolves #1053