### PR TITLE
mostly converted unlinked URLs to text with hyperlinks

### DIFF
--- a/docs/NewOntologyRegistrationInstructions.md
+++ b/docs/NewOntologyRegistrationInstructions.md
@@ -18,31 +18,31 @@ Please review the [OBO Foundry Principles](http://obofoundry.org/principles/fp-0
 Concise title of your ontology (e.g, "Gene Ontology")
 
 ## Requested ID space
-Prefix of ontology in lowercase (e.g., go, uberon, chebi, cl). The OBO Foundry ID policy is described at http://obofoundry.org/id-policy.html. Specifically, please see the guidelines for [allocating IDSPACEs](http://obofoundry.org/id-policy.html#allocating-idspaces).
+Prefix of ontology in lowercase (e.g., bfo, uberon, chebi, pato). The OBO Foundry ID policy is described [here](http://obofoundry.org/id-policy.html). Specifically, please see the guidelines for [allocating IDSPACEs](http://obofoundry.org/id-policy.html#allocating-idspaces). Note that ontology prefixes should have at least 4 letters, though you will see older ontologies with 2 or 3-letter prefixes.
 
 ## Ontology location
 Home page or URL of ontology. This can be a GitHub URL.
 
 ## Contact person
-Name, email address, and GitHub username of contact person. The OBO Foundry policy on contact person is described at http://obofoundry.org/principles/fp-011-locus-of-authority.html.
+Name, email address, and GitHub username of contact person. The OBO Foundry policy on contact person is described [here](http://obofoundry.org/principles/fp-011-locus-of-authority.html).
 
 ## Issue tracker
 URL for submitting and responding to suggestions, requests, etc. (e.g., https://github.com/geneontology/go-ontology/issues/).
 
 ## Ontology license
-Current license. Note that the OBO Foundry accepts CC0 or CC-BY. The OBO Foundry license policy is described at http://www.obofoundry.org/principles/fp-001-open.html.
+Current license. Note that the OBO Foundry accepts CC0 or CC-BY. The OBO Foundry license policy is described in [Principle 1, Open Licensing](http://www.obofoundry.org/principles/fp-001-open.html).
 
 ## Available ontology formats
-Note that OWL-RDF/XML is the only required format. The OBO Foundry format policy is described at http://obofoundry.org/principles/fp-002-format.html.
+Note that OWL-RDF/XML is the only required format. The OBO Foundry format policy is described in [Principle 2](http://obofoundry.org/principles/fp-002-format.html).
 
 ## What domain is the ontology intended to cover?
-For example, the GO covers the processes, functions and cellular locations of gene products. The OBO Foundry policy on scope of an ontology is described at http://obofoundry.org/principles/fp-005-delineated-content.html.
+For example, the GO covers the processes, functions and cellular locations of gene products. The OBO Foundry policy on scope of an ontology is described in [Principle 5](http://obofoundry.org/principles/fp-005-delineated-content.html).
 
 ## Related OBO Foundry ontologies
-What other ontologies are you aware of that intersect with your domain, and what are your plans for collaborating with them? The OBO Foundry policy on collaboration is described at http://obofoundry.org/principles/fp-010-collaboration.html.
+What other ontologies are you aware of that intersect with your domain, and what are your plans for collaborating with them? The OBO Foundry policy on collaboration is described in [Principle 10, Collaboration](http://obofoundry.org/principles/fp-010-collaboration.html).
 
 ## Intended use/related projects
-Is your ontology serving the need of one or more specific projects? If so, please describe them. The OBO Foundry policy on documented users is described at http://obofoundry.org/principles/fp-009-users.html.
+Is your ontology serving the need of one or more specific projects? If so, please describe them. The OBO Foundry policy on documented users is described in [Principle 9](http://obofoundry.org/principles/fp-009-users.html).
 
 ## Data source
 Which resources, if any, were used to generate the ontology? E.g., NCBITaxon was created from the NCBI taxonomy resource; the Protein Ontology uses, in part, UniProtKB.


### PR DESCRIPTION
also added note about how ontology prefixes should have 4+ letters. if this is too in the weeds for this page, we don't have to add it here.