### PR TITLE
Update contact information for KiSAO to conform with FP11

### DIFF
--- a/ontology/kisao.md
+++ b/ontology/kisao.md
@@ -2,8 +2,9 @@
 layout: ontology_detail
 id: kisao
 contact:
-  email: sed-ml-editors@googlegroups.com
-  label: SED-ML Editors
+  email: karr@mssm.edu
+  label: Jonathan Karr 
+  github: jonrkarr
 description: A classification of algorithms for simulating biology and their outputs
 domain: algorithms
 homepage: http://co.mbine.org/standards/kisao

--- a/ontology/kisao.md
+++ b/ontology/kisao.md
@@ -3,7 +3,7 @@ layout: ontology_detail
 id: kisao
 contact:
   email: karr@mssm.edu
-  label: Jonathan Karr 
+  label: Jonathan Karr
   github: jonrkarr
 description: A classification of algorithms for simulating biology and their outputs
 domain: algorithms


### PR DESCRIPTION
Currently, KiSAO violates FP11 (http://www.obofoundry.org/principles/fp-011-locus-of-authority.html) (based on my interpretation of it) because it uses a group email instead of denoting the single responsible person.

It appears from the [GitHub repository](https://github.com/SED-ML/KiSAO/) that @jonrkarr, @luciansmith, and @matthiaskoenig are the active contributors to the project, with Jonathan seeming to be the most responsible.

I've pulled his institutional email from his GitHub profile and updated the KiSAO metadata to denote him as the responsible person. If Matthias or Lucian were better choices, please let me know and I will update this PR accordingly.

Hopefully they will get in touch here and let us know how to proceed.