### PR TITLE
Fix leading zeros in check titles

### DIFF
--- a/principles/Makefile
+++ b/principles/Makefile
@@ -14,4 +14,4 @@ checks/fp_%.md: ../util/principles/fp_%.py | checks
 	| awk '!found && /import/ { print "```"; found=1 } 1' \
 	> $@
 	echo '```' >> $@
-	echo "---\nlayout: check\nid: $(notdir $(basename $@))\ntitle: $(subst fp_,,$(notdir $(basename $@)))\n---\n$$(cat $@)" > $@
+	echo "---\nlayout: check\nid: $(notdir $(basename $@))\ntitle: $(subst 0,,$(subst fp_,,$(notdir $(basename $@))))\n---\n$$(cat $@)" > $@

--- a/principles/checks/fp_001.md
+++ b/principles/checks/fp_001.md
@@ -1,7 +1,7 @@
 ---
 layout: check
 id: fp_001
-title: 001
+title: 1
 ---
 ## "Open" Automated Check
 

--- a/principles/checks/fp_002.md
+++ b/principles/checks/fp_002.md
@@ -1,7 +1,7 @@
 ---
 layout: check
 id: fp_002
-title: 002
+title: 2
 ---
 ## "Common Format" Automated Check
 

--- a/principles/checks/fp_003.md
+++ b/principles/checks/fp_003.md
@@ -1,7 +1,7 @@
 ---
 layout: check
 id: fp_003
-title: 003
+title: 3
 ---
 ## "URIs" Automated Check
 

--- a/principles/checks/fp_004.md
+++ b/principles/checks/fp_004.md
@@ -1,7 +1,7 @@
 ---
 layout: check
 id: fp_004
-title: 004
+title: 4
 ---
 ## "Versioning" Automated Check
 

--- a/principles/checks/fp_005.md
+++ b/principles/checks/fp_005.md
@@ -1,7 +1,7 @@
 ---
 layout: check
 id: fp_005
-title: 005
+title: 5
 ---
 ## "Scope" Automated Check
 

--- a/principles/checks/fp_006.md
+++ b/principles/checks/fp_006.md
@@ -1,7 +1,7 @@
 ---
 layout: check
 id: fp_006
-title: 006
+title: 6
 ---
 ## "Textual Definitions" Automated Check
 

--- a/principles/checks/fp_007.md
+++ b/principles/checks/fp_007.md
@@ -1,7 +1,7 @@
 ---
 layout: check
 id: fp_007
-title: 007
+title: 7
 ---
 ## "Relations" Automated Check
 

--- a/principles/checks/fp_008.md
+++ b/principles/checks/fp_008.md
@@ -1,7 +1,7 @@
 ---
 layout: check
 id: fp_008
-title: 008
+title: 8
 ---
 ## "Documented" Automated Check
 

--- a/principles/checks/fp_009.md
+++ b/principles/checks/fp_009.md
@@ -1,7 +1,7 @@
 ---
 layout: check
 id: fp_009
-title: 009
+title: 9
 ---
 ## "Plurality of Users" Automated Check
 

--- a/principles/checks/fp_011.md
+++ b/principles/checks/fp_011.md
@@ -1,7 +1,7 @@
 ---
 layout: check
 id: fp_011
-title: 011
+title: 11
 ---
 ## "Locus of Authority" Automated Check
 

--- a/principles/checks/fp_012.md
+++ b/principles/checks/fp_012.md
@@ -1,7 +1,7 @@
 ---
 layout: check
 id: fp_012
-title: 012
+title: 12
 ---
 ## "Naming Conventions" Automated Check
 

--- a/principles/checks/fp_016.md
+++ b/principles/checks/fp_016.md
@@ -1,7 +1,7 @@
 ---
 layout: check
 id: fp_016
-title: 016
+title: 16
 ---
 ## "Maintenance" Automated Check
 


### PR DESCRIPTION
Leading zeros cause weird things to happen to the titles. This removes them.