### PR TITLE
Fix reversed contact email and contact label for several ontology pages

### DIFF
--- a/ontology/aao.md
+++ b/ontology/aao.md
@@ -3,8 +3,8 @@ layout: ontology_detail
 id: aao
 title: Amphibian gross anatomy
 contact:
-  email: David Blackburn
-  label: david.c.blackburn@gmail.com
+  email: david.c.blackburn@gmail.com
+  label: David Blackburn
 taxon:
   id: NCBITaxon:8292
   label: Amphibia

--- a/ontology/adw.md
+++ b/ontology/adw.md
@@ -3,8 +3,8 @@ layout: ontology_detail
 id: adw
 title: Animal natural history and life history
 contact:
-  email: Animal Diversity Web technical staff
-  label: adw_geeks@umich.edu
+  email: adw_geeks@umich.edu
+  label: Animal Diversity Web technical staff
 homepage: http://www.animaldiversity.org
 is_obsolete: true
 activity_status: inactive

--- a/ontology/ehda.md
+++ b/ontology/ehda.md
@@ -3,8 +3,8 @@ layout: ontology_detail
 id: ehda
 title: Human developmental anatomy, timed version
 contact:
-  email: Jonathan Bard
-  label: J.Bard@ed.ac.uk
+  email: J.Bard@ed.ac.uk
+  label: Jonathan Bard
 taxon:
   id: NCBITaxon:9606
   label: Homo sapiens

--- a/ontology/ehdaa.md
+++ b/ontology/ehdaa.md
@@ -3,8 +3,8 @@ layout: ontology_detail
 id: ehdaa
 title: Human developmental anatomy, abstract version
 contact:
-  email: Jonathan Bard
-  label: J.Bard@ed.ac.uk
+  email: J.Bard@ed.ac.uk
+  label: Jonathan Bard
 taxon:
   id: NCBITaxon:9606
   label: Homo sapiens

--- a/ontology/ev.md
+++ b/ontology/ev.md
@@ -3,8 +3,8 @@ layout: ontology_detail
 id: ev
 title: eVOC (Expressed Sequence Annotation for Humans)
 contact:
-  email: eVOC mailing list
-  label: evoc@sanbi.ac.za
+  email: evoc@sanbi.ac.za
+  label: eVOC mailing list
 homepage: http://www.evocontology.org/
 is_obsolete: true
 activity_status: inactive


### PR DESCRIPTION
This PR addresses the issue where the `contact.label` and `contact.email` field were swapped for five ontologies: `aao`, `adw`, `ehda`, `ehdaa`, and `ev`.

I'm aware these were marked as deprecated/inactive, but it's still an issue with anyone trying to automatically consume content from OBO Foundry. I'm not sure the best way to update the other artifacts based on this. @matentzn are you the boss here?

