### PR TITLE
Fix output of non-ascii characters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ build/
 *.pyc
 /.idea
 /venv
+tmp/
+.tmp

--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,4 @@ build/
 /.idea
 /venv
 tmp/
-.tmp
+*.tmp

--- a/util/sort-ontologies.py
+++ b/util/sort-ontologies.py
@@ -73,9 +73,8 @@ def sort_ontologies(data, sort_order):
 def write_data(data, output):
   '''Given the ontologies data as a dictionary and an output YAML file to
   write to, write the data to the file. '''
-  yaml_str = yaml.dump(data)
   with open(output, 'w') as f:
-    f.write(yaml_str)
+    yaml.safe_dump(data, f, allow_unicode=True)
 
 
 if __name__ == '__main__':

--- a/util/yaml2json.py
+++ b/util/yaml2json.py
@@ -15,5 +15,5 @@ args = parser.parse_args()
 with open(args.yaml_file, 'r') as stream:
   data = yaml.load(stream, Loader=yaml.SafeLoader)
 data['@context'] = "http://obofoundry.github.io/registry/context.jsonld"
-json = json.dumps(data, sort_keys=True, indent=4, separators=(',', ': '))
+json = json.dumps(data, sort_keys=True, indent=4, ensure_ascii=False, separators=(',', ': '))
 print(json)


### PR DESCRIPTION
Closes #1695

This PR does two things:

1. Makes sure that the `sort-ontologies.py` script outputs YAML properly
2. Makes sure the `yaml2json.py` script outputs JSON 

This can be verified by running `make` locally

## Fixed YAML

<img width="493" alt="Screen Shot 2022-01-02 at 14 36 01" src="https://user-images.githubusercontent.com/5069736/147877530-27df7a55-4f8b-479f-ad61-56969ab9bbf2.png">

## Fixed JSON

<img width="506" alt="Screen Shot 2022-01-02 at 14 36 06" src="https://user-images.githubusercontent.com/5069736/147877515-367f212e-58b7-488c-8bdf-2e107b9a955d.png">
properly




