### PR TITLE
Add Python code quality check

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,3 +28,7 @@ If an issue gets any **-1** votes, the comments on the issue need to reach conse
 
 The project will strive for full consensus on everything until it runs into a problem with that model.
 
+## Python Code Style
+
+All Python code in this repository should conform to `black` and `isort`. You
+can automatically apply them with `tox -e lint`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,8 @@
+[tool.black]
+target-version = ["py37", "py38", "py39", "py310"]
+
+[tool.isort]
+profile = "black"
+multi_line_output = 3
+include_trailing_comma = true
+reverse_relative = true

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,18 @@ skip_install = true
 deps =
     flake8
     flake8-docstrings
+    flake8-black
+    flake8-isort
 commands =
-    flake8 --select D300 util/
+    flake8 --select D300,I001,I002,I003,I004,I005,BLK100 util/
 description = Run the flake8 code quality checks
+
+[testenv:lint]
+deps =
+    black
+    isort
+skip_install = true
+commands =
+    black .
+    isort .
+description = Run linters.

--- a/util/add_preferred_prefixes.py
+++ b/util/add_preferred_prefixes.py
@@ -35,7 +35,10 @@ def update_markdown(path: Union[str, pathlib.Path]) -> None:
         return
     if "is_obsolete" in data and data["is_obsolete"]:
         return
-    if "activity_status" in data and data["activity_status"] in {"inactive", "orphaned"}:
+    if "activity_status" in data and data["activity_status"] in {
+        "inactive",
+        "orphaned",
+    }:
         return
 
     with open(path, "w") as file:
@@ -44,7 +47,7 @@ def update_markdown(path: Union[str, pathlib.Path]) -> None:
             print(line, file=file)
         print("preferredPrefix:", data["id"].upper(), file=file)
         print("---", file=file)
-        for line in lines[idx + 1:]:
+        for line in lines[idx + 1 :]:
             print(line, file=file)
 
 

--- a/util/auto-foundry-check.py
+++ b/util/auto-foundry-check.py
@@ -3,11 +3,13 @@
 # Read the ontologies.yml file
 # check foundry criteria
 
-__author__ = 'Chris Mungall'
+__author__ = "Chris Mungall"
 
-import argparse, yaml
+import argparse
 
-header = '''---
+import yaml
+
+header = """---
 layout: doc
 title: OBO Foundry Criteria Checker
 ---
@@ -22,66 +24,76 @@ Barry Smith, Michael Ashburner, Cornelius Rosse, Jonathan Bard, William Bug, Wer
 
 ### Ontology Project Publications
 
-'''
+"""
 
-template = '- {ontology} ({id}): [{title}]({link})\n'
+template = "- {ontology} ({id}): [{title}]({link})\n"
 
-IN_FOUNDRY_ORDER = 'in_foundry_order'
+IN_FOUNDRY_ORDER = "in_foundry_order"
+
 
 def main():
-    parser = argparse.ArgumentParser(
-        description='Extract foundry data')
-    parser.add_argument('-i', '--ontologies',
-        type=argparse.FileType('r'),
-        help='the ontologies YAML file to read')
-    #parser.add_argument(-'r','--review_path',
+    parser = argparse.ArgumentParser(description="Extract foundry data")
+    parser.add_argument(
+        "-i",
+        "--ontologies",
+        type=argparse.FileType("r"),
+        help="the ontologies YAML file to read",
+    )
+    # parser.add_argument(-'r','--review_path',
     #    type=str,
     #    help='the path to the review file')
     args = parser.parse_args()
 
     data = yaml.load(args.ontologies, Loader=yaml.SafeLoader)
     reviews = []
-    for ontology in data['ontologies']:
-        if 'is_obsolete' in ontology:
+    for ontology in data["ontologies"]:
+        if "is_obsolete" in ontology:
             continue
         reviews.append(review_ontology(ontology))
 
-    print('## SUCCESS')
+    print("## SUCCESS")
     for r in reviews:
-        if r['fails'] == []:
-            print(' * {}'.format(r['id']))
-    print('## FAILS')
+        if r["fails"] == []:
+            print(" * {}".format(r["id"]))
+    print("## FAILS")
     for r in reviews:
-        if len(r['fails']) > 0:
-            conflict = ''
-            if r['conflict']:
-                conflict = '*CONFLICT*'
-            print(' * {} FAILS: {} {}'.format(r['id'],r['fails'],conflict))
+        if len(r["fails"]) > 0:
+            conflict = ""
+            if r["conflict"]:
+                conflict = "*CONFLICT*"
+            print(" * {} FAILS: {} {}".format(r["id"], r["fails"], conflict))
 
 
-FAIL_LICENSE = 'license not CC-BY or CC-0'
-FAIL_TRACKER = 'No tracker for community requests'
-FAIL_USERS = 'No real users'
+FAIL_LICENSE = "license not CC-BY or CC-0"
+FAIL_TRACKER = "No tracker for community requests"
+FAIL_USERS = "No real users"
+
+
 def review_ontology(ont):
     inject(ont)
     fails = []
     is_foundry = IN_FOUNDRY_ORDER in ont
     open_license = False
-    if 'license' in ont:
-        lurl = ont['license']['url']
-        if 'creativecommons.org/licenses/by/' in lurl or 'creativecommons.org/publicdomain/zero' in lurl:
+    if "license" in ont:
+        lurl = ont["license"]["url"]
+        if (
+            "creativecommons.org/licenses/by/" in lurl
+            or "creativecommons.org/publicdomain/zero" in lurl
+        ):
             open_license = True
     if not open_license:
         fails.append(FAIL_LICENSE)
-    if 'tracker' not in ont:
+    if "tracker" not in ont:
         fails.append(FAIL_TRACKER)
-    if 'usages' not in ont:
+    if "usages" not in ont:
         fails.append(FAIL_USERS)
-    conflict = is_foundry and len(fails)>0
-    return dict(id=ont['id'], fails=fails, conflict=conflict)
+    conflict = is_foundry and len(fails) > 0
+    return dict(id=ont["id"], fails=fails, conflict=conflict)
+
 
 def inject(ont):
     pass
-    
+
+
 if __name__ == "__main__":
     main()

--- a/util/create-html-grid.py
+++ b/util/create-html-grid.py
@@ -2,32 +2,30 @@
 
 import csv
 import sys
-
 from argparse import ArgumentParser
 
-bootstrap_css = 'https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap.min.css'
+bootstrap_css = (
+    "https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap.min.css"
+)
 
 headers = []
 
 
 def main(args):
-    parser = ArgumentParser(
-        description="Generate an HTML output of the metadata grid")
-    parser.add_argument('input_grid',
-                        type=str,
-                        help='File containing the grid (CSV, TSV, or TXT)')
-    parser.add_argument('html_grid',
-                        type=str,
-                        help='HTML file to write the output to')
+    parser = ArgumentParser(description="Generate an HTML output of the metadata grid")
+    parser.add_argument(
+        "input_grid", type=str, help="File containing the grid (CSV, TSV, or TXT)"
+    )
+    parser.add_argument("html_grid", type=str, help="HTML file to write the output to")
     args = parser.parse_args()
 
     input_grid = args.input_grid
     html_grid = args.html_grid
     lines = get_html(parse_table(input_grid))
 
-    with open(html_grid, 'w') as f:
+    with open(html_grid, "w") as f:
         for line in lines:
-            f.write(line + '\n')
+            f.write(line + "\n")
 
 
 def parse_table(input_grid):
@@ -37,10 +35,10 @@ def parse_table(input_grid):
     global headers
 
     data = {}
-    if '.tsv' in input_grid:
-        delim = '\t'
-    elif '.csv' in input_grid:
-        delim = ','
+    if ".tsv" in input_grid:
+        delim = "\t"
+    elif ".csv" in input_grid:
+        delim = ","
     else:
         print("Invalid file extension: %s" % input_grid, file=sys.stderr)
         sys.exit(1)
@@ -65,68 +63,74 @@ def get_html(data):
     lines.append('<div class="container">')
     lines.append('\t<div class="row" style="padding-top: 20px;">')
     lines.append('\t\t<table class="table table-bordered">')
-    lines.append('\t\t\t<tr>')
+    lines.append("\t\t\t<tr>")
 
     # special columns that link to reports
     c = -1
     for h in headers:
         c += 1
-        lines.append('\t\t\t\t<td><b>{0}</b></td>'.format(h))
-    lines.append('\t\t\t</tr>')
+        lines.append("\t\t\t\t<td><b>{0}</b></td>".format(h))
+    lines.append("\t\t\t</tr>")
 
     for ont, fields in data.items():
-        lines.append('\t\t\t<tr>')
-        td_class = 'active'
+        lines.append("\t\t\t<tr>")
+        td_class = "active"
         lines.append('\t\t\t\t<td class="{0}">{1}</td>'.format(td_class, ont))
         c = 0
         for field in fields:
             c += 1
-            if '|' in field:
-                f = field.split('|')[0].strip()
-                msg = field.split('|')[1]
-                if '. ' in msg:
-                    msg = msg.replace('. ', '<br>')
+            if "|" in field:
+                f = field.split("|")[0].strip()
+                msg = field.split("|")[1]
+                if ". " in msg:
+                    msg = msg.replace(". ", "<br>")
                 if '"' in msg:
                     msg = msg.replace('"', '\\"')
             else:
                 f = field.strip()
                 msg = None
 
-            if f.lower() == 'pass':
-                td_class = 'success'
+            if f.lower() == "pass":
+                td_class = "success"
                 icon = '<img src="../assets/svg/check.svg" height="15px">'
 
-            elif f.lower() == 'info':
-                td_class = 'info'
+            elif f.lower() == "info":
+                td_class = "info"
                 icon = '<img src="../assets/svg/info.svg" height="15px">'
 
-            elif f.lower() == 'warning' or f.lower() == 'warn':
-                td_class = 'warning'
+            elif f.lower() == "warning" or f.lower() == "warn":
+                td_class = "warning"
                 icon = '<img src="../assets/svg/warning.svg" height="15px">'
 
-            elif f.lower() == 'error' or f.lower() == 'fail':
-                td_class = 'danger'
+            elif f.lower() == "error" or f.lower() == "fail":
+                td_class = "danger"
                 icon = '<img src="../assets/svg/x.svg" height="15px">'
 
             else:
-                td_class = 'active'
+                td_class = "active"
                 icon = None
 
             if icon:
                 lines.append(
-                    '\t\t\t\t<td class="{0}" style="text-align:center">{1}</td>'.format(td_class, icon))
+                    '\t\t\t\t<td class="{0}" style="text-align:center">{1}</td>'.format(
+                        td_class, icon
+                    )
+                )
             else:
                 lines.append(
-                    '\t\t\t\t<td class="{0}" style="text-align:center">{1}</td>'.format(td_class, f))
+                    '\t\t\t\t<td class="{0}" style="text-align:center">{1}</td>'.format(
+                        td_class, f
+                    )
+                )
 
-        lines.append('\t\t\t</tr>')
+        lines.append("\t\t\t</tr>")
 
     # closing tags
-    lines.append('\t\t</table>')
-    lines.append('\t</div>')
-    lines.append('</div>')
+    lines.append("\t\t</table>")
+    lines.append("\t</div>")
+    lines.append("</div>")
     return lines
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main(sys.argv)

--- a/util/extract-metadata.py
+++ b/util/extract-metadata.py
@@ -2,47 +2,56 @@
 
 import argparse
 import sys
-from yamllint import config, linter
-import yaml
+
 import frontmatter
+import yaml
 from frontmatter.util import u
 from ruamel.yaml import YAML
 from ruamel.yaml.compat import StringIO
-__author__ = 'cjm'
+from yamllint import config, linter
+
+__author__ = "cjm"
 
 
 def main():
-  parser = argparse.ArgumentParser(description='Helper utils for OBO',
-                                   formatter_class=argparse.RawTextHelpFormatter)
+    parser = argparse.ArgumentParser(
+        description="Helper utils for OBO",
+        formatter_class=argparse.RawTextHelpFormatter,
+    )
 
-  subparsers = parser.add_subparsers(dest='subcommand', help='sub-command help')
+    subparsers = parser.add_subparsers(dest="subcommand", help="sub-command help")
 
-  # SUBCOMMAND
-  parser_n = subparsers.add_parser('validate', help='validate yaml inside md')
-  # parser_n.add_argument('-d', '--depth', type=int, help='number of hops')
-  parser_n.set_defaults(function=validate_markdown)
-  parser_n.add_argument('files', nargs='*')
-  parser_n = subparsers.add_parser('prettify', help = 'prettify YAML block in registry ontolgoy Markdown files')
-  parser_n.set_defaults(function=prettify)
-  parser_n.add_argument('files', nargs='*')
-  # SUBCOMMAND
-  parser_n = subparsers.add_parser('concat', help='concat ontology yamls')
-  parser_n.add_argument('-i', '--include', help='yaml file to include for header')
-  parser_n.add_argument('-o', '--output', help='output yaml file')
-  parser_n.set_defaults(function=concat_ont_yaml)
-  parser_n.add_argument('files', nargs='*')
+    # SUBCOMMAND
+    parser_n = subparsers.add_parser("validate", help="validate yaml inside md")
+    # parser_n.add_argument('-d', '--depth', type=int, help='number of hops')
+    parser_n.set_defaults(function=validate_markdown)
+    parser_n.add_argument("files", nargs="*")
+    parser_n = subparsers.add_parser(
+        "prettify", help="prettify YAML block in registry ontolgoy Markdown files"
+    )
+    parser_n.set_defaults(function=prettify)
+    parser_n.add_argument("files", nargs="*")
+    # SUBCOMMAND
+    parser_n = subparsers.add_parser("concat", help="concat ontology yamls")
+    parser_n.add_argument("-i", "--include", help="yaml file to include for header")
+    parser_n.add_argument("-o", "--output", help="output yaml file")
+    parser_n.set_defaults(function=concat_ont_yaml)
+    parser_n.add_argument("files", nargs="*")
 
-  # SUBCOMMAND
-  parser_n = subparsers.add_parser('concat-principles', help='concat principles yamls')
-  parser_n.add_argument('-i', '--include', help='yaml file to include for header')
-  parser_n.add_argument('-o', '--output', help='output yaml')
-  parser_n.set_defaults(function=concat_principles_yaml)
-  parser_n.add_argument('files', nargs='*')
+    # SUBCOMMAND
+    parser_n = subparsers.add_parser(
+        "concat-principles", help="concat principles yamls"
+    )
+    parser_n.add_argument("-i", "--include", help="yaml file to include for header")
+    parser_n.add_argument("-o", "--output", help="output yaml")
+    parser_n.set_defaults(function=concat_principles_yaml)
+    parser_n.add_argument("files", nargs="*")
 
-  args = parser.parse_args()
+    args = parser.parse_args()
 
-  func = args.function
-  func(args)
+    func = args.function
+    func(args)
+
 
 class CustomRuamelYAMLHandler(frontmatter.YAMLHandler):
     def __init__(self):
@@ -52,7 +61,7 @@ class CustomRuamelYAMLHandler(frontmatter.YAMLHandler):
         self.myyaml.indent(mapping=2, sequence=4, offset=2)
         self.myyaml.preserve_quotes = True
         self.myyaml.width = 1500
-        #self.myyaml.explicit_start = True
+        # self.myyaml.explicit_start = True
         super().__init__()
 
     def load(self, fm, **kwargs):
@@ -60,205 +69,212 @@ class CustomRuamelYAMLHandler(frontmatter.YAMLHandler):
 
     def export(self, metadata, **kwargs):
         stream = StringIO()
-        self.myyaml.dump(data = metadata, stream = stream)
+        self.myyaml.dump(data=metadata, stream=stream)
         metadata = stream.getvalue()
         metadata = metadata[:-1]
         return u(metadata)
+
 
 def prettify(args):
     for file in args.files:
         handler = CustomRuamelYAMLHandler()
         text = frontmatter.load(file, handler=handler)
         file_obj = open(file, "wb")
-        frontmatter.dump(text, fd = file_obj, handler = handler)
-        file_obj = open(file, 'a')
-        file_obj.write('\n')
+        frontmatter.dump(text, fd=file_obj, handler=handler)
+        file_obj = open(file, "a")
+        file_obj.write("\n")
         file_obj.close()
 
 
-
 def validate_markdown(args):
-  """
-  Ensure the yaml encoded inside a YAML file is syntactically valid.
-
-  First attempt to strip the yaml from the .md file, second use the standard python yaml parser
-  to parse the embedded yaml. If it can't be passed then an error will be thrown and a stack
-  trace shown. In future we may try and catch this error and provide a user-friendly report).
-
-  In future we also perform additional structural validation on the yaml - check certain fields
-  are present etc. This could be done in various ways, e.g. jsonschema, programmatic checks. We
-  should also check translation -> jsonld -> rdf works as expected.
-  """
-  def validate_structure(obj):
     """
-    Given an object, check to see if it has 'id', 'title', and 'layout' fields. If any are
-    missing, collect them in a list of errors which is then returned.
+    Ensure the yaml encoded inside a YAML file is syntactically valid.
+
+    First attempt to strip the yaml from the .md file, second use the standard python yaml parser
+    to parse the embedded yaml. If it can't be passed then an error will be thrown and a stack
+    trace shown. In future we may try and catch this error and provide a user-friendly report).
+
+    In future we also perform additional structural validation on the yaml - check certain fields
+    are present etc. This could be done in various ways, e.g. jsonschema, programmatic checks. We
+    should also check translation -> jsonld -> rdf works as expected.
     """
+
+    def validate_structure(obj):
+        """
+        Given an object, check to see if it has 'id', 'title', and 'layout' fields. If any are
+        missing, collect them in a list of errors which is then returned.
+        """
+        errs = []
+        id = obj.get("id") or ""
+        if not id:
+            errs.append("No id: ")
+        if "title" not in obj:
+            errs.append("No title: " + id)
+        if "layout" not in obj:
+            errs.append(
+                "No layout tag: " + id + " -- this is required for proper rendering"
+            )
+        # is_obsolete = ('is_obsolete' in obj)
+        # if 'description' not in obj:
+        #   errs.append("No description: " + id + " " + ("OBS" if is_obsolete else ""))
+        return errs
+
     errs = []
-    id = obj.get('id') or ''
-    if not id:
-      errs.append("No id: ")
-    if 'title' not in obj:
-      errs.append("No title: " + id)
-    if 'layout' not in obj:
-      errs.append("No layout tag: " + id + " -- this is required for proper rendering")
-    # is_obsolete = ('is_obsolete' in obj)
-    # if 'description' not in obj:
-    #   errs.append("No description: " + id + " " + ("OBS" if is_obsolete else ""))
-    return errs
-
-  errs = []
-  warn = []
-  for fn in args.files:
-    # we don't do anything with the results; an
-    # error is thrown
-    if not frontmatter.check(fn):
-        errs.append("%s does not contain frontmatter" %(fn))
-    yamltext = get_YAML_text(fn)
-    yaml_config = config.YamlLintConfig(file = "util/config.yamllint")
-    for p in linter.run("---\n" + yamltext, yaml_config):
-        if p.level == "error":
-           errs.append(f"%s: {p}" %(fn))
-        elif p.level=="warning":
-           warn.append(f"%s: {p}" %(fn))
-    (obj, md) = load_md(fn)
-    errs += validate_structure(obj)
-  if len(warn) > 0:
-      print("WARNINGS:", file = sys.stderr)
-      for w in warn:
-          print("WARN: " + w, file=sys.stderr)
-  if len(errs) > 0:
-    print("FAILURES:", file=sys.stderr)
-    for e in errs:
-      print("ERROR:" + e, file=sys.stderr)
-    sys.exit(1)
-
+    warn = []
+    for fn in args.files:
+        # we don't do anything with the results; an
+        # error is thrown
+        if not frontmatter.check(fn):
+            errs.append("%s does not contain frontmatter" % (fn))
+        yamltext = get_YAML_text(fn)
+        yaml_config = config.YamlLintConfig(file="util/config.yamllint")
+        for p in linter.run("---\n" + yamltext, yaml_config):
+            if p.level == "error":
+                errs.append(f"%s: {p}" % (fn))
+            elif p.level == "warning":
+                warn.append(f"%s: {p}" % (fn))
+        (obj, md) = load_md(fn)
+        errs += validate_structure(obj)
+    if len(warn) > 0:
+        print("WARNINGS:", file=sys.stderr)
+        for w in warn:
+            print("WARN: " + w, file=sys.stderr)
+    if len(errs) > 0:
+        print("FAILURES:", file=sys.stderr)
+        for e in errs:
+            print("ERROR:" + e, file=sys.stderr)
+        sys.exit(1)
 
 
 def concat_ont_yaml(args):
-  """
-  Given arguments with files and ouput,
-  read YAML files into an array, decorate the objects, and write an output YAML file.
-  Output will be Foundry ontologies first, Library ontologies second, and obsolete last.
-  Assumes that args.files is already sorted alphabetically.
-  """
-  def has_obo_prefix(obj):
     """
-    Check to see if the given object's 'uri_prefix' (if present) maps to the OBO PURL
+    Given arguments with files and ouput,
+    read YAML files into an array, decorate the objects, and write an output YAML file.
+    Output will be Foundry ontologies first, Library ontologies second, and obsolete last.
+    Assumes that args.files is already sorted alphabetically.
     """
-    return ('uri_prefix' not in obj) or (obj['uri_prefix'] == 'http://purl.obolibrary.org/obo/')
 
-  def has_a_product(obj):
-    """
-    Check to see if the given object has at least one product.
-    """
-    return 'products' in obj and len(obj['products']) > 0
+    def has_obo_prefix(obj):
+        """
+        Check to see if the given object's 'uri_prefix' (if present) maps to the OBO PURL
+        """
+        return ("uri_prefix" not in obj) or (
+            obj["uri_prefix"] == "http://purl.obolibrary.org/obo/"
+        )
 
-  def decorate_entry(obj, suffix=""):
-    """
-    Decorates EITHER an ontology metadata object OR a product object with a purl.
+    def has_a_product(obj):
+        """
+        Check to see if the given object has at least one product.
+        """
+        return "products" in obj and len(obj["products"]) > 0
 
-    Each object has an identifier which either identifies the ontology sensu grouping
-    project (e.g. 'go') or a specific product (e.g. 'go.obo' or 'go.owl').
+    def decorate_entry(obj, suffix=""):
+        """
+        Decorates EITHER an ontology metadata object OR a product object with a purl.
 
-    By default each id is prefixed with the OBO prefix (unless is has an alternate prefix,
-    in which case it is effectively ignored).
-    """
-    id = obj.get('id') or 'None'
-    if 'is_obsolete' not in obj and has_obo_prefix(obj):
-      obj['ontology_purl'] = "http://purl.obolibrary.org/obo/" + id + suffix
+        Each object has an identifier which either identifies the ontology sensu grouping
+        project (e.g. 'go') or a specific product (e.g. 'go.obo' or 'go.owl').
 
-  def decorate_metadata(objs):
-    """
-    Add the logo corresponding to the given object's license (if it has one), and decorate
-    it with PURLs it has any products.
-    See: https://github.com/OBOFoundry/OBOFoundry.github.io/issues/82
-    """
-    # TODO: decide on canonical URI to use for CC licenses;
-    #  ultimately this should all be specified in RDF/JSON-LD.
-    #  e.g. <http://creativecommons.org/licenses/by/3.0> foaf:depictedBy < ... > .
-    #  e.g. <http://creativecommons.org/licenses/by/3.0> owl:sameAs <https://creativecommons.org/licenses/by/3.0> .
-    for obj in objs:
-      if 'license' in obj:
-        # https://creativecommons.org/about/downloads
-        license = obj['license']
-        lurl = license['url']
-        logo = ''
-        if lurl.find('creativecommons.org/licenses/by-sa') > 0:
-          logo = 'https://mirrors.creativecommons.org/presskit/buttons/80x15/png/by-sa.png'
-        elif lurl.find('creativecommons.org/licenses/by/') > 0:
-          logo = 'http://mirrors.creativecommons.org/presskit/buttons/80x15/png/by.png'
-        elif lurl.find('creativecommons.org/publicdomain/zero/') > 0:
-          logo = 'http://mirrors.creativecommons.org/presskit/buttons/80x15/png/cc-zero.png'
-        if logo:
-          license['logo'] = logo
-      if has_a_product(obj):
-        # decorate top-level ontology; but only if it has at least one product
-        decorate_entry(obj, ".owl")
-        for product in obj['products']:
-          decorate_entry(product)
+        By default each id is prefixed with the OBO prefix (unless is has an alternate prefix,
+        in which case it is effectively ignored).
+        """
+        id = obj.get("id") or "None"
+        if "is_obsolete" not in obj and has_obo_prefix(obj):
+            obj["ontology_purl"] = "http://purl.obolibrary.org/obo/" + id + suffix
 
-  objs = []
-  foundry = []
-  library = []
-  obsolete = []
-  cfg = {}
-  if (args.include):
-    with open(args.include, 'r') as f:
-      cfg = yaml.load(f.read(), Loader=yaml.SafeLoader)
-  for fn in args.files:
-    (obj, md) = load_md(fn)
-    if obj.get('is_obsolete'):
-      obsolete.append(obj)
-    elif 'in_foundry_order' in obj:
-      foundry.append(obj)
-    else:
-      library.append(obj)
-  objs = foundry + library + obsolete
-  cfg['ontologies'] = objs
-  decorate_metadata(objs)
-  with open(args.output, 'w') as f:
-    f.write(yaml.dump(cfg))
-  return cfg
+    def decorate_metadata(objs):
+        """
+        Add the logo corresponding to the given object's license (if it has one), and decorate
+        it with PURLs it has any products.
+        See: https://github.com/OBOFoundry/OBOFoundry.github.io/issues/82
+        """
+        # TODO: decide on canonical URI to use for CC licenses;
+        #  ultimately this should all be specified in RDF/JSON-LD.
+        #  e.g. <http://creativecommons.org/licenses/by/3.0> foaf:depictedBy < ... > .
+        #  e.g. <http://creativecommons.org/licenses/by/3.0> owl:sameAs <https://creativecommons.org/licenses/by/3.0> .
+        for obj in objs:
+            if "license" in obj:
+                # https://creativecommons.org/about/downloads
+                license = obj["license"]
+                lurl = license["url"]
+                logo = ""
+                if lurl.find("creativecommons.org/licenses/by-sa") > 0:
+                    logo = "https://mirrors.creativecommons.org/presskit/buttons/80x15/png/by-sa.png"
+                elif lurl.find("creativecommons.org/licenses/by/") > 0:
+                    logo = "http://mirrors.creativecommons.org/presskit/buttons/80x15/png/by.png"
+                elif lurl.find("creativecommons.org/publicdomain/zero/") > 0:
+                    logo = "http://mirrors.creativecommons.org/presskit/buttons/80x15/png/cc-zero.png"
+                if logo:
+                    license["logo"] = logo
+            if has_a_product(obj):
+                # decorate top-level ontology; but only if it has at least one product
+                decorate_entry(obj, ".owl")
+                for product in obj["products"]:
+                    decorate_entry(product)
+
+    objs = []
+    foundry = []
+    library = []
+    obsolete = []
+    cfg = {}
+    if args.include:
+        with open(args.include, "r") as f:
+            cfg = yaml.load(f.read(), Loader=yaml.SafeLoader)
+    for fn in args.files:
+        (obj, md) = load_md(fn)
+        if obj.get("is_obsolete"):
+            obsolete.append(obj)
+        elif "in_foundry_order" in obj:
+            foundry.append(obj)
+        else:
+            library.append(obj)
+    objs = foundry + library + obsolete
+    cfg["ontologies"] = objs
+    decorate_metadata(objs)
+    with open(args.output, "w") as f:
+        f.write(yaml.dump(cfg))
+    return cfg
 
 
 def concat_principles_yaml(args):
-  """
-  Concatenate all of the principles .md files given in the command line arguments and
-  add them to the 'principles' field of the YAML object that is returned. If the
-  --include command line option has been specified, then the YAML will include information
-  from that file.
-  """
-  objs = []
-  cfg = {}
-  if (args.include):
-    with open(args.include, 'r') as f:
-      cfg = yaml.load(f.read(), Loader=yaml.SafeLoader)
-  for fn in args.files:
-    (obj, md) = load_md(fn)
-    objs.append(obj)
-  objs.sort(key=lambda x: x['id'])
-  cfg['principles'] = objs
-  with open(args.output, 'w') as f:
-    f.write(yaml.dump(cfg))
-  return cfg
+    """
+    Concatenate all of the principles .md files given in the command line arguments and
+    add them to the 'principles' field of the YAML object that is returned. If the
+    --include command line option has been specified, then the YAML will include information
+    from that file.
+    """
+    objs = []
+    cfg = {}
+    if args.include:
+        with open(args.include, "r") as f:
+            cfg = yaml.load(f.read(), Loader=yaml.SafeLoader)
+    for fn in args.files:
+        (obj, md) = load_md(fn)
+        objs.append(obj)
+    objs.sort(key=lambda x: x["id"])
+    cfg["principles"] = objs
+    with open(args.output, "w") as f:
+        f.write(yaml.dump(cfg))
+    return cfg
 
 
 def load_md(fn):
-  """
-  Load a yaml text blob from a markdown file and parse the blob.
+    """
+    Load a yaml text blob from a markdown file and parse the blob.
 
-  Returns a tuple (yaml_obj, markdown_text)
-  """
-  onto_stuff = frontmatter.load(fn)
-  return (onto_stuff.metadata, onto_stuff.content)
+    Returns a tuple (yaml_obj, markdown_text)
+    """
+    onto_stuff = frontmatter.load(fn)
+    return (onto_stuff.metadata, onto_stuff.content)
+
 
 def get_YAML_text(fn):
-    with open(fn, 'r') as f:
-      text = f.read()
-      chunks = text.split("---")
-      yamltext = chunks[1].strip()
-      return yamltext
+    with open(fn, "r") as f:
+        text = f.read()
+        chunks = text.split("---")
+        yamltext = chunks[1].strip()
+        return yamltext
+
 
 # def extract(mdtext, fn = "foo"):
 #   """
@@ -272,4 +288,4 @@ def get_YAML_text(fn):
 
 
 if __name__ == "__main__":
-  main()
+    main()

--- a/util/extract-publications.py
+++ b/util/extract-publications.py
@@ -1,16 +1,17 @@
 #!/usr/bin/env python3
 
 import argparse
+
 import yaml
 
 # Read the ontologies.yml file
 # collect the first 'publications' entry from each project,
 # and write as Markdown.
 
-__author__ = 'James A. Overton'
+__author__ = "James A. Overton"
 
 
-header = '''---
+header = """---
 layout: doc
 title: Publications Related to the OBO Foundry
 ---
@@ -31,42 +32,51 @@ Barry Smith, Michael Ashburner, Cornelius Rosse, Jonathan Bard, William Bug, Wer
 
 ### Some Ontology Project Publications (not a complete list)
 
-'''
+"""
 
-template = '- {ontology} ({id}): [{title}]({link})\n'
+template = "- {ontology} ({id}): [{title}]({link})\n"
 
 
 def main():
-  parser = argparse.ArgumentParser(description='Extract publication data')
-  parser.add_argument('ontologies', type=argparse.FileType('r'),
-                      help='the ontologies YAML file to read')
-  parser.add_argument('publications_path', type=str, help='the path to the output file')
-  args = parser.parse_args()
+    parser = argparse.ArgumentParser(description="Extract publication data")
+    parser.add_argument(
+        "ontologies",
+        type=argparse.FileType("r"),
+        help="the ontologies YAML file to read",
+    )
+    parser.add_argument(
+        "publications_path", type=str, help="the path to the output file"
+    )
+    args = parser.parse_args()
 
-  data = yaml.load(args.ontologies, Loader=yaml.SafeLoader)
-  publications = []
-  for ontology in data['ontologies']:
-    result = {}
-    if 'title' in ontology:
-      result['ontology'] = ontology['title']
-    if 'id' in ontology:
-      result['id'] = ontology['id']
+    data = yaml.load(args.ontologies, Loader=yaml.SafeLoader)
+    publications = []
+    for ontology in data["ontologies"]:
+        result = {}
+        if "title" in ontology:
+            result["ontology"] = ontology["title"]
+        if "id" in ontology:
+            result["id"] = ontology["id"]
 
-    for publication in ontology.get('publications', []):
-      if 'id' in publication and 'title' in publication:
-        result['link'] = publication['id']
-        result['title'] = publication['title']
-        break
-    if 'ontology' in result and 'id' in result \
-       and 'link' in result and 'title' in result:
-      publications.append(result)
+        for publication in ontology.get("publications", []):
+            if "id" in publication and "title" in publication:
+                result["link"] = publication["id"]
+                result["title"] = publication["title"]
+                break
+        if (
+            "ontology" in result
+            and "id" in result
+            and "link" in result
+            and "title" in result
+        ):
+            publications.append(result)
 
-  publications = sorted(publications, key=lambda k: k['ontology'])
-  with open(args.publications_path, 'w') as output:
-    output.write(header)
-    for publication in publications:
-      output.write(template.format(**publication))
+    publications = sorted(publications, key=lambda k: k["ontology"])
+    with open(args.publications_path, "w") as output:
+        output.write(header)
+        for publication in publications:
+            output.write(template.format(**publication))
 
 
 if __name__ == "__main__":
-  main()
+    main()

--- a/util/make-shacl-prefixes.py
+++ b/util/make-shacl-prefixes.py
@@ -2,54 +2,56 @@
 
 import csv
 import sys
-import yaml
-
 from argparse import ArgumentParser
+
+import yaml
 
 
 def main(args):
-  """
-  Takes ontologies.yml file and makes a triple file with SHACL prefixes.
+    """
+    Takes ontologies.yml file and makes a triple file with SHACL prefixes.
 
-  For example, for uberon it will generate:
+    For example, for uberon it will generate:
 
-      [ sh:prefix "UBERON" ; sh:namespace "http://purl.obolibrary.org/obo/UBERON_"]
+        [ sh:prefix "UBERON" ; sh:namespace "http://purl.obolibrary.org/obo/UBERON_"]
 
-  We always assume the CURIE prefix is uppercase, unless 'preferred_prefix' is specified
-  (for mixed-case prefixes, e.g. FBbt)
+    We always assume the CURIE prefix is uppercase, unless 'preferred_prefix' is specified
+    (for mixed-case prefixes, e.g. FBbt)
 
-  This can be useful for converting an OBO class PURL to a prefix without assumption-embedding string conversions.
-  It can be used to interconvert PURLs to CURIEs.
+    This can be useful for converting an OBO class PURL to a prefix without assumption-embedding string conversions.
+    It can be used to interconvert PURLs to CURIEs.
 
-  Note that while prefixes can sometimes be seen in RDF files, this is part of the syntax and not part of the data,
-  the prefixes are expanded at parse time. The obo_prefixes.ttl file makes these explicit.
+    Note that while prefixes can sometimes be seen in RDF files, this is part of the syntax and not part of the data,
+    the prefixes are expanded at parse time. The obo_prefixes.ttl file makes these explicit.
 
-  We use the SHACL vocabulary since it provides convenient predicates for putting prefixes in the domain of discourse;
-  however, it does not entail any use of SHACL
+    We use the SHACL vocabulary since it provides convenient predicates for putting prefixes in the domain of discourse;
+    however, it does not entail any use of SHACL
 
-  """
-  parser = ArgumentParser(description='''
-  Takes ontologies.yml file and makes a triple file with shacl prefixes''')
-  parser.add_argument('input')
-  args = parser.parse_args()
-  stream = open(args.input, 'r')
-  data = yaml.load(stream, Loader=yaml.SafeLoader)
+    """
+    parser = ArgumentParser(
+        description="""
+  Takes ontologies.yml file and makes a triple file with shacl prefixes"""
+    )
+    parser.add_argument("input")
+    args = parser.parse_args()
+    stream = open(args.input, "r")
+    data = yaml.load(stream, Loader=yaml.SafeLoader)
 
-  print('@prefix sh:	<http://www.w3.org/ns/shacl#> .')
-  print('@prefix xsd:    <http://www.w3.org/2001/XMLSchema#> .')
-  print('[')
-  print(' sh:declare')
-  sep = ''
-  for ont in data['ontologies']:
-    if ont.get('is_obsolete',False):
-      continue
-    prefix = ont.get('preferredPrefix', ont['id'].upper())
-    print(f'{sep}[ sh:prefix "{prefix}" ; sh:namespace "http://purl.obolibrary.org/obo/{prefix}_"]')
-    sep = ','
-  print('] .')
-    
-    
-  
+    print("@prefix sh:	<http://www.w3.org/ns/shacl#> .")
+    print("@prefix xsd:    <http://www.w3.org/2001/XMLSchema#> .")
+    print("[")
+    print(" sh:declare")
+    sep = ""
+    for ont in data["ontologies"]:
+        if ont.get("is_obsolete", False):
+            continue
+        prefix = ont.get("preferredPrefix", ont["id"].upper())
+        print(
+            f'{sep}[ sh:prefix "{prefix}" ; sh:namespace "http://purl.obolibrary.org/obo/{prefix}_"]'
+        )
+        sep = ","
+    print("] .")
 
-if __name__ == '__main__':
-  main(sys.argv)
+
+if __name__ == "__main__":
+    main(sys.argv)

--- a/util/populate_repositories.py
+++ b/util/populate_repositories.py
@@ -10,6 +10,7 @@ Author: `Charles Tapley Hoyt <https://cthoyt.com>`_.
 import pathlib
 from io import StringIO
 from typing import Union
+
 import click
 import yaml
 

--- a/util/processor.py
+++ b/util/processor.py
@@ -3,236 +3,277 @@
 import argparse
 import datetime
 import logging
-import requests
 import sys
 import time
-import yaml
-
 from contextlib import closing
-from SPARQLWrapper import SPARQLWrapper, JSON
 from json import dumps
 
-__author__ = 'cjm'
+import requests
+import yaml
+from SPARQLWrapper import JSON, SPARQLWrapper
+
+__author__ = "cjm"
 
 
 def main():
-  parser = argparse.ArgumentParser(description='Helper utils for OBO',
-                                   formatter_class=argparse.RawTextHelpFormatter)
-  parser.add_argument('-i', '--input', type=str, required=False, help='Input metadata file')
-  parser.add_argument('-v', '--verbosity', default=0, action='count',
-                      help='Increase output verbosity (min.: 0, max. 2)')
-  subparsers = parser.add_subparsers(dest='subcommand', help='sub-command help')
+    parser = argparse.ArgumentParser(
+        description="Helper utils for OBO",
+        formatter_class=argparse.RawTextHelpFormatter,
+    )
+    parser.add_argument(
+        "-i", "--input", type=str, required=False, help="Input metadata file"
+    )
+    parser.add_argument(
+        "-v",
+        "--verbosity",
+        default=0,
+        action="count",
+        help="Increase output verbosity (min.: 0, max. 2)",
+    )
+    subparsers = parser.add_subparsers(dest="subcommand", help="sub-command help")
 
-  # SUBCOMMAND
-  parser_n = subparsers.add_parser('check-urls', help='Ensure PURLs resolve')
-  parser_n.set_defaults(function=check_urls)
+    # SUBCOMMAND
+    parser_n = subparsers.add_parser("check-urls", help="Ensure PURLs resolve")
+    parser_n.set_defaults(function=check_urls)
 
-  parser_n = subparsers.add_parser('sparql-compare', help='Run SPARQL commands against the db to generate a '
-                                   'consistency report')
-  parser_n.set_defaults(function=sparql_compare_all)
+    parser_n = subparsers.add_parser(
+        "sparql-compare",
+        help="Run SPARQL commands against the db to generate a " "consistency report",
+    )
+    parser_n.set_defaults(function=sparql_compare_all)
 
-  parser_n = subparsers.add_parser('extract-context', help='Extracts JSON-LD context')
-  parser_n.set_defaults(function=extract_context)
+    parser_n = subparsers.add_parser("extract-context", help="Extracts JSON-LD context")
+    parser_n.set_defaults(function=extract_context)
 
-  parser_n = subparsers.add_parser('extract-contributors',
-                                   help='Queries github API for metadata about contributors')
-  parser_n.set_defaults(function=write_all_contributors)
+    parser_n = subparsers.add_parser(
+        "extract-contributors",
+        help="Queries github API for metadata about contributors",
+    )
+    parser_n.set_defaults(function=write_all_contributors)
 
-  args = parser.parse_args()
-  if args.verbosity >= 2:
-    logging.basicConfig(level=logging.DEBUG)
-  elif args.verbosity == 1:
-    logging.basicConfig(level=logging.INFO)
-  else:
-    logging.basicConfig(level=logging.WARNING)
+    args = parser.parse_args()
+    if args.verbosity >= 2:
+        logging.basicConfig(level=logging.DEBUG)
+    elif args.verbosity == 1:
+        logging.basicConfig(level=logging.INFO)
+    else:
+        logging.basicConfig(level=logging.WARNING)
 
-  with open(args.input, 'r') as f:
-    obj = yaml.load(f, Loader=yaml.SafeLoader)
-    ontologies = obj['ontologies']
+    with open(args.input, "r") as f:
+        obj = yaml.load(f, Loader=yaml.SafeLoader)
+        ontologies = obj["ontologies"]
 
-  func = args.function
-  func(ontologies, args)
+    func = args.function
+    func(ontologies, args)
 
 
 def check_urls(ontologies, args):
-  """
-  Ensure PURLs resolve
-  """
-  def test_url(url):
-    try:
-      with closing(requests.get(url, stream=False)) as resp:
-        return resp.status_code == 200
-    except requests.exceptions.InvalidSchema as e:
-      # TODO: requests lib doesn't handle ftp. For now simply return True in that case.
-      if not format(e).startswith("No connection adapters were found for 'ftp:"):
-        raise
-      return True
+    """
+    Ensure PURLs resolve
+    """
 
-  failed_ids = []
-  for ont in ontologies:
-    for p in ont.get('products', []):
-      pid = p['id']
-      if not test_url(p.get('ontology_purl')):
-        failed_ids.append(pid)
-  if len(failed_ids) > 0:
-    print("FAILURES:")
-    for pid in failed_ids:
-      print(pid, file=sys.stderr)
-    exit(1)
+    def test_url(url):
+        try:
+            with closing(requests.get(url, stream=False)) as resp:
+                return resp.status_code == 200
+        except requests.exceptions.InvalidSchema as e:
+            # TODO: requests lib doesn't handle ftp. For now simply return True in that case.
+            if not format(e).startswith("No connection adapters were found for 'ftp:"):
+                raise
+            return True
+
+    failed_ids = []
+    for ont in ontologies:
+        for p in ont.get("products", []):
+            pid = p["id"]
+            if not test_url(p.get("ontology_purl")):
+                failed_ids.append(pid)
+    if len(failed_ids) > 0:
+        print("FAILURES:")
+        for pid in failed_ids:
+            print(pid, file=sys.stderr)
+        exit(1)
 
 
 def extract_context(ontologies, args):
-  """
-  Writes to STDOUT a sorted JSON map from ontology prefixes to PURLs
-  """
-  def has_obo_prefix(obj):
-    return ('uri_prefix' not in obj) or (obj['uri_prefix'] == 'http://purl.obolibrary.org/obo/')
+    """
+    Writes to STDOUT a sorted JSON map from ontology prefixes to PURLs
+    """
 
-  prefix_map = {}
-  for obj in ontologies:
-    if has_obo_prefix(obj):
-      prefix = obj.get('preferredPrefix') or obj['id'].upper()
-      prefix_map[prefix] = "http://purl.obolibrary.org/obo/" + prefix + "_"
+    def has_obo_prefix(obj):
+        return ("uri_prefix" not in obj) or (
+            obj["uri_prefix"] == "http://purl.obolibrary.org/obo/"
+        )
 
-  print(dumps({'@context': prefix_map}, sort_keys=True, indent=4, separators=(',', ': ')))
+    prefix_map = {}
+    for obj in ontologies:
+        if has_obo_prefix(obj):
+            prefix = obj.get("preferredPrefix") or obj["id"].upper()
+            prefix_map[prefix] = "http://purl.obolibrary.org/obo/" + prefix + "_"
+
+    print(
+        dumps(
+            {"@context": prefix_map}, sort_keys=True, indent=4, separators=(",", ": ")
+        )
+    )
 
 
 def write_all_contributors(ontologies, args):
-  """
-  Query github API for all contributors to an ontology,
-  write results as json
-  """
-  results = []
-  for ont_obj in ontologies:
-    id = ont_obj['id']
-    logging.info("Getting info for {}".format(id))
-    repo_path = get_repo_path(ont_obj)
-    if repo_path is not None:
-      contribs = list(get_ontology_contributors(repo_path))
-      print('CONTRIBS({})=={}'.format(id, contribs))
-      for c in contribs:
-        print('#{}\t{}\n'.format(id, c['login']))
-      results.append(dict(id=id, contributors=contribs))
-    else:
-      logging.warn("No repo_path declared for {}".format(id))
-  print(dumps(results, sort_keys=True, indent=4, separators=(',', ': ')))
+    """
+    Query github API for all contributors to an ontology,
+    write results as json
+    """
+    results = []
+    for ont_obj in ontologies:
+        id = ont_obj["id"]
+        logging.info("Getting info for {}".format(id))
+        repo_path = get_repo_path(ont_obj)
+        if repo_path is not None:
+            contribs = list(get_ontology_contributors(repo_path))
+            print("CONTRIBS({})=={}".format(id, contribs))
+            for c in contribs:
+                print("#{}\t{}\n".format(id, c["login"]))
+            results.append(dict(id=id, contributors=contribs))
+        else:
+            logging.warn("No repo_path declared for {}".format(id))
+    print(dumps(results, sort_keys=True, indent=4, separators=(",", ": ")))
 
 
 def get_ontology_contributors(repo_path):
-  """
-  Get individual contributors to a org/repo_path
-  repo_path is a string "org/repo"
-  """
-  url = 'https://api.github.com/repos/{}/contributors'.format(repo_path)
-  # TODO: allow use of oauth token;
-  # GH has a quota for non-logged in API calls
-  time.sleep(3)
-  with closing(requests.get(url, stream=False)) as resp:
-    ok = resp.status_code == 200
-    if ok:
-      results = resp.json()
-      logging.info("RESP={}".format(results))
-      return results
-    else:
-      logging.error("Failed: {}".format(url))
-      return []
+    """
+    Get individual contributors to a org/repo_path
+    repo_path is a string "org/repo"
+    """
+    url = "https://api.github.com/repos/{}/contributors".format(repo_path)
+    # TODO: allow use of oauth token;
+    # GH has a quota for non-logged in API calls
+    time.sleep(3)
+    with closing(requests.get(url, stream=False)) as resp:
+        ok = resp.status_code == 200
+        if ok:
+            results = resp.json()
+            logging.info("RESP={}".format(results))
+            return results
+        else:
+            logging.error("Failed: {}".format(url))
+            return []
 
 
 def get_repo_path(ont_obj):
-  """
-  Extract the repository path for the given object
-  """
-  repo_path = None
-  if 'repository' in ont_obj:
-    repo_path = ont_obj['repository']
-  elif 'tracker' in ont_obj:
-    tracker = ont_obj['tracker']
-    if tracker is not None and 'github' in tracker:
-      repo_path = tracker.replace("/issues", "")
+    """
+    Extract the repository path for the given object
+    """
+    repo_path = None
+    if "repository" in ont_obj:
+        repo_path = ont_obj["repository"]
+    elif "tracker" in ont_obj:
+        tracker = ont_obj["tracker"]
+        if tracker is not None and "github" in tracker:
+            repo_path = tracker.replace("/issues", "")
 
-  if repo_path is not None:
-    repo_path = repo_path.replace("https://github.com/", "")
-    if repo_path.endswith("/"):
-      repo_path = repo_path[:-1]
-    return repo_path
-  else:
-    logging.warn("Could not get gh repo_path for ".format(ont_obj))
-    return None
+    if repo_path is not None:
+        repo_path = repo_path.replace("https://github.com/", "")
+        if repo_path.endswith("/"):
+            repo_path = repo_path[:-1]
+        return repo_path
+    else:
+        logging.warn("Could not get gh repo_path for ".format(ont_obj))
+        return None
 
 
 def run_sparql(obj, p, expected_value, q):
-  """
-  Generate a SPARQL statement using query q and parameter p, and expect 'expected_value' as the
-  result. Print out a message indicating whether the there is or is not a match for the given object
-  """
-  sparql = SPARQLWrapper("http://sparql.hegroup.org/sparql")
-  sparql.setQuery(q)
-  sparql.setReturnFormat(JSON)
-  results = sparql.query().convert()
+    """
+    Generate a SPARQL statement using query q and parameter p, and expect 'expected_value' as the
+    result. Print out a message indicating whether the there is or is not a match for the given object
+    """
+    sparql = SPARQLWrapper("http://sparql.hegroup.org/sparql")
+    sparql.setQuery(q)
+    sparql.setReturnFormat(JSON)
+    results = sparql.query().convert()
 
-  id = obj['id']
-  got_value = False
-  is_match = False
-  vs = []
+    id = obj["id"]
+    got_value = False
+    is_match = False
+    vs = []
 
-  for result in results["results"]["bindings"]:
-    got_value = True
-    v = result[p]["value"]
-    vs.append(str(v))
-    if v == expected_value:
-      is_match = True
+    for result in results["results"]["bindings"]:
+        got_value = True
+        v = result[p]["value"]
+        vs.append(str(v))
+        if v == expected_value:
+            is_match = True
 
-  if got_value and is_match:
-    msg = 'CONSISTENT'
-  elif got_value and not is_match:
-    if expected_value == '':
-      msg = 'UNDECLARED_LOCAL: REMOTE:' + ",".join(vs)
+    if got_value and is_match:
+        msg = "CONSISTENT"
+    elif got_value and not is_match:
+        if expected_value == "":
+            msg = "UNDECLARED_LOCAL: REMOTE:" + ",".join(vs)
+        else:
+            msg = "INCONSISTENT: REMOTE:" + ",".join(vs) + " != LOCAL:" + expected_value
     else:
-      msg = 'INCONSISTENT: REMOTE:' + ",".join(vs) + " != LOCAL:" + expected_value
-  else:
-    msg = 'UNDECLARED_REMOTE'
-  print(id + " " + p + " " + msg)
+        msg = "UNDECLARED_REMOTE"
+    print(id + " " + p + " " + msg)
 
 
 def sparql_compare_ont(obj):
-  """
-  Some ontologies will directly declare some subset of the OBO metadata
-  directly in the ontology header. In the majority of cases we should
-  yield to the provider. However, we reserve the right to override. For
-  example, OBO may have particular guidelines about the length of the title,
-  required for coherency within the registry. All differences should be
-  discussed with the provider and an accomodation reached
-  """
-  if 'ontology_purl' not in obj:
-    return
+    """
+    Some ontologies will directly declare some subset of the OBO metadata
+    directly in the ontology header. In the majority of cases we should
+    yield to the provider. However, we reserve the right to override. For
+    example, OBO may have particular guidelines about the length of the title,
+    required for coherency within the registry. All differences should be
+    discussed with the provider and an accomodation reached
+    """
+    if "ontology_purl" not in obj:
+        return
 
-  purl = obj['ontology_purl']
-  # this could be made more declarative, or driven by the context.jsonld mapping;
-  # however, for now this is relatively simple and easy to understand:
-  run_sparql(obj, 'license', obj['license']['url'] if 'license' in obj else '',
-             "SELECT DISTINCT ?license WHERE {<" + purl +
-             "> <http://purl.org/dc/elements/1.1/license> ?license}")
-  run_sparql(obj, 'title', obj['title'] if 'title' in obj else '',
-             "SELECT DISTINCT ?title WHERE {<" + purl +
-             "> <http://purl.org/dc/elements/1.1/title> ?title}")
-  run_sparql(obj, 'description', obj['description'] if 'description' in obj else '',
-             "SELECT DISTINCT ?description WHERE {<" + purl +
-             "> <http://purl.org/dc/elements/1.1/description> ?description}")
-  run_sparql(obj, 'homepage', obj['homepage'] if 'homepage' in obj else '',
-             "SELECT DISTINCT ?homepage WHERE {<" + purl +
-             "> <http://xmlns.com/foaf/0.1/homepage> ?homepage}")
+    purl = obj["ontology_purl"]
+    # this could be made more declarative, or driven by the context.jsonld mapping;
+    # however, for now this is relatively simple and easy to understand:
+    run_sparql(
+        obj,
+        "license",
+        obj["license"]["url"] if "license" in obj else "",
+        "SELECT DISTINCT ?license WHERE {<"
+        + purl
+        + "> <http://purl.org/dc/elements/1.1/license> ?license}",
+    )
+    run_sparql(
+        obj,
+        "title",
+        obj["title"] if "title" in obj else "",
+        "SELECT DISTINCT ?title WHERE {<"
+        + purl
+        + "> <http://purl.org/dc/elements/1.1/title> ?title}",
+    )
+    run_sparql(
+        obj,
+        "description",
+        obj["description"] if "description" in obj else "",
+        "SELECT DISTINCT ?description WHERE {<"
+        + purl
+        + "> <http://purl.org/dc/elements/1.1/description> ?description}",
+    )
+    run_sparql(
+        obj,
+        "homepage",
+        obj["homepage"] if "homepage" in obj else "",
+        "SELECT DISTINCT ?homepage WHERE {<"
+        + purl
+        + "> <http://xmlns.com/foaf/0.1/homepage> ?homepage}",
+    )
 
 
 def sparql_compare_all(ontologies, args):
-  """
-  Run sparql_compare_ont() on all the given ontologies.
-  """
-  # The `args` parameter is not used here but it is convenient to have it in our definition, since
-  # whether this function or one of the other main `subcommands` of this script is called is
-  # determine dynamically, and we want all of the subcommands to have a consistent signature.
-  for obj in ontologies:
-    sparql_compare_ont(obj)
+    """
+    Run sparql_compare_ont() on all the given ontologies.
+    """
+    # The `args` parameter is not used here but it is convenient to have it in our definition, since
+    # whether this function or one of the other main `subcommands` of this script is called is
+    # determine dynamically, and we want all of the subcommands to have a consistent signature.
+    for obj in ontologies:
+        sparql_compare_ont(obj)
 
 
 if __name__ == "__main__":
-  main()
+    main()

--- a/util/sort-ontologies.py
+++ b/util/sort-ontologies.py
@@ -2,80 +2,91 @@
 
 import csv
 import sys
-import yaml
-
 from argparse import ArgumentParser
+
+import yaml
 
 
 def main(args):
-  parser = ArgumentParser(description='''
+    parser = ArgumentParser(
+        description="""
   Takes a YAML file containing information for various ontologies and a metadata file specifying
-  the sorting order for ontologies, and then produces a sorted version input YAML''')
-  parser.add_argument('unsorted_yaml', type=str,
-                      help='Unsorted YAML file containing information for ontologies')
-  parser.add_argument('metadata_grid', type=str,
-                      help='CSV or TSV file containing metadata information for ontologies')
-  parser.add_argument('output_yaml', type=str,
-                      help='Name of output YAML file that will contain sorted ontology information')
-  args = parser.parse_args()
+  the sorting order for ontologies, and then produces a sorted version input YAML"""
+    )
+    parser.add_argument(
+        "unsorted_yaml",
+        type=str,
+        help="Unsorted YAML file containing information for ontologies",
+    )
+    parser.add_argument(
+        "metadata_grid",
+        type=str,
+        help="CSV or TSV file containing metadata information for ontologies",
+    )
+    parser.add_argument(
+        "output_yaml",
+        type=str,
+        help="Name of output YAML file that will contain sorted ontology information",
+    )
+    args = parser.parse_args()
 
-  data_file = args.unsorted_yaml
-  grid = args.metadata_grid
-  output = args.output_yaml
+    data_file = args.unsorted_yaml
+    grid = args.metadata_grid
+    output = args.output_yaml
 
-  sort_order = get_sort_order(grid)
-  data = load_data(data_file)
-  data = sort_ontologies(data, sort_order)
-  write_data(data, output)
+    sort_order = get_sort_order(grid)
+    data = load_data(data_file)
+    data = sort_ontologies(data, sort_order)
+    write_data(data, output)
 
 
 def get_sort_order(grid):
-  """Given the path to the metadata grid (CSV or TSV), extract the order of
-  ontologies from the grid. Return the list of ontology IDs in that order."""
-  sort_order = []
-  if '.csv' in grid:
-    separator = ','
-  elif '.tsv' or '.txt' in grid:
-    separator = '\t'
-  else:
-    print('%s must be tab- or comma-separated.', file=sys.stderr)
-    sys.exit(1)
-  with open(grid, 'r') as f:
-    reader = csv.reader(f, delimiter=separator)
-    # Ignore the header row:
-    next(reader)
-    for row in reader:
-      # Ontology IDs are in the first column of the CSV/TSV. We simply pull them out of each line
-      # in the file. Their ordering in the file is the sort ordering we are looking for:
-      sort_order.append(row[0])
-  return sort_order
+    """Given the path to the metadata grid (CSV or TSV), extract the order of
+    ontologies from the grid. Return the list of ontology IDs in that order."""
+    sort_order = []
+    if ".csv" in grid:
+        separator = ","
+    elif ".tsv" or ".txt" in grid:
+        separator = "\t"
+    else:
+        print("%s must be tab- or comma-separated.", file=sys.stderr)
+        sys.exit(1)
+    with open(grid, "r") as f:
+        reader = csv.reader(f, delimiter=separator)
+        # Ignore the header row:
+        next(reader)
+        for row in reader:
+            # Ontology IDs are in the first column of the CSV/TSV. We simply pull them out of each line
+            # in the file. Their ordering in the file is the sort ordering we are looking for:
+            sort_order.append(row[0])
+    return sort_order
 
 
 def load_data(data_file):
-  """Given a YAML file, load the data into a dictionary."""
-  stream = open(data_file, 'r')
-  data = yaml.load(stream, Loader=yaml.SafeLoader)
-  return data
+    """Given a YAML file, load the data into a dictionary."""
+    stream = open(data_file, "r")
+    data = yaml.load(stream, Loader=yaml.SafeLoader)
+    return data
 
 
 def sort_ontologies(data, sort_order):
-  """Given the ontologies data as a dictionary and the list of ontologies in
-  proper sort order, return the sorted data."""
-  ontologies = []
-  for ont_id in sort_order:
-    # We assume that ontology ids are unique:
-    ont = [ont for ont in data['ontologies'] if ont['id'] == ont_id].pop()
-    ontologies.append(ont)
-  data['ontologies'] = ontologies
-  return data
+    """Given the ontologies data as a dictionary and the list of ontologies in
+    proper sort order, return the sorted data."""
+    ontologies = []
+    for ont_id in sort_order:
+        # We assume that ontology ids are unique:
+        ont = [ont for ont in data["ontologies"] if ont["id"] == ont_id].pop()
+        ontologies.append(ont)
+    data["ontologies"] = ontologies
+    return data
 
 
 def write_data(data, output):
-  """Given the ontologies data as a dictionary and an output YAML file to
-  write to, write the data to the file."""
-  with open(output, 'w') as f:
-    yaml.safe_dump(data, f, allow_unicode=True)
+    """Given the ontologies data as a dictionary and an output YAML file to
+    write to, write the data to the file."""
+    with open(output, "w") as f:
+        yaml.safe_dump(data, f, allow_unicode=True)
 
 
-if __name__ == '__main__':
-  main(sys.argv)
+if __name__ == "__main__":
+    main(sys.argv)

--- a/util/standardize_license_labels.py
+++ b/util/standardize_license_labels.py
@@ -33,7 +33,7 @@ def update_markdown(path: Union[str, pathlib.Path]) -> None:
     for i in range(1, 3):
         line = lines[idx + i].strip()
         if "url:" in line:
-            _, license_url = line.split(':', 1)
+            _, license_url = line.split(":", 1)
 
     if license_url is None:
         tqdm.write(f"no license URL in {path}")

--- a/util/validate-metadata.py
+++ b/util/validate-metadata.py
@@ -1,346 +1,372 @@
 #!/usr/bin/env python3
 
 import json
-import jsonschema
 import os
 import re
 import sys
-import yaml
-
 from argparse import ArgumentParser
 
+import jsonschema
+import yaml
 
 # Path to JSON schema file:
-SCHEMA_FILE = 'util/schema/registry_schema.json'
+SCHEMA_FILE = "util/schema/registry_schema.json"
 
 # The metadata grid to be generated:
 metadata_grid = {}
 
 
 def main(args):
-  global metadata_grid
-  parser = ArgumentParser(description='''
+    global metadata_grid
+    parser = ArgumentParser(
+        description="""
   Validate registry metadata in the given YAML file yaml_infile and produce two output files:
   1) violations_outfile: a CSV, TSV, or TXT file which contain all metadata violations, and
-  2) grid_outfile: a CSV, TSV, or TXT file which will contain a custom sorted metadata grid''')
-  parser.add_argument('yaml_infile', type=str, help='YAML file containing registry data')
-  parser.add_argument('violations_outfile', type=str,
-                      help='Output file (CSV, TSV, or TXT) to contain metadata violations')
-  parser.add_argument('grid_outfile', type=str,
-                      help='Output file (CSV, TSV, or TXT) to contain custom sorted metadata grid')
-  args = parser.parse_args()
+  2) grid_outfile: a CSV, TSV, or TXT file which will contain a custom sorted metadata grid"""
+    )
+    parser.add_argument(
+        "yaml_infile", type=str, help="YAML file containing registry data"
+    )
+    parser.add_argument(
+        "violations_outfile",
+        type=str,
+        help="Output file (CSV, TSV, or TXT) to contain metadata violations",
+    )
+    parser.add_argument(
+        "grid_outfile",
+        type=str,
+        help="Output file (CSV, TSV, or TXT) to contain custom sorted metadata grid",
+    )
+    args = parser.parse_args()
 
-  yaml_infile = args.yaml_infile
-  violations_outfile = args.violations_outfile
-  grid_outfile = args.grid_outfile
+    yaml_infile = args.yaml_infile
+    violations_outfile = args.violations_outfile
+    grid_outfile = args.grid_outfile
 
-  # Load in the YAML and the JSON schemas that we will need:
-  data = load_data(yaml_infile)
-  schema = get_schema()
+    # Load in the YAML and the JSON schemas that we will need:
+    data = load_data(yaml_infile)
+    schema = get_schema()
 
-  results = {'error': [], 'warn': [], 'info': []}
+    results = {"error": [], "warn": [], "info": []}
 
-  # Validate each object
-  for item in data["ontologies"]:
-    add = validate_metadata(item, schema)
-    results = update_results(results, add)
+    # Validate each object
+    for item in data["ontologies"]:
+        add = validate_metadata(item, schema)
+        results = update_results(results, add)
 
-  # save the metadata-grid with ALL results
-  headers = []
-  for s in schema['properties']:
-    if 'level' in s:
-      headers.append(s)
-  save_grid(metadata_grid, headers, grid_outfile)
+    # save the metadata-grid with ALL results
+    headers = []
+    for s in schema["properties"]:
+        if "level" in s:
+            headers.append(s)
+    save_grid(metadata_grid, headers, grid_outfile)
 
-  # print and save the results that did not pass
-  print_results(results)
-  save_results(results, violations_outfile)
-  if results['error']:
-    print('Metadata validation failed with %d errors - see %s for details'
-          % (len(results['error']), violations_outfile))
-    sys.exit(1)
-  else:
-    print('Metadata validation passed - see %s for warnings' % violations_outfile)
-    sys.exit(0)
+    # print and save the results that did not pass
+    print_results(results)
+    save_results(results, violations_outfile)
+    if results["error"]:
+        print(
+            "Metadata validation failed with %d errors - see %s for details"
+            % (len(results["error"]), violations_outfile)
+        )
+        sys.exit(1)
+    else:
+        print("Metadata validation passed - see %s for warnings" % violations_outfile)
+        sys.exit(0)
 
 
 def load_data(yaml_infile):
-  """Given a YAML data file, load the data to validate."""
-  with open(yaml_infile, 'r') as stream:
-    data = yaml.load(stream, Loader=yaml.SafeLoader)
-  return data
+    """Given a YAML data file, load the data to validate."""
+    with open(yaml_infile, "r") as stream:
+        data = yaml.load(stream, Loader=yaml.SafeLoader)
+    return data
 
 
 def get_schema():
-  """Return a schema from the master schema directory."""
-  schema = None
-  try:
-    file = SCHEMA_FILE
-    with open(file, 'r') as s:
-      schema = json.load(s)
-  except Exception as e:
-    print('Unable to load %s: %s' % (file, str(e)))
-  return schema
+    """Return a schema from the master schema directory."""
+    schema = None
+    try:
+        file = SCHEMA_FILE
+        with open(file, "r") as s:
+            schema = json.load(s)
+    except Exception as e:
+        print("Unable to load %s: %s" % (file, str(e)))
+    return schema
 
 
 def validate_metadata(item, schema):
-  """Given an item and a schema, validate the item against the
-  schema. Add the full results to the metadata_grid and return a map of
-  errors, warnings, and infos for any active ontologies."""
-  global metadata_grid
+    """Given an item and a schema, validate the item against the
+    schema. Add the full results to the metadata_grid and return a map of
+    errors, warnings, and infos for any active ontologies."""
+    global metadata_grid
 
-  ont_id = item['id']
-  # these lists will be displayed on the console:
-  errors = []
-  warnings = []
-  infos = []
-  # these results are put into the metadata grid:
-  results = {}
+    ont_id = item["id"]
+    # these lists will be displayed on the console:
+    errors = []
+    warnings = []
+    infos = []
+    # these results are put into the metadata grid:
+    results = {}
 
-  # determine how to sort this item in the grid:
-  results['foundry'] = True if item.get('in_foundry_order') == 1 else False
-  results['obsolete'] = True if item.get('is_obsolete') is True else False
-  # if there is no status, put them at the bottom with inactive:
-  results['ontology_status'] = item['activity_status'] if 'activity_status' in item else 'inactive'
+    # determine how to sort this item in the grid:
+    results["foundry"] = True if item.get("in_foundry_order") == 1 else False
+    results["obsolete"] = True if item.get("is_obsolete") is True else False
+    # if there is no status, put them at the bottom with inactive:
+    results["ontology_status"] = (
+        item["activity_status"] if "activity_status" in item else "inactive"
+    )
 
-  has_error = False
-  has_warn = False
-  has_info = False
-  try:
-    jsonschema.validate(item, schema)
-  except jsonschema.exceptions.ValidationError as ve:
-      title = list(ve.absolute_schema_path)[0]  # Find the named section within the schema
-      if title == "required":
-        field_names = re.findall(r"\'(.*?)\'", ve.message)  # Rather get which field
-        if len(field_names) > 0:
-          title = field_names[0]
-      if title == "properties":
-        title = list(ve.absolute_schema_path)[1] # Get which field
-      # Get the schema "level" for this field dynamically, if we can
-      if title in list(ve.absolute_schema_path) or title in schema['properties']:
-        if title in list(ve.absolute_schema_path):
-          title_index = list(ve.absolute_schema_path).index(title)
-          path = list(ve.absolute_schema_path)[0:(title_index+1)]
-        else:
-          path = ['properties',title]
-        abs_schema = schema
-        for schema_item in path:
-          if schema_item in abs_schema:
-            if 'level' in abs_schema[schema_item]:
-              level = abs_schema[schema_item]['level']
-            abs_schema = abs_schema[schema_item]
-
-      # add to the results map
-      results[title] = level
-
-      # flag for errors, warnings, and infos
-      # without adding results to the lists that are logged
-      if level == 'error':
-        has_error = True
-      elif level == 'warning':
-        has_warn = True
-      elif level == 'info':
-        has_info = True
-
-      # these cases will not cause test failure and will not be logged
-      # the results are just added to the metadata grid:
-      # - orphaned ontology on contact or license check
-      # - inactive ontology
-      # - obsolete ontology
-      # - ontology annotated with `validate: false`
-      if not ( (item.get('activity_status') == 'orphaned' and \
-              title in ['contact', 'license', 'license-lite']) or \
-              (item.get('is_obsolete') is True or item.get('activity_status') == 'inactive' or \
-                 item.get('validate') is False) ):
-          # get a message for displaying on terminal
-          msg = ve.message
-          if title in ['license', 'license-lite']:
-            # license error message can show up in a few different ways
-            search = re.search('\'(.+?)\' is not one of', msg)
-            if search:
-              msg = '\'%s\' is not a recommended license' % search.group(1)
+    has_error = False
+    has_warn = False
+    has_info = False
+    try:
+        jsonschema.validate(item, schema)
+    except jsonschema.exceptions.ValidationError as ve:
+        title = list(ve.absolute_schema_path)[
+            0
+        ]  # Find the named section within the schema
+        if title == "required":
+            field_names = re.findall(r"\'(.*?)\'", ve.message)  # Rather get which field
+            if len(field_names) > 0:
+                title = field_names[0]
+        if title == "properties":
+            title = list(ve.absolute_schema_path)[1]  # Get which field
+        # Get the schema "level" for this field dynamically, if we can
+        if title in list(ve.absolute_schema_path) or title in schema["properties"]:
+            if title in list(ve.absolute_schema_path):
+                title_index = list(ve.absolute_schema_path).index(title)
+                path = list(ve.absolute_schema_path)[0 : (title_index + 1)]
             else:
-              search = re.search('({\'label\'.+?\'url\'.+?}) is not valid', msg)
-              if search:
-                msg = format_license_msg(search.group(1))
-              else:
-                search = re.search('({\'url\'.+?\'label\'.+?}) is not valid', msg)
+                path = ["properties", title]
+            abs_schema = schema
+            for schema_item in path:
+                if schema_item in abs_schema:
+                    if "level" in abs_schema[schema_item]:
+                        level = abs_schema[schema_item]["level"]
+                    abs_schema = abs_schema[schema_item]
+
+        # add to the results map
+        results[title] = level
+
+        # flag for errors, warnings, and infos
+        # without adding results to the lists that are logged
+        if level == "error":
+            has_error = True
+        elif level == "warning":
+            has_warn = True
+        elif level == "info":
+            has_info = True
+
+        # these cases will not cause test failure and will not be logged
+        # the results are just added to the metadata grid:
+        # - orphaned ontology on contact or license check
+        # - inactive ontology
+        # - obsolete ontology
+        # - ontology annotated with `validate: false`
+        if not (
+            (
+                item.get("activity_status") == "orphaned"
+                and title in ["contact", "license", "license-lite"]
+            )
+            or (
+                item.get("is_obsolete") is True
+                or item.get("activity_status") == "inactive"
+                or item.get("validate") is False
+            )
+        ):
+            # get a message for displaying on terminal
+            msg = ve.message
+            if title in ["license", "license-lite"]:
+                # license error message can show up in a few different ways
+                search = re.search("'(.+?)' is not one of", msg)
                 if search:
-                  msg = format_license_msg(search.group(1))
+                    msg = "'%s' is not a recommended license" % search.group(1)
+                else:
+                    search = re.search("({'label'.+?'url'.+?}) is not valid", msg)
+                    if search:
+                        msg = format_license_msg(search.group(1))
+                    else:
+                        search = re.search("({'url'.+?'label'.+?}) is not valid", msg)
+                        if search:
+                            msg = format_license_msg(search.group(1))
 
-          # format the message with the ontology ID
-          msg = '%s %s: %s' % (ont_id.upper(), title, msg)
+            # format the message with the ontology ID
+            msg = "%s %s: %s" % (ont_id.upper(), title, msg)
 
-          # append to correct set of warnings
-          if level == 'error':
-            errors.append(msg)
-          elif level == 'warning':
-            # warnings are recommended fixes, not required
-            if 'required' in msg:
-              msg = msg.replace('required', 'recommended')
-            warnings.append(msg)
-          elif level == 'info':
-            infos.append(msg)
+            # append to correct set of warnings
+            if level == "error":
+                errors.append(msg)
+            elif level == "warning":
+                # warnings are recommended fixes, not required
+                if "required" in msg:
+                    msg = msg.replace("required", "recommended")
+                warnings.append(msg)
+            elif level == "info":
+                infos.append(msg)
 
-  # add an overall validation status to the grid entry
-  if has_error:
-    results['validation_status'] = 'FAIL'
-  elif has_warn:
-    results['validation_status'] = 'WARN'
-  elif has_info:
-    results['validation_status'] = 'INFO'
-  else:
-    results['validation_status'] = 'PASS'
-  metadata_grid[ont_id] = results
+    # add an overall validation status to the grid entry
+    if has_error:
+        results["validation_status"] = "FAIL"
+    elif has_warn:
+        results["validation_status"] = "WARN"
+    elif has_info:
+        results["validation_status"] = "INFO"
+    else:
+        results["validation_status"] = "PASS"
+    metadata_grid[ont_id] = results
 
-  return {'error': errors, 'warn': warnings, 'info': infos}
+    return {"error": errors, "warn": warnings, "info": infos}
 
 
 def format_license_msg(substr):
-  """Format an exception message for a license issue."""
-  # process to dict
-  d = json.loads(substr.replace('\'', '"'))
-  url = d['url']
-  label = d['label']
-  return '\'{0}\' <{1}> is not a recommended license'.format(label, url)
+    """Format an exception message for a license issue."""
+    # process to dict
+    d = json.loads(substr.replace("'", '"'))
+    url = d["url"]
+    label = d["label"]
+    return "'{0}' <{1}> is not a recommended license".format(label, url)
 
 
 def update_results(results, add):
-  """Given a map of results for all ontologies and a map of results to add,
-  append the results to the lists in the map."""
-  results['error'] = results['error'] + add['error']
-  results['warn'] = results['warn'] + add['warn']
-  results['info'] = results['info'] + add['info']
-  return results
+    """Given a map of results for all ontologies and a map of results to add,
+    append the results to the lists in the map."""
+    results["error"] = results["error"] + add["error"]
+    results["warn"] = results["warn"] + add["warn"]
+    results["info"] = results["info"] + add["info"]
+    return results
 
 
 def sort_grid(metadata_grid):
-  """
-  Given a metadata grid as a map, sort the grid based on:
-  1. Foundry status
-  2. Ontology activity status
-  3. Validation status
-  4. Alphabetical
-  Return a sorted list of IDs.
-  """
-  foundry = {'PASS': [], 'INFO': [], 'WARN': [], 'FAIL': []}
-  active = {'PASS': [], 'INFO': [], 'WARN': [], 'FAIL': []}
-  orphaned = {'PASS': [], 'INFO': [], 'WARN': [], 'FAIL': []}
-  inactive = {'PASS': [], 'INFO': [], 'WARN': [], 'FAIL': []}
-  obsolete = {'PASS': [], 'INFO': [], 'WARN': [], 'FAIL': []}
+    """
+    Given a metadata grid as a map, sort the grid based on:
+    1. Foundry status
+    2. Ontology activity status
+    3. Validation status
+    4. Alphabetical
+    Return a sorted list of IDs.
+    """
+    foundry = {"PASS": [], "INFO": [], "WARN": [], "FAIL": []}
+    active = {"PASS": [], "INFO": [], "WARN": [], "FAIL": []}
+    orphaned = {"PASS": [], "INFO": [], "WARN": [], "FAIL": []}
+    inactive = {"PASS": [], "INFO": [], "WARN": [], "FAIL": []}
+    obsolete = {"PASS": [], "INFO": [], "WARN": [], "FAIL": []}
 
-  for ont_id, results in metadata_grid.items():
-    # get the info about the ontology to sort on
-    ontology_status = results['ontology_status']
-    validation_status = results['validation_status']
+    for ont_id, results in metadata_grid.items():
+        # get the info about the ontology to sort on
+        ontology_status = results["ontology_status"]
+        validation_status = results["validation_status"]
 
-    # foundry ontologies are displayed first
-    # they must be active
-    if results['foundry']:
-      foundry[validation_status].append(ont_id)
-      continue
+        # foundry ontologies are displayed first
+        # they must be active
+        if results["foundry"]:
+            foundry[validation_status].append(ont_id)
+            continue
 
-    # obsolete ontologies are displayed last
-    # they are always inactive
-    # (inactive does not mean obsolete)
-    if results['obsolete']:
-      obsolete[validation_status].append(ont_id)
-      continue
+        # obsolete ontologies are displayed last
+        # they are always inactive
+        # (inactive does not mean obsolete)
+        if results["obsolete"]:
+            obsolete[validation_status].append(ont_id)
+            continue
 
-    # finally, sort by: active, orphaned, inactive
-    if ontology_status == 'active':
-      active[validation_status].append(ont_id)
-    elif ontology_status == 'orphaned':
-      orphaned[validation_status].append(ont_id)
-    elif ontology_status == 'inactive':
-      inactive[validation_status].append(ont_id)
+        # finally, sort by: active, orphaned, inactive
+        if ontology_status == "active":
+            active[validation_status].append(ont_id)
+        elif ontology_status == "orphaned":
+            orphaned[validation_status].append(ont_id)
+        elif ontology_status == "inactive":
+            inactive[validation_status].append(ont_id)
 
-  # concatenate everything to a sorted list:
-  def sort_list(arr):
-    arr.sort(key=str.lower)
-    if not arr:
-      return []
-    return arr
+    # concatenate everything to a sorted list:
+    def sort_list(arr):
+        arr.sort(key=str.lower)
+        if not arr:
+            return []
+        return arr
 
-  sort = []
-  for ont_type in [foundry, active, orphaned, inactive, obsolete]:
-    for v_status in ['PASS', 'INFO', 'WARN', 'FAIL']:
-      sort = sort + sort_list(ont_type[v_status])
+    sort = []
+    for ont_type in [foundry, active, orphaned, inactive, obsolete]:
+        for v_status in ["PASS", "INFO", "WARN", "FAIL"]:
+            sort = sort + sort_list(ont_type[v_status])
 
-  return sort
+    return sort
 
 
 def save_grid(metadata_grid, headers, grid_outfile):
-  """Given a metadata grid of all results and a grid file to write to, create
-  a sorted table of the full results."""
-  if '.csv' in grid_outfile:
-    separator = ','
-  elif '.tsv' or '.txt' in grid_outfile:
-    separator = '\t'
-  else:
-    print('Grid file must be CSV, TSV, or TXT', file=sys.stderr)
-    return
+    """Given a metadata grid of all results and a grid file to write to, create
+    a sorted table of the full results."""
+    if ".csv" in grid_outfile:
+        separator = ","
+    elif ".tsv" or ".txt" in grid_outfile:
+        separator = "\t"
+    else:
+        print("Grid file must be CSV, TSV, or TXT", file=sys.stderr)
+        return
 
-  # Determine order of ontologies based on statuses
-  sort_order = sort_grid(metadata_grid)
+    # Determine order of ontologies based on statuses
+    sort_order = sort_grid(metadata_grid)
 
-  # First three help to see overall details
-  header = 'Ontology{0}Activity Status{0}Validation Status'.format(separator)
-  # After that, we show the results of each check
-  for h in headers:
-    header += separator + h
-  header += '\n'
+    # First three help to see overall details
+    header = "Ontology{0}Activity Status{0}Validation Status".format(separator)
+    # After that, we show the results of each check
+    for h in headers:
+        header += separator + h
+    header += "\n"
 
-  with open(grid_outfile, 'w') as f:
-    f.write(header)
-    for ont_id in sort_order:
-      results = metadata_grid[ont_id]
-      s = '{1}{0}{2}{0}{3}'.format(separator, ont_id, results['ontology_status'],
-                                   results['validation_status'])
-      for h in headers:
-        if h == 'license':
-          # license has two checks
-          # so the license entry will be the more severe violation
-          all_res = [results['license'], results['license-lite']]
-          if 'error' in all_res:
-            s += separator + 'error'
-          elif 'warning' in all_res:
-            s += separator + 'warning'
-          elif 'info' in all_res:
-            s += separator + 'info'
-          else:
-            s += separator + 'pass'
-          continue
-        s += separator + results[h]
-      s += '\n'
-      f.write(s)
+    with open(grid_outfile, "w") as f:
+        f.write(header)
+        for ont_id in sort_order:
+            results = metadata_grid[ont_id]
+            s = "{1}{0}{2}{0}{3}".format(
+                separator,
+                ont_id,
+                results["ontology_status"],
+                results["validation_status"],
+            )
+            for h in headers:
+                if h == "license":
+                    # license has two checks
+                    # so the license entry will be the more severe violation
+                    all_res = [results["license"], results["license-lite"]]
+                    if "error" in all_res:
+                        s += separator + "error"
+                    elif "warning" in all_res:
+                        s += separator + "warning"
+                    elif "info" in all_res:
+                        s += separator + "info"
+                    else:
+                        s += separator + "pass"
+                    continue
+                s += separator + results[h]
+            s += "\n"
+            f.write(s)
 
-  print('Full validation results written to %s' % grid_outfile)
+    print("Full validation results written to %s" % grid_outfile)
 
 
 def print_results(results):
-  """Given a map of results, log results on the console."""
-  for level, messages in results.items():
-    for m in messages:
-      print('%s\t%s' % (level.upper(), m))
+    """Given a map of results, log results on the console."""
+    for level, messages in results.items():
+        for m in messages:
+            print("%s\t%s" % (level.upper(), m))
 
 
 def save_results(results, violations_outfile):
-  """Given a map of results and an output file to write to, write each result
-  on a line."""
-  if '.csv' in violations_outfile:
-    separator = ','
-  elif '.tsv' or '.txt' in violations_outfile:
-    separator = '\t'
-  else:
-    print('Output file must be CSV, TSV, or TXT', file=sys.stderr)
-    return
-  with open(violations_outfile, 'w') as f:
-    f.write('Level%sMessage\n' % separator)
-    for level, messages in results.items():
-      for m in messages:
-        f.write('%s%s%s\n' % (level.upper(), separator, m))
+    """Given a map of results and an output file to write to, write each result
+    on a line."""
+    if ".csv" in violations_outfile:
+        separator = ","
+    elif ".tsv" or ".txt" in violations_outfile:
+        separator = "\t"
+    else:
+        print("Output file must be CSV, TSV, or TXT", file=sys.stderr)
+        return
+    with open(violations_outfile, "w") as f:
+        f.write("Level%sMessage\n" % separator)
+        for level, messages in results.items():
+            for m in messages:
+                f.write("%s%s%s\n" % (level.upper(), separator, m))
 
 
-if __name__ == '__main__':
-  main(sys.argv)
+if __name__ == "__main__":
+    main(sys.argv)

--- a/util/yaml2json.py
+++ b/util/yaml2json.py
@@ -1,19 +1,23 @@
 #!/usr/bin/env python3
 
-import yaml
 import json
-
 from argparse import ArgumentParser
 
-__author__ = 'cjm'
+import yaml
+
+__author__ = "cjm"
 
 
-parser = ArgumentParser(description="Converts a YAML file to JSON, writing the result to STDOUT")
-parser.add_argument('yaml_file', type=str, help='YAML file to convert')
+parser = ArgumentParser(
+    description="Converts a YAML file to JSON, writing the result to STDOUT"
+)
+parser.add_argument("yaml_file", type=str, help="YAML file to convert")
 args = parser.parse_args()
 
-with open(args.yaml_file, 'r') as stream:
-  data = yaml.load(stream, Loader=yaml.SafeLoader)
-data['@context'] = "http://obofoundry.github.io/registry/context.jsonld"
-json = json.dumps(data, sort_keys=True, indent=4, ensure_ascii=False, separators=(',', ': '))
+with open(args.yaml_file, "r") as stream:
+    data = yaml.load(stream, Loader=yaml.SafeLoader)
+data["@context"] = "http://obofoundry.github.io/registry/context.jsonld"
+json = json.dumps(
+    data, sort_keys=True, indent=4, ensure_ascii=False, separators=(",", ": ")
+)
 print(json)


### PR DESCRIPTION
Building on the new code quality assurance framework introduced in #1686, this PR does the following:

1. Adds linting configuation in `pyproject.toml` for `black` and `isort`
2. Adds run configuration for linting in `tox.ini`
3. Adds flake8 plugins for ensuring `black` and `isort` were applied
4. Applies `black` and `isort` to all Python files
5. Updates the CONTRIBUTING.md file to tell people to run these linters on their code

## Why all of this code churn?

Right now, it's very tough to read the Python code due to stylistic differences from the many contributors (not to say anyone has bad code style, but just there's an issue when it has a lot of variety in a given project). Using a linter makes the style more consistent, the code more approachable, and ultimately, more maintainable. 