### PR TITLE
Mark AEO as inactivate

### DIFF
--- a/ontology/aeo.md
+++ b/ontology/aeo.md
@@ -19,7 +19,7 @@ build:
   system: git
   path: src/ontology
   method: vcs
-activity_status: active
+activity_status: inactive
 repository: https://github.com/obophenotype/human-developmental-anatomy-ontology
 preferredPrefix: AEO
 ---


### PR DESCRIPTION
I just got in touch with Jonathan Bard via email and he said he's well into retirement and not able to maintain ontologies. Since the only evidence of interaction with the [GitHub repository](https://github.com/obophenotype/human-developmental-anatomy-ontology/tree/master/src/ontology) associated to this ontology is from Chris Mungall pre-2015, I think it's safe to say that it's inactive (if not orphaned). 

Additional context: the other four ontologies from Jonathan Bard (i.e., EHDA, EHDAA, EHDAA2, and MAT) are already marked as inactive.