### PR TITLE
Fix reversed email/label in obsolete ontologies

### DIFF
--- a/ontology/gro.md
+++ b/ontology/gro.md
@@ -3,8 +3,8 @@ layout: ontology_detail
 id: gro
 title: Cereal Plant Gross Anatomy
 contact:
-  email: Plant Ontology Administrators
-  label: po-discuss@plantontology.org
+  email: po-discuss@plantontology.org
+  label: Plant Ontology Administrators
 homepage: http://www.gramene.org/plant_ontology/
 is_obsolete: true
 activity_status: inactive

--- a/ontology/habronattus.md
+++ b/ontology/habronattus.md
@@ -3,8 +3,8 @@ layout: ontology_detail
 id: habronattus
 title: Habronattus courtship
 contact:
-  email: Peter Midford
-  label: peteremidford@yahoo.com
+  email: peteremidford@yahoo.com
+  label: Peter Midford
 homepage: http://www.mesquiteproject.org/ontology/Habronattus/index.html
 is_obsolete: true
 activity_status: inactive

--- a/ontology/imr.md
+++ b/ontology/imr.md
@@ -3,8 +3,8 @@ layout: ontology_detail
 id: imr
 title: Molecule role (INOH Protein name/family name ontology)
 contact:
-  email: INOH curators
-  label: curator@inoh.org
+  email: curator@inoh.org
+  label: INOH curators
 homepage: http://www.inoh.org
 is_obsolete: true
 build:

--- a/ontology/ipr.md
+++ b/ontology/ipr.md
@@ -3,8 +3,8 @@ layout: ontology_detail
 id: ipr
 title: Protein Domains
 contact:
-  email: InterPro Help
-  label: interhelp@ebi.ac.uk
+  email: interhelp@ebi.ac.uk
+  label: InterPro Help
 homepage: http://www.ebi.ac.uk/interpro/index.html
 is_obsolete: true
 activity_status: inactive

--- a/ontology/loggerhead.md
+++ b/ontology/loggerhead.md
@@ -3,8 +3,8 @@ layout: ontology_detail
 id: loggerhead
 title: Loggerhead nesting
 contact:
-  email: Peter Midford
-  label: peteremidford@yahoo.com
+  email: peteremidford@yahoo.com
+  label: Peter Midford
 homepage: http://www.mesquiteproject.org/ontology/Loggerhead/index.html
 is_obsolete: true
 activity_status: inactive

--- a/ontology/mao.md
+++ b/ontology/mao.md
@@ -3,8 +3,8 @@ layout: ontology_detail
 id: mao
 title: Multiple alignment
 contact:
-  email: Julie Thompson
-  label: julie@igbmc.u-strasbg.fr
+  email: julie@igbmc.u-strasbg.fr
+  label: Julie Thompson
 homepage: http://www-igbmc.u-strasbg.fr/BioInfo/MAO/mao.html
 is_obsolete: true
 activity_status: inactive

--- a/ontology/mat.md
+++ b/ontology/mat.md
@@ -3,8 +3,8 @@ layout: ontology_detail
 id: mat
 title: Minimal anatomical terminology
 contact:
-  email: Jonathan Bard
-  label: j.bard@ed.ac.uk
+  email: j.bard@ed.ac.uk
+  label: Jonathan Bard
 homepage: 
 is_obsolete: true
 activity_status: inactive

--- a/ontology/nif_cell.md
+++ b/ontology/nif_cell.md
@@ -4,8 +4,8 @@ id: nif_cell
 title: NIF Cell
 description: Neuronal cell types
 contact:
-  email: Fahim Imam
-  label: smtifahim@gmail.com
+  email: smtifahim@gmail.com
+  label: Fahim Imam
 homepage: http://neuinfo.org/
 is_obsolete: true
 replaced_by: cl

--- a/ontology/nif_dysfunction.md
+++ b/ontology/nif_dysfunction.md
@@ -3,8 +3,8 @@ layout: ontology_detail
 id: nif_dysfunction
 title: NIF Dysfunction
 contact:
-  email: Fahim Imam
-  label: smtifahim@gmail.com
+  email: smtifahim@gmail.com
+  label: Fahim Imam
 homepage: http://neuinfo.org/
 is_obsolete: true
 replaced_by: doid

--- a/ontology/nif_grossanatomy.md
+++ b/ontology/nif_grossanatomy.md
@@ -3,8 +3,8 @@ layout: ontology_detail
 id: nif_grossanatomy
 title: NIF Gross Anatomy
 contact:
-  email: Fahim Imam
-  label: smtifahim@gmail.com
+  email: smtifahim@gmail.com
+  label: Fahim Imam
 homepage: http://neuinfo.org/
 is_obsolete: true
 replaced_by: uberon

--- a/ontology/obo_rel.md
+++ b/ontology/obo_rel.md
@@ -3,8 +3,8 @@ layout: ontology_detail
 id: obo_rel
 title: OBO relationship types (legacy)
 contact:
-  email: Chris Mungall
-  label: cjmungall@lbl.gov
+  email: cjmungall@lbl.gov
+  label: Chris Mungall
 homepage: http://www.obofoundry.org/ro
 is_obsolete: true
 replaced_by: ro

--- a/ontology/pao.md
+++ b/ontology/pao.md
@@ -3,8 +3,8 @@ layout: ontology_detail
 id: pao
 title: Plant Anatomy Ontology
 contact:
-  email: Pankaj Jaiswal
-  label: jaiswalp@science.oregonstate.edu
+  email: jaiswalp@science.oregonstate.edu
+  label: Pankaj Jaiswal
 taxon:
   id: NCBITaxon:33090
   label: Viridiplantae

--- a/ontology/pd_st.md
+++ b/ontology/pd_st.md
@@ -3,8 +3,8 @@ layout: ontology_detail
 id: pd_st
 title: Platynereis stage ontology
 contact:
-  email: Thorsten Heinrich
-  label: henrich@embl.de
+  email: henrich@embl.de
+  label: Thorsten Heinrich
 taxon:
   id: NCBITaxon:6358
   label: Platynereis

--- a/ontology/pgdso.md
+++ b/ontology/pgdso.md
@@ -3,8 +3,8 @@ layout: ontology_detail
 id: pgdso
 title: Plant Growth and Development Stage
 contact:
-  email: Plant Ontology Administrators 
-  label: po-discuss@plantontology.org
+  email: po-discuss@plantontology.org
+  label: Plant Ontology Administrators 
 taxon:
   id: NCBITaxon:33090
   label: Viridiplantae

--- a/ontology/plo.md
+++ b/ontology/plo.md
@@ -3,8 +3,8 @@ layout: ontology_detail
 id: plo
 title: Plasmodium life cycle
 contact:
-  email: Matt Berriman
-  label: mb4@sanger.ac.uk
+  email: mb4@sanger.ac.uk
+  label: Matt Berriman
 homepage: http://www.sanger.ac.uk/Users/mb4/PLO/
 is_obsolete: true
 activity_status: inactive

--- a/ontology/propreo.md
+++ b/ontology/propreo.md
@@ -3,8 +3,8 @@ layout: ontology_detail
 id: propreo
 title: Proteomics data and process provenance
 contact:
-  email: Satya S. Sahoo
-  label: satya30@uga.edu
+  email: satya30@uga.edu
+  label: Satya S. Sahoo
 homepage: http://lsdis.cs.uga.edu/projects/glycomics/propreo/
 is_obsolete: true
 activity_status: inactive

--- a/ontology/sao.md
+++ b/ontology/sao.md
@@ -3,8 +3,8 @@ layout: ontology_detail
 id: sao
 title: Subcellular anatomy ontology
 contact:
-  email: Stephen Larson
-  label: slarson@ncmir.ucsd.edu
+  email: slarson@ncmir.ucsd.edu
+  label: Stephen Larson
 taxon:
   id: NCBITaxon:9606
   label: Homo sapiens

--- a/ontology/sopharm.md
+++ b/ontology/sopharm.md
@@ -3,8 +3,8 @@ layout: ontology_detail
 id: sopharm
 title: Suggested Ontology for Pharmacogenomics
 contact:
-  email: Adrien Coulet
-  label: Adrien.Coulet@loria.fr
+  email: Adrien.Coulet@loria.fr
+  label: Adrien Coulet
 taxon:
   id: NCBITaxon:9606
   label: Homo sapiens

--- a/ontology/tahe.md
+++ b/ontology/tahe.md
@@ -3,8 +3,8 @@ layout: ontology_detail
 id: tahe
 title: Terminology of Anatomy of Human Embryology
 contact:
-  email: Pierre Sprumont
-  label: pierre.sprumont@unifr.ch
+  email: pierre.sprumont@unifr.ch
+  label: Pierre Sprumont
 taxon:
   id: NCBITaxon:9606
   label: Homo sapiens

--- a/ontology/tahh.md
+++ b/ontology/tahh.md
@@ -3,8 +3,8 @@ layout: ontology_detail
 id: tahh
 title: Terminology of Anatomy of Human Histology
 contact:
-  email: Pierre Sprumont
-  label: pierre.sprumont@unifr.ch
+  email: pierre.sprumont@unifr.ch
+  label: Pierre Sprumont
 taxon:
   id: NCBITaxon:9606
   label: Homo sapiens

--- a/ontology/ypo.md
+++ b/ontology/ypo.md
@@ -3,8 +3,8 @@ layout: ontology_detail
 id: ypo
 title: Yeast phenotypes
 contact:
-  email: Mike Cherry
-  label: cherry@genome.stanford.edu
+  email: cherry@genome.stanford.edu
+  label: Mike Cherry
 taxon:
   id: NCBITaxon:4932
   label: Saccharomyces cerevisiae

--- a/ontology/zea.md
+++ b/ontology/zea.md
@@ -3,8 +3,8 @@ layout: ontology_detail
 id: zea
 title: Maize gross anatomy
 contact:
-  email: Leszek Vincent
-  label: Leszek@missouri.edu
+  email: Leszek@missouri.edu
+  label: Leszek Vincent
 taxon:
   id: NCBITaxon:4575
   label: Zea


### PR DESCRIPTION
When working on the validations, I noticed that several ontologies (all of them obsolete) had their emails and labels (names) reversed in their metadata files. Although these are obsolete, they are still visible in the table on http://obofoundry.org/, with email links that don't work. 

This patch reverses the values, so that the email addresses are in the correct field. 