### PR TITLE
Add new tests

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,27 @@
+#########################
+# Flake8 Configuration  #
+# (.flake8)             #
+#########################
+[flake8]
+ignore =
+    E203
+    W503
+exclude =
+    .tox,
+    .git,
+    __pycache__,
+    docs/source/conf.py,
+    build,
+    dist,
+    tests/fixtures/*,
+    *.pyc,
+    *.egg-info,
+    .cache,
+    .eggs,
+    data
+max-line-length = 120
+max-complexity = 20
+import-order-style = pycharm
+application-import-names =
+    tests
+format = ${cyan}%(path)s${reset}:${yellow_bold}%(row)d${reset}:${green_bold}%(col)d${reset}: ${red_bold}%(code)s${reset} %(text)s

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,39 @@
+name: Tests
+
+on: [ push, pull_request ]
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [ "3.8" ]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          pip install tox
+      - name: Check code quality with flake8
+        run: tox -e flake8
+  tests:
+    name: Tests
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ ubuntu-latest ]
+        python-version: [ "3.8" ]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: pip install tox
+      - name: Run tests
+        run: tox -e py

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ build/
 .jekyll-cache/
 .DS_Store
 /_site
+.tox
+*.pyc

--- a/ontology/epso.md
+++ b/ontology/epso.md
@@ -5,6 +5,9 @@ label: Epilepsy Ontology
 title: Epilepsy Ontology
 description: A application driven Epilepsy Ontology sith official terms from the ILAE.
 domain: disease
+license:
+  url: http://creativecommons.org/licenses/by/4.0/
+  label: CC BY 4.0
 tracker: https://github.com/phwegner/Epilepsyontology/issues
 dependencies:
   - id: BFO

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,8 @@
+[tool.black]
+target-version = ["py38", "py39"]
+
+[tool.isort]
+profile = "black"
+multi_line_output = 3
+include_trailing_comma = true
+reverse_relative = true

--- a/tests/test_integrity.py
+++ b/tests/test_integrity.py
@@ -1,0 +1,97 @@
+# -*- coding: utf-8 -*-
+
+"""Unit tests for metadata integrity.
+
+Run from the root of the repository using ``tox`` with:
+
+.. code-block:: sh
+
+    $ pip install tox
+    $ tox
+"""
+
+import json
+import os
+import unittest
+from io import StringIO
+from pathlib import Path
+from typing import Union
+
+import yaml
+
+HERE = Path(__file__).parent.resolve()
+ROOT = HERE.parent.resolve()
+
+SCHEMA_PATH = ROOT.joinpath("util", "schema", "registry_schema.json")
+SCHEMA = json.loads(SCHEMA_PATH.read_text())
+
+#: These are the valid licenses listed in the registry schema file
+VALID_LICENSE_LABELS = {
+    value
+    for entry in SCHEMA["properties"]["license"]["anyOf"]
+    for value in entry["properties"]["label"]["enum"]
+}
+VALID_LICENSE_URLS = {
+    value
+    for entry in SCHEMA["properties"]["license"]["anyOf"]
+    for value in entry["properties"]["url"]["enum"]
+}
+#: These ontologies have invalid licenses, but they're grandfathered in
+LEGACY_LICENSE_PREFIXES = {
+    "GSSO",
+    "HP",
+    "KISAO",
+    "MAMO",
+    "SBO",
+    "SCDO",
+    "TXPO",
+}
+
+
+def load_all():
+    """Load all metadata files in a dictionary from lowercased OBO Foundry IDs to metadata."""
+    rv = {}
+    for path in ROOT.joinpath("ontology").glob("*.md"):
+        data = load(path)
+        rv[data["id"]] = data
+    return rv
+
+
+def load(path: Union[str, os.PathLike]):
+    """Load metadata from a single markdown file."""
+    with open(path) as file:
+        lines = [line.rstrip("\n") for line in file]
+    idx = min(i for i, line in enumerate(lines[1:], start=1) if line == "---")
+    return yaml.safe_load(StringIO("\n".join(lines[1:idx])))
+
+
+class TestIntegrity(unittest.TestCase):
+    """A test case for checking metadata integrity."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Set up the test case by loading metadata for various tests."""
+        cls.metadata = load_all()
+
+    def test_license(self):
+        """Test that licenses are present and valid, based on the JSON schema.
+
+        - Ontologies marked as obsolete, orphaned, and inactive are skipped.
+        - Ontologies that had invalid licenses at the time of writing the test are skipped.
+          Future ontologies should conform to this based on OBO Foundry's
+          `openness principle <http://www.obofoundry.org/principles/fp-001-open.html>`_.
+        """
+        for prefix, data in self.metadata.items():
+            if data.get("is_obsolete") or data.get("activity_status") in {
+                "orphaned",
+                "inactive",
+            }:
+                continue
+            if prefix.upper() in LEGACY_LICENSE_PREFIXES:
+                continue
+            with self.subTest(prefix=prefix):
+                self.assertIn("license", set(data), msg=f"Failed on {prefix}")
+                self.assertIn("label", data["license"])
+                self.assertIn(data["license"]["label"], VALID_LICENSE_LABELS)
+                self.assertIn("url", data["license"])
+                self.assertIn(data["license"]["url"], VALID_LICENSE_URLS)

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,44 @@
+# Tox (http://tox.testrun.org/) is a tool for running tests
+# in multiple virtualenvs. This configuration file will run the
+# test suite on all supported python versions. To use it, "pip install tox"
+# and then run "tox" from this directory.
+
+[tox]
+envlist =
+    lint
+    flake8
+    py
+
+[testenv]
+commands = pytest {posargs:tests}
+skip_install = true
+deps =
+    pytest
+    pyyaml
+
+[testenv:lint]
+deps =
+    black
+    isort
+skip_install = true
+commands =
+    black tests/
+    isort tests/
+description = Run linters.
+
+[testenv:flake8]
+skip_install = true
+deps =
+    flake8<4.0.0
+    flake8-bandit
+    flake8-black
+    flake8-bugbear
+    flake8-colors
+    flake8-docstrings
+    flake8-isort
+    flake8-print
+    pep8-naming
+    pydocstyle
+commands =
+    flake8 tests/
+description = Run the flake8 tool with several plugins (bandit, docstrings, import order, pep8 naming).


### PR DESCRIPTION
The old tests in the OBO Foundry have a lot to be desired, from both the maintainability, correctness, and utility perspectives. For example, even though the [openness principle (FP-001)](http://www.obofoundry.org/principles/fp-001-open.html) requires both that a license is given and that it is labeled as either `CC BY 3.0`, `CC BY 4.0`, or `CC0 1.0`. The current tests run by make test gives some logging, but it does not act as a testing framework and signal CI to fail. This issue just became apparent when #1646 was accidentally merged without license information, requiring a new PR #1660. Since all reviews require precious time, automating as much of it as possible seems paramount.

This PR adds a new python module containing a single test in a new file (`tests/test_integrity.py`) with an accompanying new CI workflow that addresses this issue as a demonstration. It includes several additional configurations for assessing the code quality of this file and any future python modules put in `tests/` that are run in CI as well in order to support keeping this code high quality and maintainable.

This PR does not change any of the old test suite nor duplicate any of its functionality.

## Details

| File | Purpose |
|-----|----------|
| `tox.ini` | It's the more python-specific version of `make`. It's much more streamlined, readable, and easy to add things to. This specific file has configurations for automatic formatting (i.e., applying `black` and `isort`), for running linting (i.e., `flake8`), and running the tests in the `tests/` directory inside inside their own virtual environments, while also taking care of installation of the necessary dependencies |
| `.flake8` | Configuration for the flake8 linter |
| `pyproject.toml` | Configuration for black and isort. |
| `.github/workflows/tests.yml` | An additional GitHub Actions configuration that runs in parallel with the old tests - it runs each of the things mentioned in the `tox.ini` file |
| `tests/test_integrity.py` | A Python module implementing unit tests using a first-class unit testing framework (i.e., `unittests`). Specifically, it enforces licenses conform to the registry schema. It only has a single dependency (for now) that is automatically installed with tox. It can be run with `tox -e py` from the root. |