### PR TITLE
Fix email metadata

### DIFF
--- a/ontology/ato.md
+++ b/ontology/ato.md
@@ -3,8 +3,8 @@ layout: ontology_detail
 id: ato
 title: Amphibian taxonomy
 contact:
-  email: David Blackburn
-  label: david.c.blackburn@gmail.com
+  email: david.c.blackburn@gmail.com
+  label: David Blackburn
 taxon:
   id: NCBITaxon:8292
   label: Amphibia

--- a/ontology/bootstrep.md
+++ b/ontology/bootstrep.md
@@ -3,8 +3,8 @@ layout: ontology_detail
 id: bootstrep
 title: Gene Regulation Ontology
 contact:
-  email: Vivian Lee
-  label: vlee@ebi.ac.uk
+  email: vlee@ebi.ac.uk
+  label: Vivian Lee
 homepage: http://www.ebi.ac.uk/Rebholz-srv/GRO/GRO.html
 is_obsolete: true
 replaced_by: molecular_function

--- a/ontology/dc_cl.md
+++ b/ontology/dc_cl.md
@@ -3,8 +3,8 @@ layout: ontology_detail
 id: dc_cl
 title: Dendritic cell
 contact:
-  email: Lindsay Cowell
-  label: Lindsay.Cowell@utsouthwestern.edu
+  email: Lindsay.Cowell@utsouthwestern.edu
+  label: Lindsay Cowell
 taxon:
   id: all
   label:


### PR DESCRIPTION
This PR fixes the email metadata on ATO, DC_CL, and BOOTSTREP. They're all deprecated, but it's still a problem for anyone automatically consuming the registry.