### PR TITLE
Update Bgee contact information to conform with FP11

### DIFF
--- a/ontology/cio.md
+++ b/ontology/cio.md
@@ -2,8 +2,8 @@
 layout: ontology_detail
 id: cio
 contact:
-  email: bgee@sib.swiss
-  label: Frederic Bastian
+  label: Frédéric Bastian
+  email: frederic.bastian@unil.ch
   github: fbastian
 license:
   url: https://creativecommons.org/publicdomain/zero/1.0/

--- a/ontology/hsapdv.md
+++ b/ontology/hsapdv.md
@@ -12,8 +12,9 @@ homepage: https://github.com/obophenotype/developmental-stage-ontologies/wiki/Hs
 tracker: https://github.com/obophenotype/developmental-stage-ontologies/issues
 page: https://github.com/obophenotype/developmental-stage-ontologies
 contact:
-  label: bgee
-  email: bgee@sib.swiss
+  label: Frédéric Bastian
+  email: frederic.bastian@unil.ch
+  github: fbastian
 license:
   url: http://creativecommons.org/licenses/by/3.0/
   label: CC BY 3.0

--- a/ontology/mmusdv.md
+++ b/ontology/mmusdv.md
@@ -11,8 +11,9 @@ homepage: https://github.com/obophenotype/developmental-stage-ontologies/wiki/Mm
 tracker: https://github.com/obophenotype/developmental-stage-ontologies/issues
 page: https://github.com/obophenotype/developmental-stage-ontologies
 contact:
-  label: bgee
-  email: bgee@sib.swiss
+  label: Frédéric Bastian
+  email: frederic.bastian@unil.ch
+  github: fbastian
 license:
   url: http://creativecommons.org/licenses/by/3.0/
   label: CC BY 3.0

--- a/ontology/olatdv.md
+++ b/ontology/olatdv.md
@@ -14,8 +14,9 @@ products:
   - id: olatdv.obo
   - id: olatdv.owl
 contact:
-  label: bgee
-  email: bgee@sib.swiss
+  label: Frédéric Bastian
+  email: frederic.bastian@unil.ch
+  github: fbastian
 license:
   url: http://creativecommons.org/licenses/by/3.0/
   label: CC BY 3.0

--- a/ontology/pdumdv.md
+++ b/ontology/pdumdv.md
@@ -14,8 +14,9 @@ products:
   - id: pdumdv.owl
   - id: pdumdv.obo
 contact:
-  label: bgee
-  email: bgee@sib.swiss
+  label: Frédéric Bastian
+  email: frederic.bastian@unil.ch
+  github: fbastian
 license:
   url: http://creativecommons.org/licenses/by/3.0/
   label: CC BY 3.0


### PR DESCRIPTION
All of the Bgee resources are in violation of FP11 by listing a group email address instead of a single responsible person (similarly to #1643).

This PR switches that to Frédéric Bastian (@fbastian), the first and corresponding author on the [most recent Bgee publication](https://academic.oup.com/nar/article/49/D1/D831/5920517).