### PR TITLE
Update contact information for ARO to conform with FP11

### DIFF
--- a/ontology/aro.md
+++ b/ontology/aro.md
@@ -2,8 +2,8 @@
 layout: ontology_detail
 id: aro
 contact:
-  email: card@mcmaster.ca
-  label: CARD
+  email: raphenar@mcmaster.ca
+  label: Amogelang Raphenya
   github: raphenya
 description: Antibiotic resistance genes and mutations
 homepage: https://github.com/arpcard/aro

--- a/ontology/aro.md
+++ b/ontology/aro.md
@@ -2,9 +2,9 @@
 layout: ontology_detail
 id: aro
 contact:
-  email: raphenar@mcmaster.ca
-  label: Amogelang Raphenya
-  github: raphenya
+  email: mcarthua@mcmaster.ca
+  label: Andrew G. McArthur
+  github: agmcarthur
 description: Antibiotic resistance genes and mutations
 homepage: https://github.com/arpcard/aro
 license:


### PR DESCRIPTION
Currently, ARO violates FP11 (http://www.obofoundry.org/principles/fp-011-locus-of-authority.html) (based on my interpretation of it) because it uses a group email instead of denoting the single responsible person.

I've found the information for @raphenya via one of [his publications](https://www.mdpi.com/1999-4915/12/8/895) that lists his email address and added it as the contact information here. However, it appears Amogelang is a graduate student and might not be the ideal choice for a long term responsible contact person for the ontology. An alternative could be the corresponding author on ARO's [most recent publication](https://pubmed.ncbi.nlm.nih.gov/31665441/), Andrew G McArthur (@agmcarthur, mcarthua@mcmaster.ca).

Hopefully both of them can get in touch here and let us know how to proceed.