### PR TITLE
Additional license properties to warn on for principle 1

### DIFF
--- a/principles/checks/fp_001.md
+++ b/principles/checks/fp_001.md
@@ -128,14 +128,14 @@ class OpenValidator():
        annotations = ontology.getAnnotations()
        license = dash_utils.get_ontology_annotation_value(annotations,
                                                           license_prop)
-       bad_license = dash_utils.get_ontology_annotation_value(
-           annotations, bad_license_prop)
+
+       bad_licenses = list(filter(None, [dash_utils.get_ontology_annotation_value(annotations, prop) for prop in bad_license_props]))
 
        if license:
            self.ontology_license = license
            self.correct_property = True
-       elif bad_license:
-           self.ontology_license = bad_license
+       elif len(bad_licenses) > 0:
+           self.ontology_license = bad_licenses[0]
            self.correct_property = False
 
 
@@ -389,10 +389,10 @@ def process_results(registry_license,
    return {'status': level, 'comment': ' '.join(issues)}
 
 
-# correct dc license property namespace
+# correct dc license property
 license_prop = 'http://purl.org/dc/terms/license'
-# incorrect dc license property namespace
-bad_license_prop = 'http://purl.org/dc/elements/1.1/license'
+# incorrect dc license properties
+bad_license_props = ['http://purl.org/dc/elements/1.1/license', 'http://purl.org/dc/elements/1.1/rights', 'http://purl.org/dc/terms/rights']
 
 # license JSON schema for registry validation
 license_schema = dash_utils.load_schema('dependencies/license.json')


### PR DESCRIPTION
I added two additional properties that ontologies may be using for license info. This way we can warn about standardizing rather than stating the ontology doesn't have license info (see discussion in #1019).