### PR TITLE
Unobscure issue trackers

### DIFF
--- a/ontology/fbbt.md
+++ b/ontology/fbbt.md
@@ -25,7 +25,7 @@ build:
   checkout: git clone https://github.com/FlyBase/drosophila-anatomy-developmental-ontology.git
   system: git
   path: "."
-tracker: http://purl.obolibrary.org/obo/fbbt/tracker
+tracker: https://github.com/FlyBase/drosophila-anatomy-developmental-ontology/issues
 browsers:
   - label: FB
     title: FlyBase Browser

--- a/ontology/fbdv.md
+++ b/ontology/fbdv.md
@@ -25,7 +25,7 @@ build:
   checkout: git clone https://github.com/FlyBase/drosophila-developmental-ontology.git
   system: git
   path: "."
-tracker: http://purl.obolibrary.org/obo/fbdv/tracker
+tracker: https://github.com/FlyBase/drosophila-developmental-ontology/issues
 browsers:
   - label: FB
     title: FlyBase Browser

--- a/ontology/obi.md
+++ b/ontology/obi.md
@@ -12,7 +12,7 @@ description: An integrated ontology for the description of life-science and clin
 domain: experiments
 homepage: http://obi-ontology.org
 mailing_list: http://groups.google.com/group/obi-users
-tracker: http://purl.obolibrary.org/obo/obi/tracker
+tracker: https://github.com/obi-ontology/obi/issues
 contact:
   label: Bjoern Peters
   email: bpeters@lji.org


### PR DESCRIPTION
Some issue trackers have been obscured by PURLs. Since there isn't any direct way to identify if an ontology is hosted on GitHub, this is a bit of a problem for automatically interacting with the trackers. This PR unobscures some of these PURLs and replaces them with full GitHub links.

This affects OBI, FBbt, and FBdv. It also should affect [OHD](http://www.obofoundry.org/ontology/ohd.html), but I was unable to follow [its tracker's PURL](https://purl.obolibrary.org/obo/ohd/issues) either because the PURL service is down (I experience this quite often) or it points to a dead link.

The only inactive ontology that had this issue was the Influenza Ontology, but it links to [this SourceForge](https://sourceforge.net/p/influenzo/support-requests/) so I can safely assume it's abandoned.