### PR TITLE
Standardize license labels and update registry schema

### DIFF
--- a/ontology/aeo.md
+++ b/ontology/aeo.md
@@ -6,7 +6,7 @@ contact:
   label: Jonathan Bard
 license:
   url: https://creativecommons.org/licenses/by/4.0/
-  label: CC-BY 4.0
+  label: CC BY 4.0
 description: AEO is an ontology of anatomical structures that expands CARO, the Common Anatomy Reference Ontology
 domain: anatomy
 homepage: https://github.com/obophenotype/human-developmental-anatomy-ontology/

--- a/ontology/aero.md
+++ b/ontology/aero.md
@@ -7,7 +7,7 @@ contact:
 description: The Adverse Event Reporting Ontology (AERO) is an ontology aimed at supporting clinicians at the time of data entry, increasing quality and accuracy of reported adverse events
 license:
   url: http://creativecommons.org/licenses/by/3.0/
-  label: CC-BY
+  label: CC BY 3.0
 domain: health
 homepage: http://purl.obolibrary.org/obo/aero
 is_obsolete: true

--- a/ontology/agro.md
+++ b/ontology/agro.md
@@ -4,7 +4,7 @@ id: agro
 title: Agronomy Ontology
 license:
   url: https://creativecommons.org/licenses/by/4.0/
-  label: CC-BY 4.0
+  label: CC BY 4.0
 domain: agronomy
 build:
   checkout: git clone  https://github.com/AgriculturalSemantics/agro.git

--- a/ontology/aism.md
+++ b/ontology/aism.md
@@ -26,7 +26,7 @@ dependencies:
 tracker: https://github.com/insect-morphology/aism/issues
 license:
   url: https://creativecommons.org/licenses/by/4.0/
-  label: CC-BY 3.0
+  label: CC-BY 4.0
 activity_status: active
 repository: https://github.com/insect-morphology/aism
 preferredPrefix: AISM

--- a/ontology/aism.md
+++ b/ontology/aism.md
@@ -26,7 +26,7 @@ dependencies:
 tracker: https://github.com/insect-morphology/aism/issues
 license:
   url: https://creativecommons.org/licenses/by/4.0/
-  label: CC-BY 4.0
+  label: CC BY 4.0
 activity_status: active
 repository: https://github.com/insect-morphology/aism
 preferredPrefix: AISM

--- a/ontology/aism.md
+++ b/ontology/aism.md
@@ -26,7 +26,7 @@ dependencies:
 tracker: https://github.com/insect-morphology/aism/issues
 license:
   url: https://creativecommons.org/licenses/by/4.0/
-  label: CC-BY
+  label: CC-BY 3.0
 activity_status: active
 repository: https://github.com/insect-morphology/aism
 preferredPrefix: AISM

--- a/ontology/amphx.md
+++ b/ontology/amphx.md
@@ -20,7 +20,7 @@ dependencies:
 tracker: https://github.com/EBISPOT/amphx_ontology/issues
 license:
   url: http://creativecommons.org/licenses/by/3.0/
-  label: CC-BY
+  label: CC-BY 3.0
 activity_status: active
 repository: https://github.com/EBISPOT/amphx_ontology
 preferredPrefix: AMPHX

--- a/ontology/amphx.md
+++ b/ontology/amphx.md
@@ -20,7 +20,7 @@ dependencies:
 tracker: https://github.com/EBISPOT/amphx_ontology/issues
 license:
   url: http://creativecommons.org/licenses/by/3.0/
-  label: CC-BY 3.0
+  label: CC BY 3.0
 activity_status: active
 repository: https://github.com/EBISPOT/amphx_ontology
 preferredPrefix: AMPHX

--- a/ontology/apollo_sv.md
+++ b/ontology/apollo_sv.md
@@ -14,7 +14,7 @@ tracker: https://github.com/ApolloDev/apollo-sv/issues
 activity_status: active
 license:
   url: https://creativecommons.org/licenses/by/4.0/
-  label: CC-BY 4.0
+  label: CC BY 4.0
 repository: https://github.com/ApolloDev/apollo-sv
 preferredPrefix: APOLLO_SV
 ---

--- a/ontology/aro.md
+++ b/ontology/aro.md
@@ -9,7 +9,7 @@ description: Antibiotic resistance genes and mutations
 homepage: https://github.com/arpcard/aro
 license:
   url: https://creativecommons.org/licenses/by/4.0/
-  label: CC-BY
+  label: CC-BY 4.0
 title: Antibiotic Resistance Ontology
 tracker: https://github.com/arpcard/aro/issues
 mailing_list: https://mailman.mcmaster.ca/mailman/listinfo/card-l

--- a/ontology/aro.md
+++ b/ontology/aro.md
@@ -9,7 +9,7 @@ description: Antibiotic resistance genes and mutations
 homepage: https://github.com/arpcard/aro
 license:
   url: https://creativecommons.org/licenses/by/4.0/
-  label: CC-BY 4.0
+  label: CC BY 4.0
 title: Antibiotic Resistance Ontology
 tracker: https://github.com/arpcard/aro/issues
 mailing_list: https://mailman.mcmaster.ca/mailman/listinfo/card-l

--- a/ontology/bcgo.md
+++ b/ontology/bcgo.md
@@ -14,7 +14,7 @@ products:
 tracker: https://github.com/obi-bcgo/bcgo/issues
 license:
   url: http://creativecommons.org/licenses/by/3.0/
-  label: CC-BY
+  label: CC BY 3.0
 is_obsolete: true
 activity_status: inactive
 repository: https://github.com/obi-bcgo/bcgo

--- a/ontology/bco.md
+++ b/ontology/bco.md
@@ -8,7 +8,7 @@ contact:
   github: ramonawalls
 license:
   url: https://creativecommons.org/publicdomain/zero/1.0/
-  label: CC-0
+  label: CC0 1.0
 description: An ontology to support the interoperability of biodiversity data, including data on museum collections, environmental/metagenomic samples, and ecological surveys.
 domain: biodiversity collections
 homepage: https://github.com/tucotuco/bco

--- a/ontology/bfo.md
+++ b/ontology/bfo.md
@@ -16,7 +16,7 @@ products:
   - id: bfo.obo
 license:
   url: http://creativecommons.org/licenses/by/4.0/
-  label: CC-BY 4.0
+  label: CC BY 4.0
 title: Basic Formal Ontology
 review:
   date: 2016

--- a/ontology/bfo.md
+++ b/ontology/bfo.md
@@ -16,7 +16,7 @@ products:
   - id: bfo.obo
 license:
   url: http://creativecommons.org/licenses/by/4.0/
-  label: CC-BY
+  label: CC-BY 4.0
 title: Basic Formal Ontology
 review:
   date: 2016

--- a/ontology/bspo.md
+++ b/ontology/bspo.md
@@ -14,7 +14,7 @@ products:
 title: Biological Spatial Ontology
 license:
   url: http://creativecommons.org/licenses/by/3.0/
-  label: CC-BY
+  label: CC-BY 3.0
 build:
   checkout: git clone https://github.com/obophenotype/biological-spatial-ontology.git
   system: git

--- a/ontology/bspo.md
+++ b/ontology/bspo.md
@@ -14,7 +14,7 @@ products:
 title: Biological Spatial Ontology
 license:
   url: http://creativecommons.org/licenses/by/3.0/
-  label: CC-BY 3.0
+  label: CC BY 3.0
 build:
   checkout: git clone https://github.com/obophenotype/biological-spatial-ontology.git
   system: git

--- a/ontology/caro.md
+++ b/ontology/caro.md
@@ -7,7 +7,7 @@ contact:
   github: mellybelly
 license:
   url: https://creativecommons.org/licenses/by/3.0/
-  label: CC-BY 3.0
+  label: CC BY 3.0
 description: An upper level ontology to facilitate interoperability between existing anatomy ontologies for different species
 domain: anatomy
 homepage: https://github.com/obophenotype/caro/

--- a/ontology/cdao.md
+++ b/ontology/cdao.md
@@ -15,7 +15,7 @@ build:
   method: owl2obo
 license:
   url: https://creativecommons.org/publicdomain/zero/1.0/
-  label: CC0 1.0 Universal
+  label: CC0 1.0
 activity_status: active
 repository: https://github.com/evoinfo/cdao
 preferredPrefix: CDAO

--- a/ontology/cdno.md
+++ b/ontology/cdno.md
@@ -27,7 +27,7 @@ dependencies:
 tracker: https://github.com/Southern-Cross-Plant-Science/cdno/issues
 license:
   url: https://creativecommons.org/licenses/by/3.0/
-  label: CC-BY 3.0
+  label: CC BY 3.0
 activity_status: active
 repository: https://github.com/Southern-Cross-Plant-Science/cdno
 preferredPrefix: CDNO

--- a/ontology/cdno.md
+++ b/ontology/cdno.md
@@ -27,7 +27,7 @@ dependencies:
 tracker: https://github.com/Southern-Cross-Plant-Science/cdno/issues
 license:
   url: https://creativecommons.org/licenses/by/3.0/
-  label: CC-BY
+  label: CC-BY 3.0
 activity_status: active
 repository: https://github.com/Southern-Cross-Plant-Science/cdno
 preferredPrefix: CDNO

--- a/ontology/ceph.md
+++ b/ontology/ceph.md
@@ -28,7 +28,7 @@ jobs:
     type: travis-ci
 license:
   url: http://creativecommons.org/licenses/by/3.0/
-  label: CC-BY
+  label: CC BY 3.0
 activity_status: inactive
 repository: https://github.com/obophenotype/cephalopod-ontology
 ---

--- a/ontology/chebi.md
+++ b/ontology/chebi.md
@@ -18,7 +18,7 @@ contact:
   github: "amalik01"
 license:
   url: https://creativecommons.org/licenses/by/4.0/
-  label: CC-BY 4.0
+  label: CC BY 4.0
 domain: biochemistry
 homepage: http://www.ebi.ac.uk/chebi
 page: http://www.ebi.ac.uk/chebi/init.do?toolBarForward=userManual

--- a/ontology/chiro.md
+++ b/ontology/chiro.md
@@ -33,7 +33,7 @@ dependencies:
 tracker: https://github.com/obophenotype/chiro/issues
 license:
   url: http://creativecommons.org/publicdomain/zero/1.0/
-  label: CC-0
+  label: CC0 1.0
 activity_status: active
 repository: https://github.com/obophenotype/chiro
 preferredPrefix: CHIRO

--- a/ontology/chmo.md
+++ b/ontology/chmo.md
@@ -3,7 +3,7 @@ layout: ontology_detail
 id: chmo
 license:
   url: http://creativecommons.org/licenses/by/4.0/
-  label: CC-BY 4.0
+  label: CC BY 4.0
 contact:
   email: batchelorc@rsc.org
   label: Colin Batchelor

--- a/ontology/chmo.md
+++ b/ontology/chmo.md
@@ -3,7 +3,7 @@ layout: ontology_detail
 id: chmo
 license:
   url: http://creativecommons.org/licenses/by/4.0/
-  label: CC-BY
+  label: CC-BY 4.0
 contact:
   email: batchelorc@rsc.org
   label: Colin Batchelor

--- a/ontology/cido.md
+++ b/ontology/cido.md
@@ -13,7 +13,7 @@ products:
   - id: cido.owl
 license:
   url: http://creativecommons.org/licenses/by/4.0/
-  label: CC-BY
+  label: CC-BY 4.0
 activity_status: active
 repository: https://github.com/cido-ontology/cido
 preferredPrefix: CIDO

--- a/ontology/cido.md
+++ b/ontology/cido.md
@@ -13,7 +13,7 @@ products:
   - id: cido.owl
 license:
   url: http://creativecommons.org/licenses/by/4.0/
-  label: CC-BY 4.0
+  label: CC BY 4.0
 activity_status: active
 repository: https://github.com/cido-ontology/cido
 preferredPrefix: CIDO

--- a/ontology/cio.md
+++ b/ontology/cio.md
@@ -7,7 +7,7 @@ contact:
   github: fbastian
 license:
   url: https://creativecommons.org/publicdomain/zero/1.0/
-  label: CC0
+  label: CC0 1.0
 title: Confidence Information Ontology
 description: An ontology to capture confidence information about annotations.
 homepage: https://github.com/BgeeDB/confidence-information-ontology

--- a/ontology/cl.md
+++ b/ontology/cl.md
@@ -21,7 +21,7 @@ contact:
   github: addiehl
 license:
   url: http://creativecommons.org/licenses/by/4.0/
-  label: CC-BY 4.0
+  label: CC BY 4.0
 taxon:
   id: NCBITaxon:33208
   label: Metazoa

--- a/ontology/cl.md
+++ b/ontology/cl.md
@@ -21,7 +21,7 @@ contact:
   github: addiehl
 license:
   url: http://creativecommons.org/licenses/by/4.0/
-  label: CC-BY
+  label: CC-BY 4.0
 taxon:
   id: NCBITaxon:33208
   label: Metazoa

--- a/ontology/clao.md
+++ b/ontology/clao.md
@@ -21,7 +21,7 @@ dependencies:
 tracker: https://github.com/luis-gonzalez-m/Collembola/issues
 license:
   url: http://creativecommons.org/publicdomain/zero/1.0/
-  label: CC-0
+  label: CC0 1.0
 activity_status: active
 repository: https://github.com/luis-gonzalez-m/Collembola
 preferredPrefix: CLAO

--- a/ontology/clo.md
+++ b/ontology/clo.md
@@ -17,7 +17,7 @@ dependencies:
   - id: ncbitaxon
 license:
   url: http://creativecommons.org/licenses/by/3.0/
-  label: CC-BY 3.0
+  label: CC BY 3.0
 activity_status: active
 repository: https://github.com/CLO-Ontology/CLO
 preferredPrefix: CLO

--- a/ontology/clo.md
+++ b/ontology/clo.md
@@ -17,7 +17,7 @@ dependencies:
   - id: ncbitaxon
 license:
   url: http://creativecommons.org/licenses/by/3.0/
-  label: CC-BY
+  label: CC-BY 3.0
 activity_status: active
 repository: https://github.com/CLO-Ontology/CLO
 preferredPrefix: CLO

--- a/ontology/clyh.md
+++ b/ontology/clyh.md
@@ -23,7 +23,7 @@ dependencies:
 tracker: https://github.com/EBISPOT/clyh_ontology/issues
 license:
   url: http://creativecommons.org/licenses/by/3.0/
-  label: CC-BY 3.0
+  label: CC BY 3.0
 activity_status: active
 repository: https://github.com/EBISPOT/clyh_ontology
 preferredPrefix: CLYH

--- a/ontology/clyh.md
+++ b/ontology/clyh.md
@@ -23,7 +23,7 @@ dependencies:
 tracker: https://github.com/EBISPOT/clyh_ontology/issues
 license:
   url: http://creativecommons.org/licenses/by/3.0/
-  label: CC-BY
+  label: CC-BY 3.0
 activity_status: active
 repository: https://github.com/EBISPOT/clyh_ontology
 preferredPrefix: CLYH

--- a/ontology/cmo.md
+++ b/ontology/cmo.md
@@ -6,7 +6,7 @@ contact:
   label: Mary Shimoyama
 license:
   url: http://creativecommons.org/publicdomain/zero/1.0/
-  label: CC-0
+  label: CC0 1.0
 description: Morphological and physiological measurement records generated from clinical and model organism research and health programs.
 domain: clinical
 homepage: http://rgd.mcw.edu/rgdweb/ontology/search.html

--- a/ontology/cob.md
+++ b/ontology/cob.md
@@ -13,7 +13,7 @@ products:
   - id: cob.owl
 license:
   url: https://creativecommons.org/publicdomain/zero/1.0/
-  label: CC0
+  label: CC0 1.0
 title: Core Ontology for Biology and Biomedicine
 activity_status: active
 repository: https://github.com/OBOFoundry/COB

--- a/ontology/cro.md
+++ b/ontology/cro.md
@@ -12,7 +12,7 @@ contact:
   github: marijane
 license:
   url: https://creativecommons.org/licenses/by/2.0/
-  label: CC-BY
+  label: CC BY 2.0
 build:
   checkout: git clone https://github.com/data2health/contributor-role-ontology.git
   system: git

--- a/ontology/cteno.md
+++ b/ontology/cteno.md
@@ -28,7 +28,7 @@ taxon:
 tracker: https://github.com/obophenotype/ctenophore-ontology/issues
 license:
   url: http://creativecommons.org/licenses/by/3.0/
-  label: CC-BY
+  label: CC BY 3.0
 activity_status: active
 repository: https://github.com/obophenotype/ctenophore-ontology
 preferredPrefix: CTENO

--- a/ontology/cto.md
+++ b/ontology/cto.md
@@ -13,7 +13,7 @@ products:
   - id: cto.owl
 license:
   url: http://creativecommons.org/licenses/by/4.0/
-  label: CC-BY
+  label: CC BY 4.0
 activity_status: active
 repository: https://github.com/ClinicalTrialOntology/CTO
 preferredPrefix: CTO

--- a/ontology/ddanat.md
+++ b/ontology/ddanat.md
@@ -11,7 +11,7 @@ homepage: http://dictybase.org/
 twitter: dictybase
 license:
   url: https://creativecommons.org/publicdomain/zero/1.0/
-  label: CC0 1.0 Universal
+  label: CC0 1.0
 products:
   - id: ddanat.owl
   - id: ddanat.obo

--- a/ontology/ddpheno.md
+++ b/ontology/ddpheno.md
@@ -7,7 +7,7 @@ contact:
   github: pfey03
 license:
   url: http://creativecommons.org/publicdomain/zero/1.0/
-  label: CC-0
+  label: CC0 1.0
 description: A structured controlled vocabulary of phenotypes of the slime-mould <i>Dictyostelium discoideum</i>.
 domain: anatomy
 homepage: http://dictybase.org/

--- a/ontology/dideo.md
+++ b/ontology/dideo.md
@@ -9,7 +9,7 @@ contact:
   github: mbrochhausen
 license:
   url: https://creativecommons.org/licenses/by/4.0/
-  label: CC-BY 4.0
+  label: CC BY 4.0
 homepage: https://github.com/DIDEO/DIDEO
 tracker: https://github.com/DIDEO/DIDEO/issues
 products:

--- a/ontology/dinto.md
+++ b/ontology/dinto.md
@@ -13,7 +13,7 @@ domain: health
 tracker: https://github.com/labda/DINTO/issues
 license:
   url: https://creativecommons.org/licenses/by/3.0/
-  label: CC-BY
+  label: CC BY 3.0
 publications:
   - id: http://pubs.acs.org/doi/10.1021/acs.jcim.5b00119
     title: "DINTO: Using OWL Ontologies and SWRL Rules to Infer Drug–Drug Interactions and Their Mechanisms."

--- a/ontology/doid.md
+++ b/ontology/doid.md
@@ -41,7 +41,7 @@ publications:
     title: "Disease Ontology 2015 update: an expanded and updated database of human diseases for linking biomedical knowledge through disease data"
 license:
   url: https://creativecommons.org/publicdomain/zero/1.0/
-  label: CC0 1.0 Universal
+  label: CC0 1.0
 usages:
   - user: https://www.alliancegenome.org
     description: Alliance of Genome Resources - MGD, RGD, SGD, FlyBase, WormBase, ZFIN use DO

--- a/ontology/dpo.md
+++ b/ontology/dpo.md
@@ -18,7 +18,7 @@ taxon:
 title: Drosophila Phenotype Ontology
 license:
   url: http://creativecommons.org/licenses/by/3.0/
-  label: CC-BY
+  label: CC BY 3.0
 build:
   checkout: git clone https://github.com/FlyBase/drosophila-phenotype-ontolog.git
   system: git

--- a/ontology/dron.md
+++ b/ontology/dron.md
@@ -16,7 +16,7 @@ build:
 tracker: https://github.com/ufbmi/dron/issues
 license:
   url: http://creativecommons.org/licenses/by/3.0/
-  label: CC-BY
+  label: CC BY 3.0
 activity_status: active
 repository: https://github.com/ufbmi/dron/
 preferredPrefix: DRON

--- a/ontology/duo.md
+++ b/ontology/duo.md
@@ -23,7 +23,7 @@ dependencies:
 tracker: https://github.com/EBISPOT/DUO/issues
 license:
   url: http://creativecommons.org/licenses/by/4.0/
-  label: CC-BY
+  label: CC BY 4.0
 activity_status: active
 repository: https://github.com/EBISPOT/DUO
 preferredPrefix: DUO

--- a/ontology/ecao.md
+++ b/ontology/ecao.md
@@ -23,7 +23,7 @@ dependencies:
 tracker: https://github.com/echinoderm-ontology/ecao_ontology/issues
 license:
   url: http://creativecommons.org/licenses/by/3.0/
-  label: CC-BY
+  label: CC BY 3.0
 activity_status: active
 repository: https://github.com/echinoderm-ontology/ecao_ontology
 preferredPrefix: ECAO

--- a/ontology/eco.md
+++ b/ontology/eco.md
@@ -28,7 +28,7 @@ publications:
     title: "Standardized description of scientific evidence using the Evidence Ontology (ECO)"
 license:
   url: https://creativecommons.org/publicdomain/zero/1.0/
-  label: CC0 1.0 Universal
+  label: CC0 1.0
 funded_by:
   - "http://www.nsf.gov/awardsearch/showAward?AWD_ID=1458400"
 usages:

--- a/ontology/ecocore.md
+++ b/ontology/ecocore.md
@@ -33,7 +33,7 @@ dependencies:
 tracker: https://github.com/EcologicalSemantics/ecocore/issues
 license:
   url: http://creativecommons.org/licenses/by/3.0/
-  label: CC-BY
+  label: CC BY 3.0
 activity_status: active
 repository: https://github.com/EcologicalSemantics/ecocore
 preferredPrefix: ECOCORE

--- a/ontology/ecto.md
+++ b/ontology/ecto.md
@@ -48,7 +48,7 @@ dependencies:
 tracker: https://github.com/EnvironmentOntology/environmental-exposure-ontology/issues
 license:
   url: https://creativecommons.org/publicdomain/zero/1.0/
-  label: CC0
+  label: CC0 1.0
 activity_status: active
 repository: https://github.com/EnvironmentOntology/environmental-exposure-ontology
 preferredPrefix: ECTO

--- a/ontology/ehdaa2.md
+++ b/ontology/ehdaa2.md
@@ -6,7 +6,7 @@ contact:
   label: Jonathan Bard
 license:
   url: https://creativecommons.org/licenses/by/4.0/
-  label: CC-BY 4.0
+  label: CC BY 4.0
 description: A structured controlled vocabulary of stage-specific anatomical structures of the developing human.
 tracker: https://github.com/obophenotype/human-developmental-anatomy-ontology/issues
 domain: anatomy

--- a/ontology/emapa.md
+++ b/ontology/emapa.md
@@ -7,7 +7,7 @@ contact:
   github: tfhayamizu
 license:
   url: https://creativecommons.org/licenses/by/4.0/
-  label: CC-BY 4.0
+  label: CC BY 4.0
 description: "An ontology for mouse anatomy covering embryonic development and postnatal stages."
 domain: anatomy
 homepage: http://www.informatics.jax.org/expression.shtml

--- a/ontology/envo.md
+++ b/ontology/envo.md
@@ -11,7 +11,7 @@ homepage: http://environmentontology.org/
 page: https://github.com/EnvironmentOntology/envo
 license:
   url: http://creativecommons.org/licenses/by/3.0/
-  label: CC-BY
+  label: CC BY 3.0
 publications:
   - id: http://www.dx.doi.org/10.1186/2041-1480-4-43
     title: "The environment ontology: contextualising biological and biomedical entities"

--- a/ontology/eo.md
+++ b/ontology/eo.md
@@ -18,7 +18,7 @@ products:
 tracker: https://github.com/Planteome/plant-environment-ontology/issues
 license:
   url: https://creativecommons.org/licenses/by/4.0/
-  label: CC-BY 4.0
+  label: CC BY 4.0
 is_obsolete: true
 replaced_by: peco
 publications:

--- a/ontology/ero.md
+++ b/ontology/ero.md
@@ -6,7 +6,7 @@ contact:
   label: Marc Ciriello
 license:
   url: https://creativecommons.org/licenses/by/2.0/
-  label: CC-BY 2.0
+  label: CC BY 2.0
 description: An ontology of research resources such as instruments. protocols, reagents, animal models and biospecimens.
 domain: resources
 homepage: https://open.med.harvard.edu/wiki/display/eaglei/Ontology

--- a/ontology/eupath.md
+++ b/ontology/eupath.md
@@ -7,7 +7,7 @@ contact:
   github: cstoeckert
 license:
   url: http://creativecommons.org/licenses/by/4.0/
-  label: CC-BY
+  label: CC BY 4.0
 depicted_by: https://raw.githubusercontent.com/EuPathDB/communitysite/master/assets/images/VEuPathDB-logo-s.png
 domain: functional genomics, population biology, clinical epidemiology, and microbiomes
 description: An ontology is developed to support Eukaryotic Pathogen, Host & Vector Genomics Resource (VEuPathDB; https://veupathdb.org).

--- a/ontology/fao.md
+++ b/ontology/fao.md
@@ -7,7 +7,7 @@ contact:
   github: mah11
 license:
   url: http://creativecommons.org/publicdomain/zero/1.0/
-  label: CC-0
+  label: CC0 1.0
 description: A structured controlled vocabulary for the anatomy of fungi.
 domain: anatomy
 tracker: https://github.com/obophenotype/fungal-anatomy-ontology/issues

--- a/ontology/fbbt.md
+++ b/ontology/fbbt.md
@@ -20,7 +20,7 @@ taxon:
 title: Drosophila gross anatomy
 license:
   url: http://creativecommons.org/licenses/by/3.0/
-  label: CC-BY
+  label: CC BY 3.0
 build:
   checkout: git clone https://github.com/FlyBase/drosophila-anatomy-developmental-ontology.git
   system: git

--- a/ontology/fbcv.md
+++ b/ontology/fbcv.md
@@ -15,7 +15,7 @@ products:
 title: FlyBase Controlled Vocabulary
 license:
   url: http://creativecommons.org/licenses/by/3.0/
-  label: CC-BY
+  label: CC BY 3.0
 build:
   checkout: git clone https://github.com/FlyBase/flybase-controlled-vocabulary.git
   system: git

--- a/ontology/fbdv.md
+++ b/ontology/fbdv.md
@@ -20,7 +20,7 @@ taxon:
 title: Drosophila development
 license:
   url: http://creativecommons.org/licenses/by/3.0/
-  label: CC-BY
+  label: CC BY 3.0
 build:
   checkout: git clone https://github.com/FlyBase/drosophila-developmental-ontology.git
   system: git

--- a/ontology/fideo.md
+++ b/ontology/fideo.md
@@ -13,7 +13,7 @@ products:
   - id: fideo.owl
 license:
   url: https://creativecommons.org/publicdomain/zero/1.0/
-  label: CC0
+  label: CC0 1.0
 tracker: https://github.com/getbordea/fideo/issues
 activity_status: active
 repository: https://github.com/getbordea/fideo

--- a/ontology/flopo.md
+++ b/ontology/flopo.md
@@ -10,7 +10,7 @@ domain: phenotype
 homepage: https://github.com/flora-phenotype-ontology/flopoontology
 license:
   url: https://creativecommons.org/publicdomain/zero/1.0/
-  label: CC-0
+  label: CC0 1.0
 products:
   - id: flopo.owl
 build:

--- a/ontology/fma.md
+++ b/ontology/fma.md
@@ -6,7 +6,7 @@ contact:
   label: Onard Mejino
 license:
   url: https://creativecommons.org/licenses/by/3.0/
-  label: CC-BY 3.0
+  label: CC BY 3.0
 description: This is currently a slimmed down version of FMA
 domain: anatomy
 homepage: http://si.washington.edu/projects/fma

--- a/ontology/fobi.md
+++ b/ontology/fobi.md
@@ -9,7 +9,7 @@ description: FOBI (Food-Biomarker Ontology) is an ontology to represent food int
 domain: metabolomics and nutrition
 license:
   url: http://creativecommons.org/licenses/by/3.0/
-  label: CC-BY
+  label: CC BY 3.0
 products:
   - id: fobi.owl
     title: FOBI is an ontology to represent food intake data and associate it with metabolomic data

--- a/ontology/foodon.md
+++ b/ontology/foodon.md
@@ -10,7 +10,7 @@ domain: food
 homepage: https://foodon.org/
 license:
   url: http://creativecommons.org/licenses/by/3.0/
-  label: CC-BY
+  label: CC BY 3.0
 products:
   - id: foodon.owl
     title: FoodOn full ontology including 9000 SIREN indexed food products

--- a/ontology/fovt.md
+++ b/ontology/fovt.md
@@ -38,7 +38,7 @@ dependencies:
 tracker: https://github.com/futres/fovt/issues
 license:
   url: https://creativecommons.org/publicdomain/zero/1.0/
-  label: CC0
+  label: CC0 1.0
 activity_status: active
 repository: https://github.com/futres/fovt
 preferredPrefix: FOVT

--- a/ontology/fypo.md
+++ b/ontology/fypo.md
@@ -25,7 +25,7 @@ publications:
     title: "FYPO: The Fission Yeast Phenotype Ontology."
 license:
   url: http://creativecommons.org/licenses/by/4.0/
-  label: CC-BY
+  label: CC BY 4.0
 depicted_by: https://github.com/pombase/website/blob/master/src/assets/FYPO_logo_tiny.png
 usages:
   - user: https://www.pombase.org

--- a/ontology/gaz.md
+++ b/ontology/gaz.md
@@ -19,7 +19,7 @@ tracker: https://github.com/EnvironmentOntology/gaz/issues
 mailing_list: "https://groups.google.com/forum/#!forum/obo-gazetteer"
 license:
   url: https://creativecommons.org/publicdomain/zero/1.0/
-  label: CC0 1.0 Universal
+  label: CC0 1.0
 activity_status: inactive
 repository: https://github.com/EnvironmentOntology/gaz
 ---

--- a/ontology/gecko.md
+++ b/ontology/gecko.md
@@ -13,7 +13,7 @@ products:
   - id: gecko.owl
 license:
   url: https://creativecommons.org/licenses/by/4.0/
-  label: CC-BY 4.0
+  label: CC BY 4.0
 tracker: https://github.com/IHCC-cohorts/GECKO/issues
 usages:
   - user: https://ihccglobal.org/

--- a/ontology/genepio.md
+++ b/ontology/genepio.md
@@ -10,7 +10,7 @@ homepage: http://genepio.org/
 page: https://github.com/GenEpiO/genepio
 license:
   url: http://creativecommons.org/licenses/by/3.0/
-  label: CC-BY
+  label: CC BY 3.0
 products:
   - id: genepio.owl
     homepage: http://genepio.github.io/genepio/

--- a/ontology/geno.md
+++ b/ontology/geno.md
@@ -12,7 +12,7 @@ contact:
   github: mbrush
 license:
   url: https://creativecommons.org/licenses/by-sa/2.0/
-  label: CC-BY-SA
+  label: CC BY-SA 2.0
 build:
   checkout: git clone https://github.com/monarch-initiative/GENO-ontology.git
   system: git

--- a/ontology/geo.md
+++ b/ontology/geo.md
@@ -7,7 +7,7 @@ contact:
   github: hoganwr
 license:
   url: https://creativecommons.org/licenses/by/4.0/
-  label: CC-BY 4.0
+  label: CC BY 4.0
 homepage: https://github.com/ufbmi/geographical-entity-ontology/wiki
 description: An ontology of geographical entities
 products:

--- a/ontology/gno.md
+++ b/ontology/gno.md
@@ -23,7 +23,7 @@ build:
 tracker: https://github.com/glygen-glycan-data/GNOme/issues
 license:
   url: https://creativecommons.org/licenses/by/4.0/
-  label: CC-BY 4.0
+  label: CC BY 4.0
 browsers:
   - label: Structure Browser
     title: GNOme Glycan Structure Browser

--- a/ontology/hancestro.md
+++ b/ontology/hancestro.md
@@ -18,7 +18,7 @@ products:
     title: HANCESTRO BFO
 license:
   url: https://creativecommons.org/licenses/by/4.0/
-  label: CC-BY 4.0
+  label: CC BY 4.0
 usages:
   - user: http://www.ebi.ac.uk/efo
     description: The Experimental Factor Ontology (EFO) provides a systematic description of many experimental variables available in EBI databases, and for external projects such as the NHGRI GWAS catalogue. It combines parts of several biological ontologies, such as anatomy, disease and chemical compounds.

--- a/ontology/hao.md
+++ b/ontology/hao.md
@@ -7,7 +7,7 @@ contact:
 tracker: https://github.com/hymao/hao/issues
 license:
   url: https://creativecommons.org/publicdomain/zero/1.0/
-  label: CC-0
+  label: CC0 1.0
 description: A structured controlled vocabulary of the anatomy of the Hymenoptera (bees, wasps, and ants)
 domain: anatomy
 homepage: http://hymao.org

--- a/ontology/hom.md
+++ b/ontology/hom.md
@@ -18,7 +18,7 @@ build:
   path: src/ontology
 license:
   url: https://creativecommons.org/publicdomain/zero/1.0/
-  label: CC0
+  label: CC0 1.0
 activity_status: active
 repository: https://github.com/BgeeDB/homology-ontology
 preferredPrefix: HOM

--- a/ontology/hsapdv.md
+++ b/ontology/hsapdv.md
@@ -16,7 +16,7 @@ contact:
   email: bgee@sib.swiss
 license:
   url: http://creativecommons.org/licenses/by/3.0/
-  label: CC-BY
+  label: CC BY 3.0
 products:
   - id: hsapdv.owl
   - id: hsapdv.obo

--- a/ontology/hso.md
+++ b/ontology/hso.md
@@ -11,7 +11,7 @@ homepage: https://w3id.org/hso
 page: https://github.com/SVA-SE/HSO
 license:
   url: http://creativecommons.org/licenses/by/3.0/
-  label: CC-BY
+  label: CC BY 3.0
 products:
   - id: hso.owl
     homepage: https://w3id.org/hso

--- a/ontology/htn.md
+++ b/ontology/htn.md
@@ -8,7 +8,7 @@ contact:
   label: Amanda Hicks
   email: aellenhicks@gmail.com
 license:
-  label: CC-BY 4.0
+  label: CC BY 4.0
   url: http://creativecommons.org/licenses/by/4.0/
 tracker: https://github.com/aellenhicks/htn_owl/issues
 source_url: https://raw.githubusercontent.com/aellenhicks/htn_owl/master/htn.owl

--- a/ontology/iao.md
+++ b/ontology/iao.md
@@ -10,7 +10,7 @@ domain: information
 homepage: https://github.com/information-artifact-ontology/IAO/
 license:
   url: http://creativecommons.org/licenses/by/4.0/
-  label: CC-BY
+  label: CC BY 4.0
 products:
   - id: iao.owl
   - id: iao/ontology-metadata.owl

--- a/ontology/iceo.md
+++ b/ontology/iceo.md
@@ -12,7 +12,7 @@ products:
   - id: iceo.owl
 license:
   url: http://creativecommons.org/licenses/by/4.0/
-  label: CC-BY
+  label: CC BY 4.0
 activity_status: active
 repository: https://github.com/ontoice/ICEO
 preferredPrefix: ICEO

--- a/ontology/ico.md
+++ b/ontology/ico.md
@@ -6,7 +6,7 @@ description: An ontology of clinical informed consents
 domain: informed consent
 license:
   url: http://creativecommons.org/licenses/by/3.0/
-  label: CC-BY
+  label: CC BY 3.0
 contact:
   email: yongqunh@med.umich.edu
   label: Yongqun Oliver He

--- a/ontology/ido.md
+++ b/ontology/ido.md
@@ -7,7 +7,7 @@ contact:
   github: lgcowell
 license:
   url: https://creativecommons.org/licenses/by/3.0/
-  label: CC-BY 3.0
+  label: CC BY 3.0
 domain: health
 homepage: http://www.bioontology.org/wiki/index.php/Infectious_Disease_Ontology
 products:

--- a/ontology/idomal.md
+++ b/ontology/idomal.md
@@ -6,7 +6,7 @@ contact:
   label: Pantelis Topalis
 license:
   url: https://creativecommons.org/publicdomain/zero/1.0/
-  label: CC0
+  label: CC0 1.0
 description: An application ontology to cover all aspects of malaria as well as the intervention attempts to control it.
 domain: health
 homepage: https://www.vectorbase.org/ontology-browser

--- a/ontology/ino.md
+++ b/ontology/ino.md
@@ -5,7 +5,7 @@ title: Interaction Network Ontology
 description: An ontology of interactions and interaction networks
 license:
   url: http://creativecommons.org/licenses/by/3.0/
-  label: CC-BY
+  label: CC BY 3.0
 contact:
   email: yongqunh@med.umich.edu
   label: Yongqun Oliver He

--- a/ontology/ma.md
+++ b/ontology/ma.md
@@ -7,7 +7,7 @@ contact:
   github: tfhayamizu
 license:
   url: https://creativecommons.org/licenses/by/4.0/
-  label: CC-BY 4.0
+  label: CC BY 4.0
 description: A structured controlled vocabulary of the adult anatomy of the mouse (Mus).
 domain: anatomy
 homepage: https://github.com/obophenotype/mouse-anatomy-ontology

--- a/ontology/maxo.md
+++ b/ontology/maxo.md
@@ -40,7 +40,7 @@ dependencies:
 tracker: https://github.com/monarch-initiative/MAxO/issues
 license:
   url: http://creativecommons.org/licenses/by/3.0/
-  label: CC-BY
+  label: CC BY 3.0
 activity_status: active
 repository: https://github.com/monarch-initiative/MAxO
 preferredPrefix: MAXO

--- a/ontology/mco.md
+++ b/ontology/mco.md
@@ -36,7 +36,7 @@ dependencies:
 tracker: https://github.com/microbial-conditions-ontology/microbial-conditions-ontology/issues
 license:
   url: http://creativecommons.org/licenses/by/3.0/
-  label: CC-BY
+  label: CC BY 3.0
 activity_status: active
 repository: https://github.com/microbial-conditions-ontology/microbial-conditions-ontology
 preferredPrefix: MCO

--- a/ontology/mf.md
+++ b/ontology/mf.md
@@ -17,7 +17,7 @@ build:
 tracker: https://github.com/jannahastings/mental-functioning-ontology/issues
 license:
   url: http://creativecommons.org/licenses/by/3.0/
-  label: CC-BY
+  label: CC BY 3.0
 activity_status: active
 repository: https://github.com/jannahastings/mental-functioning-ontology
 preferredPrefix: MF

--- a/ontology/mfmo.md
+++ b/ontology/mfmo.md
@@ -6,7 +6,7 @@ description: The Mammalian Feeding Muscle Ontology is an antomy ontology for the
 homepage: https://github.com/rdruzinsky/feedontology
 license:
   url: http://creativecommons.org/licenses/by/3.0/
-  label: CC-BY
+  label: CC BY 3.0
 taxon:
   id: NCBITaxon:40674
   label: Mammalian

--- a/ontology/mfoem.md
+++ b/ontology/mfoem.md
@@ -17,7 +17,7 @@ build:
 tracker: https://github.com/jannahastings/emotion-ontology/issues
 license:
   url: http://creativecommons.org/licenses/by/3.0/
-  label: CC-BY
+  label: CC BY 3.0
 activity_status: active
 repository: https://github.com/jannahastings/emotion-ontology
 preferredPrefix: MFOEM

--- a/ontology/mfomd.md
+++ b/ontology/mfomd.md
@@ -13,7 +13,7 @@ products:
 tracker: https://github.com/jannahastings/mental-functioning-ontology/issues
 license:
   url: http://creativecommons.org/licenses/by/3.0/
-  label: CC-BY
+  label: CC BY 3.0
 activity_status: active
 repository: https://github.com/jannahastings/mental-functioning-ontology
 preferredPrefix: MFOMD

--- a/ontology/miapa.md
+++ b/ontology/miapa.md
@@ -12,7 +12,7 @@ products:
 title: MIAPA Ontology
 license:
   url: http://creativecommons.org/publicdomain/zero/1.0/
-  label: CC-0
+  label: CC0 1.0
 repository: https://github.com/evoinfo/miapa
 tracker: https://github.com/evoinfo/miapa/issues
 releases: https://github.com/evoinfo/miapa/releases

--- a/ontology/micro.md
+++ b/ontology/micro.md
@@ -11,7 +11,7 @@ homepage: https://github.com/carrineblank/MicrO
 tracker: https://github.com/carrineblank/MicrO/issues
 license:
   url: https://creativecommons.org/licenses/by/2.0/
-  label: CC-BY 2.0
+  label: CC BY 2.0
 products:
   - id: micro.owl
 activity_status: active

--- a/ontology/mirnao.md
+++ b/ontology/mirnao.md
@@ -6,7 +6,7 @@ contact:
   label: Pantelis Topalis
 license:
   url: https://creativecommons.org/publicdomain/zero/1.0/
-  label: CC0
+  label: CC0 1.0
 description: An application ontology for use with miRNA databases.
 homepage: http://code.google.com/p/mirna-ontology/
 products:

--- a/ontology/mmo.md
+++ b/ontology/mmo.md
@@ -6,7 +6,7 @@ contact:
   label: Jennifer Smith
 license:
   url: https://creativecommons.org/publicdomain/zero/1.0/
-  label: CC-0
+  label: CC0 1.0
 description: "A representation of the variety of methods used to make clinical and phenotype measurements. "
 domain: clinical
 homepage: https://rgd.mcw.edu/rgdweb/ontology/view.html?acc_id=MMO:0000000

--- a/ontology/mmusdv.md
+++ b/ontology/mmusdv.md
@@ -15,7 +15,7 @@ contact:
   email: bgee@sib.swiss
 license:
   url: http://creativecommons.org/licenses/by/3.0/
-  label: CC-BY
+  label: CC BY 3.0
 products:
   - id: mmusdv.owl
   - id: mmusdv.obo

--- a/ontology/mod.md
+++ b/ontology/mod.md
@@ -6,7 +6,7 @@ contact:
   label: Pierre-Alain Binz
 license:
   url: https://creativecommons.org/licenses/by/4.0/
-  label: CC-BY 4.0
+  label: CC BY 4.0
 publications:
   - id: https://pubmed.ncbi.nlm.nih.gov/18688235/
     title: "The PSI-MOD community standard for representation of protein modification data"

--- a/ontology/mop.md
+++ b/ontology/mop.md
@@ -6,7 +6,7 @@ contact:
   label: Colin Batchelor
 license:
   url: https://creativecommons.org/licenses/by/4.0/
-  label: CC-BY 4.0
+  label: CC BY 4.0
 mailing_list: "chemistry-ontologies@googlegroups.com"
 title: Molecular Process Ontology
 description: Processes at the molecular level

--- a/ontology/mp.md
+++ b/ontology/mp.md
@@ -4,7 +4,7 @@ id: mp
 title: Mammalian Phenotype Ontology
 license:
   url: http://creativecommons.org/licenses/by/4.0/
-  label: CC-BY 4.0
+  label: CC BY 4.0
 build:
   checkout: git clone https://github.com/obophenotype/mammalian-phenotype-ontology.git
   system: git

--- a/ontology/mpath.md
+++ b/ontology/mpath.md
@@ -16,7 +16,7 @@ taxon:
 title: Mouse pathology ontology
 license:
   url: http://creativecommons.org/licenses/by/3.0/
-  label: CC-BY
+  label: CC BY 3.0
 build:
   source_url: https://raw.githubusercontent.com/PaulNSchofield/mpath/master/mpath.obo
   insert_ontology_id: true

--- a/ontology/mpio.md
+++ b/ontology/mpio.md
@@ -14,7 +14,7 @@ products:
 tracker: https://github.com/MPIO-Developers/MPIO/issues
 license:
   url: http://creativecommons.org/licenses/by/4.0/
-  label: CC-BY
+  label: CC BY 4.0
 activity_status: active
 repository: https://github.com/MPIO-Developers/MPIO
 preferredPrefix: MPIO

--- a/ontology/mro.md
+++ b/ontology/mro.md
@@ -12,7 +12,7 @@ contact:
   github: bpeters42
 license:
   url: https://creativecommons.org/licenses/by/3.0/
-  label: CC-BY
+  label: CC BY 3.0
 products:
   - id: mro.owl
 usages:

--- a/ontology/ms.md
+++ b/ontology/ms.md
@@ -25,7 +25,7 @@ products:
   - id: ms.owl
 license:
   url: https://creativecommons.org/licenses/by/3.0/
-  label: CC-BY
+  label: CC BY 3.0
 build:
   source_url: https://raw.githubusercontent.com/HUPO-PSI/psi-ms-CV/master/psi-ms.obo
   method: obo2owl

--- a/ontology/nbo.md
+++ b/ontology/nbo.md
@@ -13,7 +13,7 @@ products:
 title: Neuro Behavior Ontology
 license:
   url: http://creativecommons.org/licenses/by/3.0/
-  label: CC-BY
+  label: CC BY 3.0
 browsers:
   - label: BioPortal
     title: BioPortal Ontology Browser

--- a/ontology/ncbitaxon.md
+++ b/ontology/ncbitaxon.md
@@ -42,7 +42,7 @@ products:
     page: https://github.com/obophenotype/ncbitaxon/blob/master/subsets/README.md
 license:
   url: https://creativecommons.org/publicdomain/zero/1.0/
-  label: CC0 1.0 Universal
+  label: CC0 1.0
 activity_status: active
 repository: https://github.com/obophenotype/ncbitaxon
 ---

--- a/ontology/ncit.md
+++ b/ontology/ncit.md
@@ -8,7 +8,7 @@ contact:
   github: mellybelly
 license:
   url: https://creativecommons.org/licenses/by/4.0/
-  label: CC-BY 4.0
+  label: CC BY 4.0
 homepage: https://github.com/NCI-Thesaurus/thesaurus-obo-edition
 tracker: https://github.com/NCI-Thesaurus/thesaurus-obo-edition/issues
 description: NCI Thesaurus (NCIt)is a reference terminology that includes broad coverage of the cancer domain, including cancer related diseases, findings and abnormalities. The NCIt OBO Edition aims to increase integration of the NCIt with OBO Library ontologies. NCIt OBO Edition releases should be considered experimental.

--- a/ontology/ncro.md
+++ b/ontology/ncro.md
@@ -13,7 +13,7 @@ contact:
   github: Huang-OMIT
 license:
   url: https://creativecommons.org/licenses/by/4.0/
-  label: CC-BY 4.0
+  label: CC BY 4.0
 # depicted_by:
 # build:
 #  source_url: http://purl.obofoundry.org/obo/obi/repository/trunk/src/ontology/branches/

--- a/ontology/nomen.md
+++ b/ontology/nomen.md
@@ -9,7 +9,7 @@ contact:
   label: Matt Yoder
 license:
   url: https://creativecommons.org/publicdomain/zero/1.0/
-  label: CC-0
+  label: CC0 1.0
 description: NOMEN is a nomenclatural ontology for biological names (not concepts).  It encodes the goverened rules of nomenclature.
 domain: biological nomenclature
 homepage: https://github.com/SpeciesFileGroup/nomen

--- a/ontology/oae.md
+++ b/ontology/oae.md
@@ -16,7 +16,7 @@ build:
   method: owl2obo
 license:
   url: http://creativecommons.org/licenses/by/3.0/
-  label: CC-BY
+  label: CC BY 3.0
 activity_status: active
 repository: https://github.com/OAE-ontology/OAE
 preferredPrefix: OAE

--- a/ontology/oba.md
+++ b/ontology/oba.md
@@ -6,7 +6,7 @@ contact:
   label: Chris Mungall
 license:
   url: http://creativecommons.org/publicdomain/zero/1.0/
-  label: CC-0
+  label: CC0 1.0
 description: A collection of biological attributes (traits) covering all kingdoms of life.
 domain: phenotype
 homepage: https://github.com/obophenotype/bio-attribute-ontology

--- a/ontology/obcs.md
+++ b/ontology/obcs.md
@@ -14,7 +14,7 @@ products:
 tracker: https://github.com/obcs/obcs/issues
 license:
   url: http://creativecommons.org/licenses/by/3.0/
-  label: CC-BY
+  label: CC BY 3.0
 activity_status: active
 repository: https://github.com/obcs/obcs
 preferredPrefix: OBCS

--- a/ontology/obi.md
+++ b/ontology/obi.md
@@ -19,7 +19,7 @@ contact:
   email: bpeters@lji.org
 license:
   url: https://creativecommons.org/licenses/by/4.0/
-  label: CC-BY 4.0
+  label: CC BY 4.0
 depicted_by: https://svn.code.sf.net/p/obi/code/trunk/web/htdocs/images/obi-lotext.png
 build:
   source_url: http://purl.obofoundry.org/obo/obi/repository/trunk/src/ontology/branches/

--- a/ontology/obib.md
+++ b/ontology/obib.md
@@ -23,7 +23,7 @@ usages:
     description: The National Cancer Institute Biorepositories and Biospecimen Research Branch (BBRB) is an international leader in research and policy activities related to biospecimen collection, processing, and storage, also known as biobanking.
 license:
   url: http://creativecommons.org/licenses/by/4.0/
-  label: CC-BY
+  label: CC BY 4.0
 activity_status: active
 repository: https://github.com/biobanking/biobanking
 preferredPrefix: OBIB

--- a/ontology/ogg.md
+++ b/ontology/ogg.md
@@ -12,7 +12,7 @@ title: The Ontology of Genes and Genomes
 tracker: https://bitbucket.org/hegroup/ogg/issues/
 license:
   url: http://creativecommons.org/licenses/by/3.0/
-  label: CC-BY
+  label: CC BY 3.0
 activity_status: active
 preferredPrefix: OGG
 ---

--- a/ontology/ogms.md
+++ b/ontology/ogms.md
@@ -6,7 +6,7 @@ contact:
   label: Brian Aevermann
 license:
   url: http://creativecommons.org/licenses/by/4.0/
-  label: CC-BY
+  label: CC BY 4.0
 description: An ontology for representing treatment of disease and diagnosis and on carcinomas and other pathological entities
 domain: medicine
 homepage: https://github.com/OGMS/ogms

--- a/ontology/ogsf.md
+++ b/ontology/ogsf.md
@@ -8,7 +8,7 @@ contact:
   email: linikujp@gmail.com
 license:
   url: https://creativecommons.org/licenses/by/3.0/
-  label: CC-BY 3.0
+  label: CC BY 3.0
 products:
   - id: ogsf.owl
 title: Ontology of Genetic Susceptibility Factor

--- a/ontology/ohd.md
+++ b/ontology/ohd.md
@@ -9,7 +9,7 @@ domain: health
 homepage: https://purl.obolibrary.org/obo/ohd/home
 license:
   url: http://creativecommons.org/licenses/by/4.0/
-  label: CC-BY
+  label: CC BY 4.0
 products:
   - id: ohd.owl
   - id: ohd/dev/ohd.owl

--- a/ontology/ohmi.md
+++ b/ontology/ohmi.md
@@ -13,7 +13,7 @@ products:
   - id: ohmi.owl
 license:
   url: http://creativecommons.org/licenses/by/4.0/
-  label: CC-BY
+  label: CC BY 4.0
 activity_status: active
 repository: https://github.com/ohmi-ontology/ohmi
 preferredPrefix: OHMI

--- a/ontology/ohpi.md
+++ b/ontology/ohpi.md
@@ -13,7 +13,7 @@ products:
   - id: ohpi.owl
 license:
   url: http://creativecommons.org/licenses/by/4.0/
-  label: CC-BY
+  label: CC BY 4.0
 activity_status: active
 repository: https://github.com/OHPI/ohpi
 preferredPrefix: OHPI

--- a/ontology/olatdv.md
+++ b/ontology/olatdv.md
@@ -18,7 +18,7 @@ contact:
   email: bgee@sib.swiss
 license:
   url: http://creativecommons.org/licenses/by/3.0/
-  label: CC-BY
+  label: CC BY 3.0
 activity_status: active
 repository: https://github.com/obophenotype/developmental-stage-ontologies
 ---

--- a/ontology/omiabis.md
+++ b/ontology/omiabis.md
@@ -13,7 +13,7 @@ products:
 tracker: https://github.com/OMIABIS/omiabis-dev/issues
 license:
   url: http://creativecommons.org/licenses/by/3.0/
-  label: CC-BY
+  label: CC BY 3.0
 is_obsolete: true
 activity_status: inactive
 repository: https://github.com/OMIABIS/omiabis-dev

--- a/ontology/omit.md
+++ b/ontology/omit.md
@@ -7,7 +7,7 @@ contact:
   label: Huang, Jingshan
 license:
   url: https://creativecommons.org/licenses/by/3.0/
-  label: CC-BY 3.0
+  label: CC BY 3.0
 description: Ontology to establish data exchange standards and common data elements in the microRNA (miR) domain
 homepage: http://omit.cis.usouthal.edu/
 tracker: https://github.com/OmniSearch/omit/issues

--- a/ontology/omo.md
+++ b/ontology/omo.md
@@ -13,7 +13,7 @@ products:
   - id: omo.owl
 license:
   url: https://creativecommons.org/publicdomain/zero/1.0/
-  label: CC0
+  label: CC0 1.0
 title: OBO Metadata Ontology
 usages:
   - user: http://obofoundry.org

--- a/ontology/omp.md
+++ b/ontology/omp.md
@@ -16,7 +16,7 @@ build:
   method: obo2owl
 license:
   url: http://creativecommons.org/licenses/by/3.0/
-  label: CC-BY
+  label: CC BY 3.0
 tracker: https://github.com/microbialphenotypes/OMP-ontology/issues
 activity_status: active
 repository: https://github.com/microbialphenotypes/OMP-ontology

--- a/ontology/omrse.md
+++ b/ontology/omrse.md
@@ -6,7 +6,7 @@ contact:
   label: Bill Hogan
 license:
   url: https://creativecommons.org/licenses/by/4.0/
-  label: CC-BY 4.0
+  label: CC BY 4.0
 description: This ontology covers the domain of social entities that are related to health care, such as demographic information and the roles of various individuals and organizations.
 domain: medicine
 homepage: https://github.com/ufbmi/OMRSE/wiki/OMRSE-Overview

--- a/ontology/one.md
+++ b/ontology/one.md
@@ -13,7 +13,7 @@ homepage: https://github.com/cyang0128/Nutritional-epidemiologic-ontologies
 page: https://github.com/cyang0128/Nutritional-epidemiologic-ontologies
 license:
   url: https://creativecommons.org/licenses/by/4.0/
-  label: CC-BY
+  label: CC BY 4.0
 products:
   - id: one.owl
 dependencies:

--- a/ontology/ons.md
+++ b/ontology/ons.md
@@ -13,7 +13,7 @@ homepage: https://github.com/enpadasi/Ontology-for-Nutritional-Studies
 page: https://github.com/enpadasi/Ontology-for-Nutritional-Studies
 license:
   url: https://creativecommons.org/licenses/by/4.0/
-  label: CC-BY
+  label: CC BY 4.0
 products:
   - id: ons.owl
     title: ONS latest release

--- a/ontology/ontoneo.md
+++ b/ontology/ontoneo.md
@@ -8,7 +8,7 @@ contact:
 description: The Obstetric and Neonatal Ontology is a structured controlled vocabulary to provide a representation of the data from electronic health records (EHRs) involved in the care of the pregnant woman, and of her baby.
 license:
   url: http://creativecommons.org/licenses/by/3.0/
-  label: CC-BY
+  label: CC BY 3.0
 domain: biomedical, health
 homepage: ontoneo.com
 mailing_list: http://groups.google.com/group/ontoneo-discuss

--- a/ontology/oostt.md
+++ b/ontology/oostt.md
@@ -13,7 +13,7 @@ products:
 tracker: https://github.com/OOSTT/OOSTT/issues
 license:
   url: http://creativecommons.org/licenses/by/4.0/
-  label: CC-BY
+  label: CC BY 4.0
 activity_status: active
 repository: https://github.com/OOSTT/OOSTT
 preferredPrefix: OOSTT

--- a/ontology/opl.md
+++ b/ontology/opl.md
@@ -6,7 +6,7 @@ contact:
   label: Priti Parikh
 license:
   url: https://creativecommons.org/licenses/by/4.0/
-  label: CC-BY 4.0
+  label: CC BY 4.0
 description: A reference ontology for parasite life cycle stages.
 domain: life cycle stage, parasite organism
 homepage: https://github.com/OPL-ontology/OPL

--- a/ontology/opmi.md
+++ b/ontology/opmi.md
@@ -13,7 +13,7 @@ products:
   - id: opmi.owl
 license:
   url: http://creativecommons.org/licenses/by/4.0/
-  label: CC-BY
+  label: CC BY 4.0
 activity_status: active
 repository: https://github.com/OPMI/opmi
 preferredPrefix: OPMI

--- a/ontology/ornaseq.md
+++ b/ontology/ornaseq.md
@@ -13,7 +13,7 @@ products:
 tracker: https://github.com/safisher/ornaseq/issues
 license:
   url: http://creativecommons.org/licenses/by/4.0/
-  label: CC-BY
+  label: CC BY 4.0
 activity_status: active
 repository: https://github.com/safisher/ornaseq
 preferredPrefix: ORNASEQ

--- a/ontology/ovae.md
+++ b/ontology/ovae.md
@@ -12,7 +12,7 @@ products:
   - id: ovae.owl
 license:
   url: http://creativecommons.org/licenses/by/3.0/
-  label: CC-BY
+  label: CC BY 3.0
 activity_status: active
 repository: https://github.com/OVAE-Ontology/ovae
 preferredPrefix: OVAE

--- a/ontology/pato.md
+++ b/ontology/pato.md
@@ -23,7 +23,7 @@ browsers:
     url: https://bioportal.bioontology.org/ontologies/PATO
 license:
   url: http://creativecommons.org/licenses/by/3.0/
-  label: CC-BY
+  label: CC BY 3.0
 tracker: https://github.com/pato-ontology/pato/issues
 jobs:
   - id: https://travis-ci.org/pato-ontology/pato

--- a/ontology/pco.md
+++ b/ontology/pco.md
@@ -30,7 +30,7 @@ dependencies:
 tracker: https://github.com/PopulationAndCommunityOntology/pco/issues
 license:
   url: http://creativecommons.org/publicdomain/zero/1.0/
-  label: CC-0
+  label: CC0 1.0
 activity_status: active
 repository: https://github.com/PopulationAndCommunityOntology/pco
 preferredPrefix: PCO

--- a/ontology/pdumdv.md
+++ b/ontology/pdumdv.md
@@ -18,7 +18,7 @@ contact:
   email: bgee@sib.swiss
 license:
   url: http://creativecommons.org/licenses/by/3.0/
-  label: CC-BY
+  label: CC BY 3.0
 activity_status: active
 repository: https://github.com/obophenotype/developmental-stage-ontologies
 ---

--- a/ontology/peco.md
+++ b/ontology/peco.md
@@ -15,7 +15,7 @@ products:
 tracker: https://github.com/Planteome/plant-experimental-conditions-ontology/issues
 license:
   url: https://creativecommons.org/licenses/by/4.0/
-  label: CC-BY 4.0
+  label: CC BY 4.0
 publications:
   - id: https://doi.org/10.1093/nar/gkx1152
     title: "The Planteome database: an integrated resource for reference ontologies, plant genomics and phenomics."

--- a/ontology/phipo.md
+++ b/ontology/phipo.md
@@ -23,7 +23,7 @@ dependencies:
 tracker: https://github.com/PHI-base/phipo/issues
 license:
   url: http://creativecommons.org/licenses/by/3.0/
-  label: CC-BY
+  label: CC BY 3.0
 activity_status: active
 repository: https://github.com/PHI-base/phipo
 preferredPrefix: PHIPO

--- a/ontology/plana.md
+++ b/ontology/plana.md
@@ -30,7 +30,7 @@ usages:
 tracker: https://github.com/obophenotype/planaria-ontology/issues
 license:
   url: http://creativecommons.org/licenses/by/3.0/
-  label: CC-BY
+  label: CC BY 3.0
 activity_status: active
 repository: https://github.com/obophenotype/planaria-ontology
 preferredPrefix: PLANA

--- a/ontology/planp.md
+++ b/ontology/planp.md
@@ -26,7 +26,7 @@ dependencies:
 tracker: https://github.com/obophenotype/planarian-phenotype-ontology/issues
 license:
   url: http://creativecommons.org/licenses/by/3.0/
-  label: CC-BY
+  label: CC BY 3.0
 activity_status: active
 repository: https://github.com/obophenotype/planarian-phenotype-ontology
 preferredPrefix: PLANP

--- a/ontology/po.md
+++ b/ontology/po.md
@@ -40,7 +40,7 @@ browsers:
     url: http://browser.planteome.org/amigo
 license:
   url: https://creativecommons.org/licenses/by/4.0/
-  label: CC-BY 4.0
+  label: CC BY 4.0
 taxon:
   id: NCBITaxon:33090
   label: Viridiplantae

--- a/ontology/poro.md
+++ b/ontology/poro.md
@@ -15,7 +15,7 @@ taxon:
   label: Porifera
 license:
   url: http://creativecommons.org/licenses/by/3.0/
-  label: CC-BY
+  label: CC BY 3.0
 title: Porifera Ontology
 publications:
   - id: https://doi.org/10.1186/2041-1480-5-39

--- a/ontology/ppo.md
+++ b/ontology/ppo.md
@@ -12,7 +12,7 @@ mailing_list: ppo-discuss@googlegroups.com
 tracker: https://github.com/PlantPhenoOntology/PPO/issues
 license:
   url: http://creativecommons.org/licenses/by/3.0/
-  label: CC-BY
+  label: CC BY 3.0
 products:
   - id: ppo.owl
 taxon:

--- a/ontology/pr.md
+++ b/ontology/pr.md
@@ -30,7 +30,7 @@ review:
   date: 2010
 license:
   url: http://creativecommons.org/licenses/by/4.0/
-  label: CC-BY
+  label: CC BY 4.0
 depicted_by: https://raw.githubusercontent.com/PROconsortium/logo/master/PROlogo_small.png
 build:
   oort_args: --no-reasoner

--- a/ontology/psdo.md
+++ b/ontology/psdo.md
@@ -22,7 +22,7 @@ dependencies:
 tracker: https://github.com/Display-Lab/psdo/issues
 license:
   url: http://creativecommons.org/licenses/by/3.0/
-  label: CC-BY
+  label: CC BY 3.0
 activity_status: active
 repository: https://github.com/Display-Lab/psdo
 preferredPrefix: PSDO

--- a/ontology/pso.md
+++ b/ontology/pso.md
@@ -23,7 +23,7 @@ dependencies:
 tracker: https://github.com/Planteome/plant-stress-ontology/issues
 license:
   url: http://creativecommons.org/licenses/by/3.0/
-  label: CC-BY
+  label: CC BY 3.0
 activity_status: active
 repository: https://github.com/Planteome/plant-stress-ontology
 preferredPrefix: PSO

--- a/ontology/pw.md
+++ b/ontology/pw.md
@@ -6,7 +6,7 @@ contact:
   label: G. Thomas Hayman
 license:
   url: https://creativecommons.org/licenses/by/4.0/
-  label: CC-BY
+  label: CC BY 4.0
 description: A controlled vocabulary for annotating gene products to pathways.
 domain: biological process
 homepage: http://rgd.mcw.edu/rgdweb/ontology/search.html

--- a/ontology/rbo.md
+++ b/ontology/rbo.md
@@ -41,7 +41,7 @@ dependencies:
 tracker: https://github.com/Radiobiology-Informatics-Consortium/RBO/issues
 license:
   url: http://creativecommons.org/licenses/by/3.0/
-  label: CC-BY
+  label: CC BY 3.0
 activity_status: active
 repository: https://github.com/Radiobiology-Informatics-Consortium/RBO
 preferredPrefix: RBO

--- a/ontology/rnao.md
+++ b/ontology/rnao.md
@@ -6,7 +6,7 @@ contact:
   label: Colin Batchelor
 license:
   url: https://creativecommons.org/publicdomain/zero/1.0/
-  label: CC-0
+  label: CC0 1.0
 domain: molecular structure
 homepage: https://github.com/bgsu-rna/rnao
 browsers:

--- a/ontology/ro.md
+++ b/ontology/ro.md
@@ -49,7 +49,7 @@ products:
     page: http://bioinformatics.oxfordjournals.org/content/28/9/1262.long
 license:
   url: http://creativecommons.org/publicdomain/zero/1.0/
-  label: CC-0
+  label: CC0 1.0
 usages:
   - user: http://geneontology.org
     type: annotation

--- a/ontology/rs.md
+++ b/ontology/rs.md
@@ -6,7 +6,7 @@ contact:
   label: Shur-Jen Wang
 license:
   url: https://creativecommons.org/licenses/by/4.0/
-  label: CC-BY 4.0
+  label: CC BY 4.0
 description: Ontology of rat strains
 homepage: http://rgd.mcw.edu/rgdweb/search/strains.html
 tracker: https://github.com/rat-genome-database/RS-Rat-Strain-Ontology/issues

--- a/ontology/rxno.md
+++ b/ontology/rxno.md
@@ -6,7 +6,7 @@ contact:
   label: Colin Batchelor
 license:
   url: https://creativecommons.org/licenses/by/4.0/
-  label: CC-BY 4.0
+  label: CC BY 4.0
 mailing_list: "chemistry-ontologies@googlegroups.com"
 title: Name Reaction Ontology
 description: Connects organic name reactions to their roles in an organic synthesis and to processes in MOP

--- a/ontology/sepio.md
+++ b/ontology/sepio.md
@@ -11,7 +11,7 @@ contact:
   label: Matthew Brush
 license:
   url: https://creativecommons.org/licenses/by/3.0/
-  label: CC-BY
+  label: CC BY 3.0
 build:
   checkout: git clone https://github.com/monarch-initiative/SEPIO-ontology.git
   system: git

--- a/ontology/sibo.md
+++ b/ontology/sibo.md
@@ -14,7 +14,7 @@ products:
 title: Social Insect Behavior Ontology
 license:
   url: http://creativecommons.org/licenses/by/3.0/
-  label: CC-BY
+  label: CC BY 3.0
 build:
   checkout: git clone https://github.com/obophenotype/sibo.git
   system: git

--- a/ontology/so.md
+++ b/ontology/so.md
@@ -6,7 +6,7 @@ contact:
   label: Karen Eilbeck
 license:
   url: https://creativecommons.org/licenses/by/4.0/
-  label: CC-BY 4.0
+  label: CC BY 4.0
 description: A structured controlled vocabulary for sequence annotation, for the exchange of annotation data and for the description of sequence objects in databases.
 domain: biological sequence
 homepage: https://github.com/The-Sequence-Ontology/SO-Ontologies

--- a/ontology/spd.md
+++ b/ontology/spd.md
@@ -6,7 +6,7 @@ contact:
   label: Martin Ramirez
 license:
   url: https://creativecommons.org/licenses/by/3.0/
-  label: CC-BY 3.0
+  label: CC BY 3.0
 description: An ontology for spider comparative biology including anatomical parts (e.g. leg, claw), behavior (e.g. courtship, combing) and products (i.g. silk, web, borrow).
 domain: anatomy
 homepage: http://research.amnh.org/atol/files/

--- a/ontology/stato.md
+++ b/ontology/stato.md
@@ -13,7 +13,7 @@ products:
   - id: stato.owl
 license:
   url: http://creativecommons.org/licenses/by/3.0/
-  label: CC-BY
+  label: CC BY 3.0
 depicted_by: https://raw.githubusercontent.com/ISA-tools/stato/dev/images/stato-logo-3.png
 tracker: https://github.com/ISA-tools/stato/issues
 activity_status: active

--- a/ontology/symp.md
+++ b/ontology/symp.md
@@ -21,7 +21,7 @@ build:
 tracker: https://github.com/DiseaseOntology/SymptomOntology/issues
 license:
   url: https://creativecommons.org/publicdomain/zero/1.0/
-  label: CC0
+  label: CC0 1.0
 usages:
   - user: http://www.disease-ontology.org
     description: Symptoms of human diseases in the DO

--- a/ontology/tads.md
+++ b/ontology/tads.md
@@ -6,7 +6,7 @@ contact:
   label: Daniel Sonenshine
 license:
   url: https://creativecommons.org/licenses/by/4.0/
-  label: CC-BY 4.0
+  label: CC BY 4.0
 description: "The anatomy of the Tick, <i>Families: Ixodidae, Argassidae</i>"
 domain: anatomy
 homepage: https://www.vectorbase.org/ontology-browser

--- a/ontology/tao.md
+++ b/ontology/tao.md
@@ -15,7 +15,7 @@ taxon:
 title: Teleost Anatomy Ontology
 license:
   url: http://creativecommons.org/publicdomain/zero/1.0/
-  label: CC-0
+  label: CC0 1.0
 build:
   source_url: http://purl.obolibrary.org/obo/tao.obo
   method: obo2owl

--- a/ontology/taxrank.md
+++ b/ontology/taxrank.md
@@ -21,7 +21,7 @@ build:
 tracker: https://github.com/phenoscape/taxrank/issues
 license:
   url: http://creativecommons.org/publicdomain/zero/1.0/
-  label: CC-0
+  label: CC0 1.0
 activity_status: active
 repository: https://github.com/phenoscape/taxrank
 preferredPrefix: TAXRANK

--- a/ontology/tgma.md
+++ b/ontology/tgma.md
@@ -6,7 +6,7 @@ contact:
   label: Pantelis Topalis
 license:
   url: https://creativecommons.org/publicdomain/zero/1.0/
-  label: CC0
+  label: CC0 1.0
 description: A structured controlled vocabulary of the anatomy of mosquitoes.
 domain: anatomy
 homepage: https://www.vectorbase.org/ontology-browser

--- a/ontology/to.md
+++ b/ontology/to.md
@@ -13,7 +13,7 @@ products:
   - id: to.obo
 license:
   url: https://creativecommons.org/licenses/by/4.0/
-  label: CC-BY 4.0
+  label: CC BY 4.0
 taxon:
   id: NCBITaxon:33090
   label: Viridiplantae

--- a/ontology/trans.md
+++ b/ontology/trans.md
@@ -18,7 +18,7 @@ build:
 tracker: https://github.com/DiseaseOntology/PathogenTransmissionOntology/issues
 license:
   url: https://creativecommons.org/publicdomain/zero/1.0/
-  label: CC0
+  label: CC0 1.0
 usages:
   - user: http://www.disease-ontology.org
     description: Methods of trnasmission of human diseases in the DO

--- a/ontology/tto.md
+++ b/ontology/tto.md
@@ -16,7 +16,7 @@ taxon:
 title: Teleost taxonomy ontology
 license:
   url: http://creativecommons.org/publicdomain/zero/1.0/
-  label: CC-0
+  label: CC0 1.0
 tracker: https://github.com/phenoscape/teleost-taxonomy-ontology/issues
 activity_status: active
 repository: https://github.com/phenoscape/teleost-taxonomy-ontology

--- a/ontology/txpo.md
+++ b/ontology/txpo.md
@@ -13,7 +13,7 @@ products:
   - id: txpo.owl
 license:
   url: https://creativecommons.org/licenses/by/3.0/
-  label: CC-BY 3.0
+  label: CC BY 3.0
 title: Toxic Process Ontology
 # depicted_by: icon_url
 browsers:

--- a/ontology/uberon.md
+++ b/ontology/uberon.md
@@ -77,7 +77,7 @@ funded_by:
 canonical: uberon.owl
 license:
   url: http://creativecommons.org/licenses/by/3.0/
-  label: CC-BY
+  label: CC BY 3.0
 taxon:
   id: NCBITaxon:33208
   label: Metazoa

--- a/ontology/uo.md
+++ b/ontology/uo.md
@@ -13,7 +13,7 @@ products:
 title: Units of measurement ontology
 license:
   url: http://creativecommons.org/licenses/by/3.0/
-  label: CC-BY
+  label: CC BY 3.0
 build:
   source_url: https://raw.githubusercontent.com/bio-ontology-research-group/unit-ontology/master/unit.obo
   method: obo2owl

--- a/ontology/upa.md
+++ b/ontology/upa.md
@@ -28,7 +28,7 @@ dependencies:
 tracker: https://github.com/geneontology/unipathway/issues
 license:
   url: http://creativecommons.org/licenses/by/3.0/
-  label: CC-BY
+  label: CC BY 3.0
 repository: https://github.com/geneontology/unipathway
 ---
 

--- a/ontology/upheno.md
+++ b/ontology/upheno.md
@@ -7,7 +7,7 @@ homepage: https://github.com/obophenotype/upheno
 tracker: https://github.com/obophenotype/upheno/issues
 license:
   url: https://creativecommons.org/publicdomain/zero/1.0/
-  label: CC0
+  label: CC0 1.0
 contact:
   label: Nicole Vasilevsky
   email: vasilevs@ohsu.edu

--- a/ontology/vo.md
+++ b/ontology/vo.md
@@ -15,7 +15,7 @@ build:
   source_url: https://raw.githubusercontent.com/vaccineontology/VO/master/src/VO_merged.owl
 license:
   url: http://creativecommons.org/licenses/by/3.0/
-  label: CC-BY
+  label: CC BY 3.0
 activity_status: active
 repository: https://github.com/vaccineontology/VO
 preferredPrefix: VO

--- a/ontology/vto.md
+++ b/ontology/vto.md
@@ -16,7 +16,7 @@ contact:
   email: balhoff@renci.org
 license:
   url: http://creativecommons.org/publicdomain/zero/1.0/
-  label: CC-0
+  label: CC0 1.0
 usages:
   - user: http://phenoscape.org
     description: Phenoscape uses VTO to annotate systematics data

--- a/ontology/wbbt.md
+++ b/ontology/wbbt.md
@@ -7,7 +7,7 @@ contact:
   label: Raymond Lee
 license:
   url: https://creativecommons.org/licenses/by/4.0/
-  label: CC-BY 4.0
+  label: CC BY 4.0
 description: A structured controlled vocabulary of the anatomy of <i>Caenorhabditis elegans</i>.
 domain: anatomy
 homepage: https://github.com/obophenotype/c-elegans-gross-anatomy-ontology

--- a/ontology/xao.md
+++ b/ontology/xao.md
@@ -36,7 +36,7 @@ usages:
         description: Xenopus genes expressed in the pronephric kidney.
 license:
   url: http://creativecommons.org/licenses/by/3.0/
-  label: CC-BY
+  label: CC BY 3.0
 activity_status: active
 repository: https://github.com/xenopus-anatomy/xao
 preferredPrefix: XAO

--- a/ontology/xco.md
+++ b/ontology/xco.md
@@ -5,7 +5,7 @@ contact:
   label: Jennifer Smith
 license:
   url: https://creativecommons.org/publicdomain/zero/1.0/
-  label: CC-0
+  label: CC0 1.0
 description: Conditions under which physiological and morphological measurements are made both in the clinic and in studies involving humans or model organisms.
 domain: clinical
 homepage: https://rgd.mcw.edu/rgdweb/ontology/view.html?acc_id=XCO:0000000

--- a/ontology/xlmod.md
+++ b/ontology/xlmod.md
@@ -18,7 +18,7 @@ products:
   - id: xlmod.obo
 license:
   url: https://creativecommons.org/licenses/by/3.0/
-  label: CC-BY
+  label: CC BY 3.0
 build:
   source_url: https://raw.githubusercontent.com/HUPO-PSI/mzIdentML/master/cv/XLMOD.obo
   method: obo2owl

--- a/ontology/xpo.md
+++ b/ontology/xpo.md
@@ -34,7 +34,7 @@ dependencies:
 tracker: https://github.com/obophenotype/xenopus-phenotype-ontology/issues
 license:
   url: http://creativecommons.org/licenses/by/3.0/
-  label: CC-BY
+  label: CC BY 3.0
 activity_status: active
 repository: https://github.com/obophenotype/xenopus-phenotype-ontology
 preferredPrefix: XPO

--- a/ontology/zeco.md
+++ b/ontology/zeco.md
@@ -17,7 +17,7 @@ taxon:
   label: Danio
 license:
   url: http://creativecommons.org/licenses/by/3.0/
-  label: CC-BY
+  label: CC BY 3.0
 build:
   source_url: https://raw.githubusercontent.com/ybradford/zebrafish-experimental-conditions-ontology/master/zeco.obo
   method: obo2owl

--- a/ontology/zfa.md
+++ b/ontology/zfa.md
@@ -20,7 +20,7 @@ review:
   date: 2010
 license:
   url: http://creativecommons.org/licenses/by/3.0/
-  label: CC-BY
+  label: CC BY 3.0
 build:
   notes: may be ready to switch to vcs soon
   source_url: https://raw.githubusercontent.com/cerivs/zebrafish-anatomical-ontology/master/src/zebrafish_anatomy.obo

--- a/ontology/zfs.md
+++ b/ontology/zfs.md
@@ -19,7 +19,7 @@ taxon:
 title: Zebrafish developmental stages ontology
 license:
   url: http://creativecommons.org/licenses/by/3.0/
-  label: CC-BY 3.0
+  label: CC BY 3.0
 build:
   source_url: https://raw.githubusercontent.com/obophenotype/developmental-stage-ontologies/master/src/zfs/zfs.obo
   method: obo2owl

--- a/ontology/zp.md
+++ b/ontology/zp.md
@@ -29,7 +29,7 @@ dependencies:
 tracker: https://github.com/obophenotype/zebrafish-phenotype-ontology/issues
 license:
   url: http://creativecommons.org/licenses/by/3.0/
-  label: CC-BY
+  label: CC BY 3.0
 usages:
   - user: https://monarchinitiative.org/
     type: annotation

--- a/util/schema/registry_schema.json
+++ b/util/schema/registry_schema.json
@@ -212,8 +212,7 @@
 						},
 						"label": {
 							"enum": [
-								"CC BY 4.0",
-								"CC-BY 4.0"
+								"CC BY 4.0"
 							]
 						}
 					}
@@ -228,9 +227,6 @@
 						},
 						"label": {
 							"enum": [
-								"CC-0",
-								"CC0",
-								"CC0 1.0 Universal",
 								"CC0 1.0"
 							]
 						}
@@ -246,7 +242,6 @@
 						},
 						"label": {
 							"enum": [
-								"CC-BY 3.0",
 								"CC BY 3.0"
 							]
 						}
@@ -292,8 +287,7 @@
 						},
 						"label": {
 							"enum": [
-								"CC BY 2.0",
-								"CC-BY 2.0"
+								"CC BY 2.0"
 							]
 						}
 					}
@@ -428,8 +422,8 @@
 					"description": {"type":"string"},
 					"seeAlso": {
                                                 "description": "secondary link to the user, such as a FAIR Sharing entry",
-						"type": "string", 
-						"format": "uri" 
+						"type": "string",
+						"format": "uri"
 						},
         				"examples": {
 						"description": "specific page showing how the ontology is used by that user/resource",
@@ -454,7 +448,7 @@
 							"type": "object",
 							"additionalProperties" : false,
 							"properties": {
-								"id": { 
+								"id": {
 									"type": "string",
 									"format": "uri"
 								},
@@ -462,7 +456,7 @@
 							},
 							"required": ["id", "title"]
 						}
-					}  
+					}
       				},
       				"required": ["user", "description"]
 			}

--- a/util/schema/registry_schema.json
+++ b/util/schema/registry_schema.json
@@ -212,7 +212,6 @@
 						},
 						"label": {
 							"enum": [
-								"CC-BY",
 								"CC BY 4.0",
 								"CC-BY 4.0"
 							]
@@ -247,7 +246,6 @@
 						},
 						"label": {
 							"enum": [
-								"CC-BY",
 								"CC-BY 3.0",
 								"CC BY 3.0"
 							]
@@ -279,7 +277,6 @@
 						},
 						"label": {
 							"enum": [
-								"CC-BY-SA",
 								"CC BY-SA 2.0"
 							]
 						}
@@ -295,7 +292,6 @@
 						},
 						"label": {
 							"enum": [
-								"CC-BY",
 								"CC BY 2.0",
 								"CC-BY 2.0"
 							]

--- a/util/standardize_license_labels.py
+++ b/util/standardize_license_labels.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-"""
+"""Standardize the license labels using the Bioregistry.
 
 Run with: ``python standardize_license_labels.py``.
 

--- a/util/standardize_license_labels.py
+++ b/util/standardize_license_labels.py
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*-
+
+"""
+
+Run with: ``python standardize_license_labels.py``.
+
+Author: `Charles Tapley Hoyt <https://cthoyt.com>`_.
+"""
+
+import pathlib
+from typing import Union
+
+import click
+from bioregistry.license_standardizer import LICENSES
+from tqdm import tqdm
+
+HERE = pathlib.Path(__file__).parent.resolve()
+ONTOLOGY_DIRECTORY = HERE.parent.joinpath("ontology").resolve()
+
+
+def update_markdown(path: Union[str, pathlib.Path]) -> None:
+    """Update the given markdown file."""
+    with open(path) as file:
+        lines = [line.rstrip("\n") for line in file]
+
+    try:
+        idx = min(i for i, line in enumerate(lines) if line.startswith("license:"))
+    except ValueError:
+        tqdm.write(f"no license in {path}")
+        return
+
+    license_url = None
+    for i in range(1, 3):
+        line = lines[idx + i].strip()
+        if "url:" in line:
+            _, license_url = line.split(':', 1)
+
+    if license_url is None:
+        tqdm.write(f"no license URL in {path}")
+        return
+
+    new_label = LICENSES.get(license_url.strip())
+    if new_label is None:
+        tqdm.write(f"could not standardize license URL {license_url} in {path}")
+        return
+
+    license_label, license_label_idx = None, None
+    for i in range(1, 3):
+        line = lines[idx + i].strip()
+        if "label:" in line:
+            license_label_idx = idx + i
+            _, license_label = line.split(":", 1)
+
+    if license_label.replace("-", "") == new_label.replace("-", ""):
+        return
+
+    if license_label_idx is None:
+        tqdm.write(f"no license label in {path}")
+        return
+
+    with open(path, "w") as file:
+        for i, line in enumerate(lines):
+            if i == license_label_idx:
+                print(f"  label: {new_label}", file=file)
+            else:
+                print(line, file=file)
+
+
+@click.command()
+def main():
+    for path in ONTOLOGY_DIRECTORY.glob("*.md"):
+        update_markdown(path)
+
+
+if __name__ == "__main__":
+    main()

--- a/util/standardize_license_labels.py
+++ b/util/standardize_license_labels.py
@@ -26,7 +26,7 @@ def update_markdown(path: Union[str, pathlib.Path]) -> None:
     try:
         idx = min(i for i, line in enumerate(lines) if line.startswith("license:"))
     except ValueError:
-        tqdm.write(f"no license in {path}")
+        # no license
         return
 
     license_url = None


### PR DESCRIPTION
Closes #1638. This PR does the following:

1. Introduces a script to standardize license labels
2. Applies standardization to all licenses based on the URLs given
3. Updates the registry schema to not allow unversioned licenses