### PR TITLE
Update context map generation in processor.py

### DIFF
--- a/util/processor.py
+++ b/util/processor.py
@@ -92,8 +92,9 @@ def extract_context(ontologies, args):
   prefix_map = {}
   for obj in ontologies:
     if has_obo_prefix(obj):
+      oid = obj['id'].upper()
       prefix = obj.get('preferredPrefix') or obj['id'].upper()
-      prefix_map[prefix] = "http://purl.obolibrary.org/obo/" + prefix + "_"
+      prefix_map[oid] = "http://purl.obolibrary.org/obo/" + prefix + "_"
 
   print(dumps({'@context': prefix_map}, sort_keys=True, indent=4, separators=(',', ': ')))
 


### PR DESCRIPTION
Without this, entires like DPO will never make it into the context map, if the preferred prefix is shared with another ontology:

https://github.com/OBOFoundry/OBOFoundry.github.io/blob/master/ontology/dpo.md

This kind of change could be huge - I don't know now how to evaluate/test it.