### PR TITLE
fix broken link on CompletedReviews page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -6454,45 +6454,45 @@ ontologies:
     label: Zea
   title: Maize gross anatomy
 principles:
-- id: fp-004-versioning
+- id: fp-000-summary
   layout: principle
-  title: Versioning (principle 4)
+  title: Overview
+- id: fp-001-open
+  layout: principle
+  title: Open (principle 1)
 - id: fp-002-format
   layout: principle
   title: Common Format (principle 2)
 - id: fp-003-uris
   layout: principle
   title: URI/Identifier Space (principle 3)
-- id: fp-000-summary
+- id: fp-004-versioning
   layout: principle
-  title: Overview
-- id: fp-012-naming-conventions
-  layout: principle
-  title: Naming Conventions (principle 12)
-- id: fp-006-textual-definitions
-  layout: principle
-  title: Textual Definitions (principle 6)
-- id: fp-009-users
-  layout: principle
-  title: Documented Plurality of Users (principle 9)
-- id: fp-001-open
-  layout: principle
-  title: Open (principle 1)
-- id: fp-010-collaboration
-  layout: principle
-  title: Commitment To Collaboration (principle 10)
-- id: fp-016-maintenance
-  layout: principle
-  title: Maintenance (principle 16)
+  title: Versioning (principle 4)
 - id: fp-005-delineated-content
   layout: principle
   title: Scope (principle 5)
+- id: fp-006-textual-definitions
+  layout: principle
+  title: Textual Definitions (principle 6)
 - id: fp-007-relations
   layout: principle
   title: Relations (principle 7)
-- id: fp-011-locus-of-authority
-  layout: principle
-  title: Locus of Authority (principle 11)
 - id: fp-008-documented
   layout: principle
   title: Documentation (principle 8)
+- id: fp-009-users
+  layout: principle
+  title: Documented Plurality of Users (principle 9)
+- id: fp-010-collaboration
+  layout: principle
+  title: Commitment To Collaboration (principle 10)
+- id: fp-011-locus-of-authority
+  layout: principle
+  title: Locus of Authority (principle 11)
+- id: fp-012-naming-conventions
+  layout: principle
+  title: Naming Conventions (principle 12)
+- id: fp-016-maintenance
+  layout: principle
+  title: Maintenance (principle 16)

--- a/_includes/review_table.html
+++ b/_includes/review_table.html
@@ -9,7 +9,7 @@
 		  {% if ont.review %}
 		  <tr>
 				<td class="tg-yp4a">
-					<a href="ontology/{{ ont.id }}.html">{{ont.title}}</a>
+					<a href="../ontology/{{ ont.id }}.html">{{ont.title}}</a>
 				</td>
 				<td class="tg-yp4a">
 					{% if ont.review %}

--- a/principles/all.yml
+++ b/principles/all.yml
@@ -1,43 +1,43 @@
 principles:
-- id: fp-004-versioning
+- id: fp-000-summary
   layout: principle
-  title: Versioning (principle 4)
+  title: Overview
+- id: fp-001-open
+  layout: principle
+  title: Open (principle 1)
 - id: fp-002-format
   layout: principle
   title: Common Format (principle 2)
 - id: fp-003-uris
   layout: principle
   title: URI/Identifier Space (principle 3)
-- id: fp-000-summary
+- id: fp-004-versioning
   layout: principle
-  title: Overview
-- id: fp-012-naming-conventions
-  layout: principle
-  title: Naming Conventions (principle 12)
-- id: fp-006-textual-definitions
-  layout: principle
-  title: Textual Definitions (principle 6)
-- id: fp-009-users
-  layout: principle
-  title: Documented Plurality of Users (principle 9)
-- id: fp-001-open
-  layout: principle
-  title: Open (principle 1)
-- id: fp-010-collaboration
-  layout: principle
-  title: Commitment To Collaboration (principle 10)
-- id: fp-016-maintenance
-  layout: principle
-  title: Maintenance (principle 16)
+  title: Versioning (principle 4)
 - id: fp-005-delineated-content
   layout: principle
   title: Scope (principle 5)
+- id: fp-006-textual-definitions
+  layout: principle
+  title: Textual Definitions (principle 6)
 - id: fp-007-relations
   layout: principle
   title: Relations (principle 7)
-- id: fp-011-locus-of-authority
-  layout: principle
-  title: Locus of Authority (principle 11)
 - id: fp-008-documented
   layout: principle
   title: Documentation (principle 8)
+- id: fp-009-users
+  layout: principle
+  title: Documented Plurality of Users (principle 9)
+- id: fp-010-collaboration
+  layout: principle
+  title: Commitment To Collaboration (principle 10)
+- id: fp-011-locus-of-authority
+  layout: principle
+  title: Locus of Authority (principle 11)
+- id: fp-012-naming-conventions
+  layout: principle
+  title: Naming Conventions (principle 12)
+- id: fp-016-maintenance
+  layout: principle
+  title: Maintenance (principle 16)


### PR DESCRIPTION
The ontology links on the CompletedReviews page were broken due to a coding error in `_includes/review_table.html`.