### PR TITLE
Add a GitHub Action to automatically rebuild files

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,35 @@
+name: Build derived files
+on:
+  # Allows for on-demand build
+  workflow_dispatch:
+  # Automatically rebuilds when somebody edits a markdown file in
+  # the ontology/ directory
+  push:
+    branches:
+      - master
+    paths:
+      - 'ontology/*.md'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container: obolibrary/odkfull:v1.2.30
+    steps:
+      - uses: actions/checkout@master
+        with:
+          persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN, instead of your personal token
+          fetch-depth: 0 # otherwise, you will failed to push refs to dest repo
+      - name: Create local changes
+        run: |
+          python -m pip install -r requirements.txt
+          make
+      - name: Commit files
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git commit -m "🚀 Automatically rebuilt derived files" -a
+      - name: Push changes
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ github.ref }}


### PR DESCRIPTION
Closes #1224

This PR adds a new GitHub Action configuration, `build.yml` that does the following things:

1. Installs ODK container
2. Installs the Python requirements from this repository's `requirements.txt` 
3. Runs `make`
4. Commits/pushes the result back to the `master` branch

It automatically runs any time a markdown file is changed in the `ontology/` folder on the master branch. This means that there's no longer a need for a second set of discussions, PRs, etc. every time a metadata file is updated. In theory, the build process is automated and does not itself need review. This also has the added benefit that potential contributors can see their updates incorporated much faster.

This action can also be run on demand, in case some of the tooling changes and you don't want to wait for the next change to a markdown file.

You can see the workflow in action at https://github.com/cthoyt/OBOFoundry.github.io/runs/4226590920?check_suite_focus=true and see the resulting commit it made in https://github.com/cthoyt/OBOFoundry.github.io/commit/663461070fb5889be058863069530e05251d3419. Note it's a pretty boring commit due to the fact that no markdown files were changed. Unfortunately, the RDF dump is not deterministic so this is actually a completely spurious diff. Either way, it demonstrates that everything runs properly.