### PR TITLE
Removed out of date info on license

### DIFF
--- a/ontology/obi.md
+++ b/ontology/obi.md
@@ -60,4 +60,4 @@ The Ontology for Biomedical Investigations (OBI) project is developing an integr
 - [OBI mailing list](http://groups.google.com/group/obi-users)
 - To cite a journal article for OBI please use [Bandrowski et al, PLOS ONE, 2016](https://journals.plos.org/plosone/article?id=10.1371/journal.pone.0154556)
 - To refer to the most current information on the OBI project, please use the following: The OBI Consortium [http://purl.obolibrary.org/obo/obi](http://purl.obolibrary.org/obo/obi)
-- To use OBI, remember the licensing terms: OBI is released under [CC-by 3.0 Unported License](http://creativecommons.org/licenses/by/3.0/)
+


### PR DESCRIPTION
this was inconsistent with the license declared in the metadata

I chose to remove it altogether since it's already shown on the navbar but feel free to close/edit and replace with a PR where it is in sync

Also IMHO the text "To use OBI, remember the licensing terms" should be more welcoming in the open OBO spirit but YMMV