### PR TITLE
Create cido.md

### DIFF
--- a/ontology/cido.md
+++ b/ontology/cido.md
@@ -1,0 +1,20 @@
+---
+layout: ontology_detail
+id: cido
+title: Coronavirus Infectious Disease Ontology
+description: The Coronavirus Infectious Disease Ontology (CIDO) aims to ontologically represent and standardize various aspects of coronavirus infectious diseases, including their etiology, transmission, epidemiology, pathogenesis, diagnosis, prevention, and treatment.
+homepage: https://github.com/cido-ontology/cido
+mailing_list: cido-discuss@googlegroups.com 
+tracker: https://github.com/cido-ontology/cido/issues
+contact:
+  email: yongqunh@med.umich.edu
+  label: Yongqun Oliver He
+products:
+  - id: cido.owl
+license:
+  url: http://creativecommons.org/licenses/by/4.0/
+  label: CC-BY
+activity_status: active
+---
+
+The Ontology of Coronavirus Infectious Disease (CIDO) is a community-driven open-source biomedical ontology in the area of coronavirus infectious disease. The CIDO is developed to provide standardized human- and computer-interpretable annotation and representation of various coronavirus infectious diseases, including their etiology, transmission, epidemiology, pathogenesis, diagnosis, prevention, and treatment. Its development follows the OBO Foundry Principles.


### PR DESCRIPTION
The CIDO ontology has been posted to obo-discuss email list for discussion for over 2 weeks and has been agreed from the discussion that this is a timely ontology to study coronavirus diseases including COVID-19. A note of change is that we transferred the CIDO github organization location from github.com/biomedontology to the newly generated https://github.com/CIDO-ontology organization. Such a transfer is to better support its organization with more options (such as generating new repositories).