### PR TITLE
🎅 Update repo metadata 

### DIFF
--- a/ontology/aism.md
+++ b/ontology/aism.md
@@ -8,7 +8,7 @@ build:
   path: "."
 contact:
   email: entiminae@gmail.com
-  label: Jennifer C. Girón
+  label: Jennifer C. Giron
   github: JCGiron
 description: The AISM contains terms used in insect biodiversity research for describing structures of the exoskeleton and the skeletomuscular system. It aims to serve as the basic backbone of generalized terms to be expanded with order-specific terminology.
 domain: anatomy

--- a/ontology/aism.md
+++ b/ontology/aism.md
@@ -8,7 +8,7 @@ build:
   path: "."
 contact:
   email: entiminae@gmail.com
-  label: Jennifer C. Giron
+  label: Jennifer C. Girón
   github: JCGiron
 description: The AISM contains terms used in insect biodiversity research for describing structures of the exoskeleton and the skeletomuscular system. It aims to serve as the basic backbone of generalized terms to be expanded with order-specific terminology.
 domain: anatomy

--- a/ontology/aism.md
+++ b/ontology/aism.md
@@ -9,6 +9,7 @@ build:
 contact:
   email: entiminae@gmail.com
   label: Jennifer C. Girón
+  github: JCGiron
 description: The AISM contains terms used in insect biodiversity research for describing structures of the exoskeleton and the skeletomuscular system. It aims to serve as the basic backbone of generalized terms to be expanded with order-specific terminology.
 domain: anatomy
 homepage: https://github.com/insect-morphology/aism

--- a/ontology/amphx.md
+++ b/ontology/amphx.md
@@ -9,6 +9,7 @@ build:
 contact:
   email: hescriva@obs-banyuls.fr
   label: Hector Escriva
+  github: hescriva
 description: An ontology for the development and anatomy of Amphioxus (Branchiostoma lanceolatum).
 domain: anatomy
 homepage: https://github.com/EBISPOT/amphx_ontology

--- a/ontology/apollo_sv.md
+++ b/ontology/apollo_sv.md
@@ -4,6 +4,7 @@ id: apollo_sv
 contact:
   email: MBrochhausen@uams.edu
   label: Mathias Brochhausen
+  github: mbrochhausen
 homepage: https://github.com/ApolloDev/apollo-sv
 description: Defines terms and relations necessary for interoperation between epidemic models and public health application software that interface with these models
 products:

--- a/ontology/bco.md
+++ b/ontology/bco.md
@@ -11,13 +11,13 @@ license:
   label: CC0 1.0
 description: An ontology to support the interoperability of biodiversity data, including data on museum collections, environmental/metagenomic samples, and ecological surveys.
 domain: biodiversity collections
-homepage: https://github.com/tucotuco/bco
+homepage: https://github.com/BiodiversityOntologies/bco
 products:
   - id: bco.owl
 title: Biological Collections Ontology
-tracker: https://github.com/tucotuco/bco/issues
+tracker: https://github.com/BiodiversityOntologies/bco/issues
 activity_status: active
-repository: https://github.com/tucotuco/bco
+repository: https://github.com/BiodiversityOntologies/bco/bco
 preferredPrefix: BCO
 ---
 

--- a/ontology/bco.md
+++ b/ontology/bco.md
@@ -17,7 +17,7 @@ products:
 title: Biological Collections Ontology
 tracker: https://github.com/BiodiversityOntologies/bco/issues
 activity_status: active
-repository: https://github.com/BiodiversityOntologies/bco/bco
+repository: https://github.com/BiodiversityOntologies/bco
 preferredPrefix: BCO
 ---
 

--- a/ontology/clo.md
+++ b/ontology/clo.md
@@ -4,6 +4,7 @@ id: clo
 contact:
   email: siiraa@umich.edu
   label: Sirarat Sarntivijai
+  github: siiraa
 description: An ontology to standardize and integrate cell line information and to support computer-assisted reasoning.
 homepage: http://www.clo-ontology.org
 products:

--- a/ontology/cmo.md
+++ b/ontology/cmo.md
@@ -4,6 +4,7 @@ id: cmo
 contact:
   email: shimoyama@mcw.edu
   label: Mary Shimoyama
+  github: maryshimoyama
 license:
   url: http://creativecommons.org/publicdomain/zero/1.0/
   label: CC0 1.0

--- a/ontology/colao.md
+++ b/ontology/colao.md
@@ -4,7 +4,7 @@ id: colao
 title: "Coleoptera Anatomy Ontology (COLAO)"
 contact:
   email: entiminae@gmail.com
-  label: Jennifer C. Girón
+  label: Jennifer C. Giron
   github: JCGiron
 description: "The Coleoptera Anatomy Ontology contains terms used for describing the anatomy and phenotype of beetles in biodiversity research. It has been built using the Ontology Develoment Kit, with the Ontology for the Anatomy of the Insect Skeleto-Muscular system (AISM) as a backbone."
 domain: Insect Anatomy.

--- a/ontology/colao.md
+++ b/ontology/colao.md
@@ -4,7 +4,7 @@ id: colao
 title: "Coleoptera Anatomy Ontology (COLAO)"
 contact:
   email: entiminae@gmail.com
-  label: Jennifer C. Giron
+  label: Jennifer C. Girón
   github: JCGiron
 description: "The Coleoptera Anatomy Ontology contains terms used for describing the anatomy and phenotype of beetles in biodiversity research. It has been built using the Ontology Develoment Kit, with the Ontology for the Anatomy of the Insect Skeleto-Muscular system (AISM) as a backbone."
 domain: Insect Anatomy.

--- a/ontology/cvdo.md
+++ b/ontology/cvdo.md
@@ -4,6 +4,7 @@ id: cvdo
 contact:
   email: paul.fabry@usherbrooke.ca
   label: Paul Fabry
+  github: pfabry
 license:
   url: https://creativecommons.org/licenses/by/4.0/
   label: CC BY 4.0

--- a/ontology/eo.md
+++ b/ontology/eo.md
@@ -8,6 +8,7 @@ build:
 contact:
   email: jaiswalp@science.oregonstate.edu
   label: Pankaj Jaiswal
+  github: jaiswalp
 description: A structured, controlled vocabulary which describes the treatments, growing conditions, and/or study types used in plant biology experiments.
 domain: environment
 homepage: http://planteome.org/

--- a/ontology/fbbi.md
+++ b/ontology/fbbi.md
@@ -3,7 +3,7 @@ layout: ontology_detail
 id: fbbi
 preferredPrefix: FBbi
 contact:
-  email: wawong@gmail.com  
+  email: wawong@gmail.com
   label: Willy Wong
   github: wawong
 license:

--- a/ontology/fbbi.md
+++ b/ontology/fbbi.md
@@ -3,9 +3,9 @@ layout: ontology_detail
 id: fbbi
 preferredPrefix: FBbi
 contact:
-  email: dorloff@ncmir.ucsd.edu
-  label: David Orloff
-  github: orloff18
+  email: wawong@gmail.com  
+  label: Willy Wong
+  github: wawong
 license:
   url: https://creativecommons.org/licenses/by/4.0/
   label: CC BY 4.0

--- a/ontology/fbbi.md
+++ b/ontology/fbbi.md
@@ -5,6 +5,7 @@ preferredPrefix: FBbi
 contact:
   email: dorloff@ncmir.ucsd.edu
   label: David Orloff
+  github: orloff18
 license:
   url: https://creativecommons.org/licenses/by/4.0/
   label: CC BY 4.0

--- a/ontology/fbbt.md
+++ b/ontology/fbbt.md
@@ -9,6 +9,7 @@ contact:
 description: An ontology representing the gross anatomy of Drosophila melanogaster.
 domain: Drosophilid anatomy
 homepage: http://purl.obolibrary.org/obo/fbbt
+repository: https://github.com/FlyBase/drosophila-anatomy-developmental-ontology
 products:
   - id: fbbt.owl
   - id: fbbt.obo

--- a/ontology/fbdv.md
+++ b/ontology/fbdv.md
@@ -9,6 +9,7 @@ contact:
 description: A structured controlled vocabulary of the development of Drosophila melanogaster.
 domain: development
 homepage: http://purl.obolibrary.org/obo/fbdv
+repository: https://github.com/FlyBase/drosophila-developmental-ontology
 products:
   - id: fbdv.owl
   - id: fbdv.obo

--- a/ontology/fobi.md
+++ b/ontology/fobi.md
@@ -14,7 +14,7 @@ products:
   - id: fobi.owl
     title: FOBI is an ontology to represent food intake data and associate it with metabolomic data
     format: owl-rdf/xml
-title: FOBI
+title: Food-Biomarker Ontology
 dependencies:
   - id: chebi
   - id: foodon

--- a/ontology/fovt.md
+++ b/ontology/fovt.md
@@ -11,8 +11,8 @@ build:
   path: "."
 contact:
   email: rlwalls2008@gmail.com
-  label: FuTRES Ontology of Vertebrate Traits
-  github: https://github.com/futres/fovt
+  label: Ramona Walls
+  github: ramonawalls
 description: FuTRES Ontology of Vertebrate Traits is an application ontology used to convert vertebrate trait data in spreadsheet to triples. FOVT leverages the BioCollections Ontology (BCO) to link observations of individual specimens to their trait values. Traits are defined in the Ontology of Biological Attributes (OBA).
 domain: vertebrate traits
 homepage: https://github.com/futres/fovt

--- a/ontology/fovt.md
+++ b/ontology/fovt.md
@@ -10,9 +10,9 @@ build:
   system: git
   path: "."
 contact:
-  email: rlwalls2008@gmail.com
-  label: Ramona Walls
-  github: ramonawalls
+  email: meghan.balk@gmail.com
+  label: Meghan Balk
+  github: megbalk
 description: FuTRES Ontology of Vertebrate Traits is an application ontology used to convert vertebrate trait data in spreadsheet to triples. FOVT leverages the BioCollections Ontology (BCO) to link observations of individual specimens to their trait values. Traits are defined in the Ontology of Biological Attributes (OBA).
 domain: vertebrate traits
 homepage: https://github.com/futres/fovt

--- a/ontology/genepio.md
+++ b/ontology/genepio.md
@@ -4,6 +4,7 @@ id: genepio
 contact:
   email: damion_dooley@sfu.ca
   label: Damion Dooley
+  github: ddooley
 description: The Genomic Epidemiology Ontology (GenEpiO) covers vocabulary necessary to identify, document and research foodborne pathogens and associated outbreaks.
 domain: health
 homepage: http://genepio.org/

--- a/ontology/go.md
+++ b/ontology/go.md
@@ -5,6 +5,7 @@ in_foundry_order: 1
 contact:
   email: suzia@stanford.edu
   label: Suzi Aleksander
+  github: suzialeksander
 license:
   url: https://creativecommons.org/licenses/by/4.0/
   label: CC BY 4.0

--- a/ontology/hancestro.md
+++ b/ontology/hancestro.md
@@ -4,6 +4,7 @@ id: hancestro
 contact:
   email: danielle.welter@uni.lu
   label: Danielle Welter
+  github: daniwelter
 title: Human Ancestry Ontology
 description: The Human Ancestry Ontology (HANCESTRO) provides a systematic description of the ancestry concepts used in the NHGRI-EBI Catalog of published genome-wide association studies.
 homepage: https://github.com/EBISPOT/ancestro

--- a/ontology/htn.md
+++ b/ontology/htn.md
@@ -7,6 +7,7 @@ homepage: https://github.com/aellenhicks/htn_owl
 contact:
   label: Amanda Hicks
   email: aellenhicks@gmail.com
+  github: aellenhicks
 license:
   label: CC BY 4.0
   url: http://creativecommons.org/licenses/by/4.0/

--- a/ontology/iceo.md
+++ b/ontology/iceo.md
@@ -8,6 +8,7 @@ tracker: https://github.com/ontoice/ICEO/issues
 contact:
   email: liumeng94@sjtu.edu.cn
   label: Meng LIU
+  github: Lemon-Liu
 products:
   - id: iceo.owl
 license:

--- a/ontology/labo.md
+++ b/ontology/labo.md
@@ -5,6 +5,7 @@ title: clinical LABoratory Ontology
 contact:
   email: paul.fabry@usherbrooke.ca
   label: Paul Fabry
+  github: pfabry
 description: LABO is an ontology of informational entities formalizing clinical laboratory tests prescriptions and reporting documents.
 domain: clinical documentation
 usages:

--- a/ontology/mco.md
+++ b/ontology/mco.md
@@ -12,6 +12,7 @@ build:
 contact:
   email: citlalli.mejiaalmonte@gmail.com
   label: Citlalli Mejía-Almonte
+  github: citmejia
 description: Microbial Conditions Ontology is an ontology...
 domain: experimental conditions
 homepage: https://github.com/microbial-conditions-ontology/microbial-conditions-ontology

--- a/ontology/mfomd.md
+++ b/ontology/mfomd.md
@@ -4,6 +4,7 @@ id: mfomd
 contact:
   email: janna.hastings@gmail.com
   label: Janna Hastings
+  github: jannahastings
 title: Mental Disease Ontology
 description: An ontology to describe and classify mental diseases such as schizophrenia, annotated with DSM-IV and ICD codes where applicable
 domain: health

--- a/ontology/mi.md
+++ b/ontology/mi.md
@@ -4,6 +4,7 @@ id: mi
 contact:
   email: pporras@ebi.ac.uk
   label: Pablo Porras Millán
+  github: pporrasebi
 tracker: https://github.com/HUPO-PSI/psi-mi-CV/issues
 license:
   url: https://creativecommons.org/licenses/by/4.0/

--- a/ontology/mmo.md
+++ b/ontology/mmo.md
@@ -4,6 +4,7 @@ id: mmo
 contact:
   email: jrsmith@mcw.edu
   label: Jennifer Smith
+  github: jrsjrs
 license:
   url: https://creativecommons.org/publicdomain/zero/1.0/
   label: CC0 1.0

--- a/ontology/mod.md
+++ b/ontology/mod.md
@@ -4,6 +4,7 @@ id: mod
 contact:
   email: pierre-alain.binz@chuv.ch
   label: Pierre-Alain Binz
+  github: pabinz
 license:
   url: https://creativecommons.org/licenses/by/4.0/
   label: CC BY 4.0

--- a/ontology/mp.md
+++ b/ontology/mp.md
@@ -13,8 +13,9 @@ description: Standard terms for annotating mammalian phenotypic data.
 homepage: http://www.informatics.jax.org/searches/MP_form.shtml
 page: https://github.com/mgijax/mammalian-phenotype-ontology
 contact:
-  email: pheno@jax.org
-  label: JAX phenotype list
+  email: drsbello@gmail.com
+  label: Sue Bello
+  github: sbello
 domain: phenotype
 products:
   - id: mp.owl

--- a/ontology/mp.md
+++ b/ontology/mp.md
@@ -6,12 +6,12 @@ license:
   url: http://creativecommons.org/licenses/by/4.0/
   label: CC BY 4.0
 build:
-  checkout: git clone https://github.com/obophenotype/mammalian-phenotype-ontology.git
+  checkout: git clone https://github.com/mgijax/mammalian-phenotype-ontology.git
   system: git
   path: "."
 description: Standard terms for annotating mammalian phenotypic data.
 homepage: http://www.informatics.jax.org/searches/MP_form.shtml
-page: https://github.com/obophenotype/mammalian-phenotype-ontology
+page: https://github.com/mgijax/mammalian-phenotype-ontology
 contact:
   email: pheno@jax.org
   label: JAX phenotype list
@@ -20,19 +20,19 @@ products:
   - id: mp.owl
     title: "MP (OWL edition)"
     description: "The main ontology in OWL. Contains all MP terms and links to other OBO ontologies."
-    page: https://github.com/obophenotype/mammalian-phenotype-ontology/releases/tag/current
+    page: https://github.com/mgijax/mammalian-phenotype-ontology/releases/tag/current
   - id: mp.obo
     title: "MP (OBO edition)"
     description: "A direct translation of the MP (OWL edition) into OBO format."
-    page: https://github.com/obophenotype/mammalian-phenotype-ontology/releases/tag/current
+    page: https://github.com/mgijax/mammalian-phenotype-ontology/releases/tag/current
   - id: mp.json
     title: MP (obographs JSON edition)
     description: "For a description of the format see https://github.com/geneontology/obographs."
-    page: https://github.com/obophenotype/mammalian-phenotype-ontology/releases/tag/current
+    page: https://github.com/mgijax/mammalian-phenotype-ontology/releases/tag/current
   - id: mp/mp-base.owl
     title: MP Base Module
     description: "The main ontology plus axioms connecting to select external ontologies, excluding axioms from the the external ontologies themselves."
-    page: https://github.com/obophenotype/mammalian-phenotype-ontology/releases/tag/current
+    page: https://github.com/mgijax/mammalian-phenotype-ontology/releases/tag/current
 browsers:
   - label: MGI
     title: MGI MP Browser
@@ -65,10 +65,10 @@ jobs:
 taxon:
   id: NCBITaxon:40674
   label: Mammalia
-tracker: https://github.com/obophenotype/mammalian-phenotype-ontology/issues
+tracker: https://github.com/mgijax/mammalian-phenotype-ontology/issues
 mailing_list: https://groups.google.com/forum/#!forum/phenotype-ontologies-editors
 activity_status: active
-repository: https://github.com/obophenotype/mammalian-phenotype-ontology
+repository: https://github.com/mgijax/mammalian-phenotype-ontology
 preferredPrefix: MP
 ---
 

--- a/ontology/mpath.md
+++ b/ontology/mpath.md
@@ -4,6 +4,7 @@ id: mpath
 contact:
   email: pns12@hermes.cam.ac.uk
   label: Paul Schofield
+  github: PaulNSchofield
 description: A structured controlled vocabulary of mutant and transgenic mouse pathology phenotypes
 domain: health
 homepage: http://www.pathbase.net

--- a/ontology/ms.md
+++ b/ontology/ms.md
@@ -8,6 +8,7 @@ createdWith: http://oboedit.org
 contact:
   email: gerhard.mayer@rub.de
   label: Gerhard Mayer
+  github: germa
 integration_server: https://raw.githubusercontent.com/HUPO-PSI/psi-ms-CV/master
 domain: MS experiments
 mailing_list: psidev-ms-vocab@lists.sourceforge.net

--- a/ontology/ncro.md
+++ b/ontology/ncro.md
@@ -6,7 +6,7 @@ description: An ontology for non-coding RNA, both of biological origin, and engi
 domain: experiments
 homepage: http://omnisearch.soc.southalabama.edu/w/index.php/Ontology
 mailing_list: ncro-devel@googlegroups.com, ncro-discuss@googlegroups.com
-tracker: https://github.com/OmniSearch/NCRO-Ontology-Files/issues
+tracker: https://github.com/OmniSearch/ncro/issues
 contact:
   label: Jingshan Huang
   email: huang@southalabama.edu
@@ -25,7 +25,7 @@ build:
   source_url: http://purl.obolibrary.org/obo/ncro/prebuild/ncro.owl
   method: owl2obo
 activity_status: active
-repository: https://github.com/OmniSearch/NCRO-Ontology-Files
+repository: https://github.com/OmniSearch/ncro
 preferredPrefix: NCRO
 ---
 

--- a/ontology/nomen.md
+++ b/ontology/nomen.md
@@ -3,7 +3,7 @@ layout: ontology_detail
 id: nomen
 type: owl:Ontology
 label: NOMEN
-title: NOMEN - A nomenclatural ontology for biological names
+title: A nomenclatural ontology for biological names
 contact:
   email: diapriid@gmail.com
   label: Matt Yoder

--- a/ontology/nomen.md
+++ b/ontology/nomen.md
@@ -3,7 +3,7 @@ layout: ontology_detail
 id: nomen
 type: owl:Ontology
 label: NOMEN
-title: A nomenclatural ontology for biological names
+title: NOMEN - A nomenclatural ontology for biological names
 contact:
   email: diapriid@gmail.com
   label: Matt Yoder

--- a/ontology/oarcs.md
+++ b/ontology/oarcs.md
@@ -9,7 +9,7 @@ contact:
   label: Matt Yoder
   github: mjy
 domain: anatomy
-repository: http://http://oarcs.speciesfilegroup.org
+repository: https://github.com/aszool/oarcs
 license:
   url: http://creativecommons.org/licenses/by/3.0/
   label: CC BY 3.0

--- a/ontology/obcs.md
+++ b/ontology/obcs.md
@@ -7,6 +7,7 @@ description: A biomedical ontology in the domain of biological and clinical stat
 contact:
   email: jiezheng@pennmedicine.upenn.edu
   label: Jie Zheng
+  github: zhengj2007
 domain: statistics
 homepage: https://github.com/obcs/obcs
 products:

--- a/ontology/obi.md
+++ b/ontology/obi.md
@@ -17,6 +17,7 @@ repository: https://github.com/obi-ontology/obi
 contact:
   label: Bjoern Peters
   email: bpeters@lji.org
+  github: bpeters42
 license:
   url: https://creativecommons.org/licenses/by/4.0/
   label: CC BY 4.0

--- a/ontology/obib.md
+++ b/ontology/obib.md
@@ -5,6 +5,7 @@ title: Ontology for Biobanking
 contact:
   email: jiezheng@pennmedicine.upenn.edu
   label: Jie Zheng
+  github: zhengj2007
 description: An ontology built for annotation and modeling of biobank repository and biobanking administration
 domain: biobanking, specimens, bio-repository, biocuration
 homepage: https://github.com/biobanking/biobanking

--- a/ontology/ogms.md
+++ b/ontology/ogms.md
@@ -4,6 +4,7 @@ id: ogms
 contact:
   email: baeverma@jcvi.org
   label: Brian Aevermann
+  github: BAevermann
 license:
   url: http://creativecommons.org/licenses/by/4.0/
   label: CC BY 4.0

--- a/ontology/ohd.md
+++ b/ontology/ohd.md
@@ -20,6 +20,7 @@ build:
   source_url: http://purl.obolibrary.org/obo/ohd.owl
   method: owl2obo
 tracker: https://purl.obolibrary.org/obo/ohd/issues
+repository: https://github.com/oral-health-and-disease-ontologies/ohd-ontology
 activity_status: active
 preferredPrefix: OHD
 ---

--- a/ontology/ohpi.md
+++ b/ontology/ohpi.md
@@ -9,6 +9,7 @@ tracker: https://github.com/OHPI/ohpi/issues
 contact:
   email: edong@umich.edu
   label: Edison Ong
+  github: e4ong1031
 products:
   - id: ohpi.owl
 license:

--- a/ontology/omit.md
+++ b/ontology/omit.md
@@ -4,7 +4,8 @@ id: omit
 in_foundry: false
 contact:
   email: huang@southalabama.edu
-  label: Huang, Jingshan
+  label: Jingshan Huang
+  github: Huang-OMIT
 license:
   url: https://creativecommons.org/licenses/by/3.0/
   label: CC BY 3.0

--- a/ontology/omp.md
+++ b/ontology/omp.md
@@ -4,6 +4,7 @@ id: omp
 contact:
   email: jimhu@tamu.edu
   label: James C. Hu
+  github: jimhu-tamu
 description: An ontology of phenotypes covering microbes
 domain: phenotype
 homepage: http://microbialphenotypes.org

--- a/ontology/ontoneo.md
+++ b/ontology/ontoneo.md
@@ -5,6 +5,7 @@ title: Obstetric and Neonatal Ontology
 contact:
   email: fernanda.farinelli@gmail.com
   label: Fernanda Farinelli
+  github: FernandaFarinelli
 description: The Obstetric and Neonatal Ontology is a structured controlled vocabulary to provide a representation of the data from electronic health records (EHRs) involved in the care of the pregnant woman, and of her baby.
 license:
   url: http://creativecommons.org/licenses/by/3.0/

--- a/ontology/oostt.md
+++ b/ontology/oostt.md
@@ -5,6 +5,7 @@ title: Ontology of Organizational Structures of Trauma centers and Trauma system
 contact:
   email: mbrochhausen@gmail.com
   label: Mathias Brochhausen
+  github: mbrochhausen
 description: An ontology built for representating the organizational components of trauma centers and trauma systems.
 domain: health
 homepage: https://github.com/OOSTT/OOSTT

--- a/ontology/ornaseq.md
+++ b/ontology/ornaseq.md
@@ -5,6 +5,7 @@ title: Ontology of RNA Sequencing
 contact:
   email: safisher@upenn.edu
   label: Stephen Fisher
+  github: safisher
 description: An application ontology designed to annotate next-generation sequencing experiments performed on RNA.
 domain: experiments
 homepage: http://kim.bio.upenn.edu/software/ornaseq.shtml

--- a/ontology/pao.md
+++ b/ontology/pao.md
@@ -5,6 +5,7 @@ title: Plant Anatomy Ontology
 contact:
   email: jaiswalp@science.oregonstate.edu
   label: Pankaj Jaiswal
+  github: jaiswalp
 taxon:
   id: NCBITaxon:33090
   label: Viridiplantae

--- a/ontology/peco.md
+++ b/ontology/peco.md
@@ -5,6 +5,7 @@ title: Plant Experimental Conditions Ontology
 contact:
   email: jaiswalp@science.oregonstate.edu
   label: Pankaj Jaiswal
+  github: jaiswalp
 description: A structured, controlled vocabulary which describes the treatments, growing conditions, and/or study types used in plant biology experiments.
 domain: experimental conditions
 homepage: http://planteome.org/

--- a/ontology/phipo.md
+++ b/ontology/phipo.md
@@ -12,6 +12,7 @@ build:
 contact:
   email: alayne.cuzick@rothamsted.ac.uk
   label: Alayne Cuzick
+  github: CuzickA
 description: PHIPO is a formal ontology of species-neutral phenotypes observed in pathogen-host interactions.
 domain: phenotype
 homepage: https://github.com/PHI-base/phipo

--- a/ontology/poro.md
+++ b/ontology/poro.md
@@ -4,6 +4,7 @@ id: poro
 contact:
   email: robert.thacker@stonybrook.edu
   label: Bob Thacker
+  github: bobthacker
 description: An ontology covering the anatomy of the taxon Porifera (sponges)
 domain: anatomy
 homepage: https://github.com/obophenotype/porifera-ontology

--- a/ontology/pso.md
+++ b/ontology/pso.md
@@ -12,6 +12,7 @@ build:
 contact:
   email: cooperl@science.oregonstate.edu
   label: Laurel Cooper
+  github: cooperl09
 description: The Plant Stress Ontology describes...
 domain: plant disease and abiotic stress
 homepage: https://github.com/Planteome/plant-stress-ontology

--- a/ontology/pw.md
+++ b/ontology/pw.md
@@ -4,6 +4,7 @@ id: pw
 contact:
   email: gthayman@mcw.edu
   label: G. Thomas Hayman
+  github: gthayman
 license:
   url: https://creativecommons.org/licenses/by/4.0/
   label: CC BY 4.0

--- a/ontology/rs.md
+++ b/ontology/rs.md
@@ -4,6 +4,7 @@ id: rs
 contact:
   email: sjwang@mcw.edu
   label: Shur-Jen Wang
+  github: shurjenw
 license:
   url: https://creativecommons.org/licenses/by/4.0/
   label: CC BY 4.0

--- a/ontology/sepio.md
+++ b/ontology/sepio.md
@@ -9,6 +9,7 @@ tracker: https://github.com/monarch-initiative/SEPIO-ontology/issues
 contact:
   email: mhb120@gmail.com
   label: Matthew Brush
+  github: mbrush
 license:
   url: https://creativecommons.org/licenses/by/3.0/
   label: CC BY 3.0

--- a/ontology/so.md
+++ b/ontology/so.md
@@ -4,6 +4,7 @@ id: so
 contact:
   email: keilbeck@genetics.utah.edu
   label: Karen Eilbeck
+  github: keilbeck
 license:
   url: https://creativecommons.org/licenses/by/4.0/
   label: CC BY 4.0

--- a/ontology/spd.md
+++ b/ontology/spd.md
@@ -4,6 +4,7 @@ id: spd
 contact:
   email: ramirez@macn.gov.ar
   label: Martin Ramirez
+  github: martinjramirez
 license:
   url: https://creativecommons.org/licenses/by/3.0/
   label: CC BY 3.0

--- a/ontology/stato.md
+++ b/ontology/stato.md
@@ -7,6 +7,7 @@ description: STATO is a general-purpose STATistics Ontology. Its aim is to provi
 contact:
   email: alejandra.gonzalez.beltran@gmail.com
   label: Alejandra Gonzalez-Beltran
+  github: agbeltran
 domain: statistics
 homepage: http://stato-ontology.org/
 products:

--- a/ontology/symp.md
+++ b/ontology/symp.md
@@ -4,6 +4,7 @@ id: symp
 contact:
   email: lynn.schriml@gmail.com
   label: Lynn Schriml
+  github: lschriml
 description: An ontology of disease symptoms, with symptoms encompasing perceived changes in function, sensations or appearance reported by a patient indicative of a disease.
 domain: disease
 homepage: http://symptomontologywiki.igs.umaryland.edu/mediawiki/index.php/Main_Page

--- a/ontology/to.md
+++ b/ontology/to.md
@@ -4,6 +4,7 @@ id: to
 contact:
   email: jaiswalp@science.oregonstate.edu
   label: Pankaj Jaiswal
+  github: jaiswalp
 description: A controlled vocabulary to describe phenotypic traits in plants.
 domain: phenotype
 homepage: http://browser.planteome.org/amigo

--- a/ontology/trans.md
+++ b/ontology/trans.md
@@ -4,6 +4,7 @@ id: trans
 contact:
   email: lynn.schriml@gmail.com
   label: Lynn Schriml
+  github: lschriml
 description: "An ontology representing the disease transmission process during which the pathogen is transmitted directly or indirectly from its natural reservoir, a susceptible host or source to a new host."
 domain: disease
 homepage: https://github.com/DiseaseOntology/PathogenTransmissionOntology

--- a/ontology/txpo.md
+++ b/ontology/txpo.md
@@ -4,7 +4,7 @@ id: txpo
 contact:
   email: y-yamagata@nibiohn.go.jp
   label: Yuki Yamagata
-  github: txpo-ontology
+  github: yuki-yamagata
 description: TOXic Process Ontology (TXPO) systematizes a wide variety of terms involving toxicity courses and processes. The first version of TXPO focuses on liver toxicity.
 domain: toxicity
 homepage: https://toxpilot.nibiohn.go.jp/

--- a/ontology/uo.md
+++ b/ontology/uo.md
@@ -5,6 +5,7 @@ in_foundry: false
 contact:
   email: g.gkoutos@gmail.com
   label: George Gkoutos
+  github: gkoutos
 description: Metrical units for use in conjunction with PATO
 domain: phenotype
 homepage: https://github.com/bio-ontology-research-group/unit-ontology

--- a/ontology/vt.md
+++ b/ontology/vt.md
@@ -9,6 +9,7 @@ tracker: https://github.com/AnimalGenome/vertebrate-trait-ontology/issues
 contact:
   label: Carissa Park
   email: caripark@iastate.edu
+  github: caripark
 license:
   url: https://creativecommons.org/licenses/by/4.0/
   label: CC BY 4.0

--- a/ontology/wbbt.md
+++ b/ontology/wbbt.md
@@ -5,6 +5,7 @@ preferredPrefix: WBbt
 contact:
   email: raymond@caltech.edu
   label: Raymond Lee
+  github: raymond91125
 license:
   url: https://creativecommons.org/licenses/by/4.0/
   label: CC BY 4.0

--- a/ontology/wbls.md
+++ b/ontology/wbls.md
@@ -5,6 +5,7 @@ preferredPrefix: WBls
 contact:
   email: cgrove@caltech.edu
   label: Chris Grove
+  github: chris-grove
 license:
   url: https://creativecommons.org/licenses/by/4.0/
   label: CC BY 4.0

--- a/ontology/wbphenotype.md
+++ b/ontology/wbphenotype.md
@@ -5,6 +5,7 @@ preferredPrefix: WBPhenotype
 contact:
   email: cgrove@caltech.edu
   label: Chris Grove
+  github: chris-grove
 license:
   url: http://creativecommons.org/licenses/by/4.0/
   label: CC BY 4.0

--- a/ontology/xco.md
+++ b/ontology/xco.md
@@ -3,6 +3,7 @@ layout: ontology_detail
 contact:
   email: jrsmith@mcw.edu
   label: Jennifer Smith
+  github: jrsjrs
 license:
   url: https://creativecommons.org/publicdomain/zero/1.0/
   label: CC0 1.0

--- a/ontology/xlmod.md
+++ b/ontology/xlmod.md
@@ -8,6 +8,7 @@ createdWith: http://oboedit.org
 contact:
   email: gerhard.mayer@rub.de
   label: Gerhard Mayer
+  github: germa
 integration_server: https://raw.githubusercontent.com/HUPO-PSI/mzIdentML/tree/master/cv
 domain: MS cross-linker reagents
 mailing_list: psidev-ms-vocab@lists.sourceforge.net

--- a/ontology/zfs.md
+++ b/ontology/zfs.md
@@ -5,6 +5,7 @@ in_foundry: false
 contact:
   email: van_slyke@zfin.org
   label: Ceri Van Slyke
+  github: cerivs
 description: Developmental stages of the Zebrafish
 domain: anatomy
 homepage: https://wiki.zfin.org/display/general/Anatomy+Atlases+and+Resources


### PR DESCRIPTION
This PR makes the following updates to OBO Foundry metadata:

1. Updates some out of date GitHub repository URLs (BCO, MP, NCRO)
2. Adds GitHub repositories to ontologies with no repository annotation (FBbt, FBdv)
3. Fixes repository annotations that weren't using GitHub (OARCS)
4. Update the contact's handle on TXPO to correspond to the contact person (to comply with [FP-11 - Locus of Authority](https://obofoundry.org/principles/fp-011-locus-of-authority.html)) instead of a group GitHub handle
5. Add several missing GitHub handles
6. Update MP's contact information to be a specific person (Sue Bello) instead of a contact list, which was also in violation of FP-11