### PR TITLE
Removed link to out-of-date Setting Up Protege page

### DIFF
--- a/docs/TableOfContents.md
+++ b/docs/TableOfContents.md
@@ -25,4 +25,4 @@ Operations committee
 
   * [PURL requests](/docs/Policy_for_OBO_namespace_and_associated_PURL_requests.html)
   * [OBO PURL configuration](/docs/OBOPURLDomain.html)
-  * [Setting up Protege 4.3](/docs/SettingUpProtege.html)
+  * [Ontology tools and resources](/resources)


### PR DESCRIPTION
replaced with link to /resources
This partially addresses #476