### PR TITLE
Update PATO md with usage

### DIFF
--- a/ontology/pato.md
+++ b/ontology/pato.md
@@ -35,7 +35,7 @@ products:
 usages:
  - user: https://hpo.jax.org/app/
    type: annotation
-   description: PATO is used by the Human Phenotype Ontology for logical definitions of phenotypes that facilitate cross-species integration.
+   description: PATO is used by the Human Phenotype Ontology (HPO) for logical definitions of phenotypes that facilitate cross-species integration.
    examples:
     - url: https://www.ebi.ac.uk/ols/ontologies/hp/terms?iri=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FHP_0011017&viewMode=All&siblings=false
    reference: https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6324074/


### PR DESCRIPTION
I accidentally commited to master the first time around, please look at the whole usage blob when reviewing this.

```
usages:
 - user: https://hpo.jax.org/app/
   type: annotation
   description: PATO is used by the Human Phenotype Ontology (HPO) for logical definitions of phenotypes that facilitate cross-species integration.
   examples:
    - url: https://www.ebi.ac.uk/ols/ontologies/hp/terms?iri=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FHP_0011017&viewMode=All&siblings=false
   reference: https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6324074/
```