### PR TITLE
Update gno.md

### DIFF
--- a/ontology/gno.md
+++ b/ontology/gno.md
@@ -22,4 +22,8 @@ license:
   url: https://creativecommons.org/licenses/by/4.0/
   label: CC-BY 4.0
 activity_status: active
+browsers:
+  - label: GNOme
+    title: GNOme Glycan Composition Browser and Subsumption Navigator
+    url: https://raw.githack.com/glygen-glycan-data/GNOme/master/GNOme.browser.html
 ---


### PR DESCRIPTION
Provide link to the GNOme Glycan Composition Browser and Subsumption Navigator as a browser.

Note, the example provides a link with an accession in it, but its not clear whether this is necessary/required as the OBOFoundry user-interface does not appear to provide any way to set this accession for the user. 