### PR TITLE
Changed Python 3.4 to 3.6 in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 python:
-  - "3.4"
+  - "3.6"
 
 # command to install dependencies
 install:


### PR DESCRIPTION
Changed in order to use newer libraries for `yamllint` package from issue #1382, PR #1384 