### PR TITLE
Update mod.md to direct to the correct PURL

### DIFF
--- a/ontology/mod.md
+++ b/ontology/mod.md
@@ -15,7 +15,7 @@ products:
   - id: mod.owl
 title: Protein modification
 build:
-  source_url: https://raw.githubusercontent.com/MICommunity/psidev/master/psi/mod/data/PSI-MOD.obo
+  source_url: https://raw.githubusercontent.com/HUPO-PSI/psi-mod-CV/master/PSI-MOD.obo
   insert_ontology_id: true
   method: obo2owl
 activity_status: active


### PR DESCRIPTION
The PURL for PSI-MOD ontology is incorrect.  This new link directs to the correct version.