### PR TITLE
Update obi.md

### DIFF
--- a/ontology/obi.md
+++ b/ontology/obi.md
@@ -12,8 +12,8 @@ contact:
   label: Bjoern Peters
   email: bpeters@lji.org
 license:
-  url: https://creativecommons.org/licenses/by/3.0/
-  label: CC-BY 3.0
+  url: https://creativecommons.org/licenses/by/4.0/
+  label: CC-BY 4.0
 depicted_by: https://svn.code.sf.net/p/obi/code/trunk/web/htdocs/images/obi-lotext.png
 build:
   source_url: http://purl.obofoundry.org/obo/obi/repository/trunk/src/ontology/branches/


### PR DESCRIPTION
Updated the version of the license from CC-by 3.0 to CC-by 4.0, as discussed on the OBI call 3/9/2020. This brings the license version in the registry and the OWL file in alignment, and should thus fix an error reported in the OBO dashboard.