### PR TITLE
CTO: Core Ontology of Clinical Trials metadata file

### DIFF
--- a/ontology/cto.md
+++ b/ontology/cto.md
@@ -8,6 +8,7 @@ tracker: https://github.com/ClinicalTrialOntology/CTO/issues
 contact:
   email: alpha.tom.kodamullil@scai.fraunhofer.de
   label: Dr. Alpha Tom Kodamullil
+  github: akodamullil
 products:
   - id: cto.owl
 license:

--- a/ontology/cto.md
+++ b/ontology/cto.md
@@ -1,7 +1,7 @@
 ---
 layout: ontology_detail
 id: cto
-title: CTO: Core Ontology of Clinical Trials
+title: "CTO: Core Ontology of Clinical Trials"
 description: The core Ontology of Clinical Trials (CTO) will serve as a structured resource integrating basic terms and concepts in the context of clinical trials. Thereby covering clinicaltrails.gov. CoreCTO will serve as a basic ontology to generate extended versions for specific applications such as annotation of variables in study documents from clinical trials.
 homepage: https://github.com/ClinicalTrialOntology/CTO/
 tracker: https://github.com/ClinicalTrialOntology/CTO/issues

--- a/ontology/cto.md
+++ b/ontology/cto.md
@@ -1,0 +1,19 @@
+---
+layout: ontology_detail
+id: cto
+title: CTO: Core Ontology of Clinical Trials
+description: The core Ontology of Clinical Trials (CTO) will serve as a structured resource integrating basic terms and concepts in the context of clinical trials. Thereby covering clinicaltrails.gov. CoreCTO will serve as a basic ontology to generate extended versions for specific applications such as annotation of variables in study documents from clinical trials.
+homepage: https://github.com/ClinicalTrialOntology/CTO/
+tracker: https://github.com/ClinicalTrialOntology/CTO/issues
+contact:
+  email: alpha.tom.kodamullil@scai.fraunhofer.de
+  label: Dr. Alpha Tom Kodamullil
+products:
+  - id: cto.owl
+license:
+  url: http://creativecommons.org/licenses/by/4.0/
+  label: CC-BY
+activity_status: active
+---
+
+The core Ontology of Clinical Trials (CTO) will serve as a structured resource integrating basic terms and concepts in the context of clinical trials. Thereby covering clinicaltrails.gov. CoreCTO will serve as a basic ontology to generate extended versions for specific applications such as annotation of variables in study documents from clinical trials.


### PR DESCRIPTION
Adds the metadata file for  CTO: Core Ontology of Clinical Trials (https://github.com/OBOFoundry/OBOFoundry.github.io/issues/1220)