### PR TITLE
Add missing preferred prefix annotation for VariO

### DIFF
--- a/ontology/vario.md
+++ b/ontology/vario.md
@@ -1,6 +1,7 @@
 ---
 layout: ontology_detail
 id: vario
+preferredPrefix: VariO
 description: Variation Ontology, VariO, is an ontology for standardized, systematic description of effects, consequences and mechanisms of variations.
 homepage: http://variationontology.org
 products:


### PR DESCRIPTION
Following the style of FBbt and related, this PR adds the lexical variant of VariO as the "preferred prefix" to the ontology metadata.