### PR TITLE
Add information for people that wish to register a prefix but are not (yet) ready for OBO Foundry

### DIFF
--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -98,6 +98,7 @@
             <!-- these just direct to the relevant pages: I think someone should make dedicated FAQ entries -->
             <li><a href="/principles/fp-000-summary.html">What are the OBO Foundry Principles?</a></li>
             <li><a href="/id-policy.html">What is the OBO ID Policy?</a></li>
+            <li><a href="/docs/ReserveNamespace.html">My ontology is not ready for OBO Foundry, can I reserve a namespace anyway?</a></li>
             <li role="separator" class="divider"></li>
             <li><i>Citation</i></li>
             <li><a href="/docs/Citation.html">How do I cite an ontology?</a></li>

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -98,7 +98,7 @@
             <!-- these just direct to the relevant pages: I think someone should make dedicated FAQ entries -->
             <li><a href="/principles/fp-000-summary.html">What are the OBO Foundry Principles?</a></li>
             <li><a href="/id-policy.html">What is the OBO ID Policy?</a></li>
-            <li><a href="/docs/ReserveNamespace.html">My ontology is not ready for OBO Foundry, can I reserve a namespace anyway?</a></li>
+            <li><a href="/docs/ReservePrefix.html">My ontology is not ready for OBO Foundry, can I reserve a prefix anyway?</a></li>
             <li role="separator" class="divider"></li>
             <li><i>Citation</i></li>
             <li><a href="/docs/Citation.html">How do I cite an ontology?</a></li>

--- a/docs/ReserveNamespace.md
+++ b/docs/ReserveNamespace.md
@@ -1,0 +1,5 @@
+# My ontology is not ready for OBO Foundry, can I reserve a namespace anyway?
+
+If your ontology is not eligible for inclusion in the OBO Foundry you can not directly reserve a namespace in the OBO Foundry. 
+However, if you want to make sure that no one uses your prefix, you can [register your prefix at the Bioregistry](https://github.com/biopragmatics/bioregistry/issues/new/choose).
+The updated [OBO policy on IDs](https://obofoundry.org/id-policy) ensures that new prefix requests must not clash with existing prefixes registered at the Bioregistry.

--- a/docs/ReserveNamespace.md
+++ b/docs/ReserveNamespace.md
@@ -1,3 +1,9 @@
+---
+layout: doc
+id: ReserveNamespace
+title: Reserve Namespace outside of OBO
+---
+
 # My ontology is not ready for OBO Foundry, can I reserve a namespace anyway?
 
 If your ontology is not eligible for inclusion in the OBO Foundry you can not directly reserve a namespace in the OBO Foundry. 

--- a/docs/ReserveNamespace.md
+++ b/docs/ReserveNamespace.md
@@ -3,3 +3,5 @@
 If your ontology is not eligible for inclusion in the OBO Foundry you can not directly reserve a namespace in the OBO Foundry. 
 However, if you want to make sure that no one uses your prefix, you can [register your prefix at the Bioregistry](https://github.com/biopragmatics/bioregistry/issues/new/choose).
 The updated [OBO policy on IDs](https://obofoundry.org/id-policy) ensures that new prefix requests must not clash with existing prefixes registered at the Bioregistry.
+
+_Note_: when making a OBO Foundry New Ontology Request which conflicts with a previously registered prefix at one of the registries listed by the [OBO policy on IDs](https://obofoundry.org/id-policy), you will be asked to provide evidence that the submitted ontology and the previously submitted prefix (i.e. at the Bioregistry) indeed refer to the same resource.

--- a/docs/ReservePrefix.md
+++ b/docs/ReservePrefix.md
@@ -1,7 +1,7 @@
 ---
 layout: doc
 id: ReservePrefix
-title: Reserve Prefix outside of OBO
+title: Reserve prefix outside of OBO
 ---
 
 # My ontology is not ready for OBO Foundry, can I reserve a prefix anyway?

--- a/docs/ReservePrefix.md
+++ b/docs/ReservePrefix.md
@@ -1,12 +1,12 @@
 ---
 layout: doc
-id: ReserveNamespace
-title: Reserve Namespace outside of OBO
+id: ReservePrefix
+title: Reserve Prefix outside of OBO
 ---
 
-# My ontology is not ready for OBO Foundry, can I reserve a namespace anyway?
+# My ontology is not ready for OBO Foundry, can I reserve a prefix anyway?
 
-If your ontology is not eligible for inclusion in the OBO Foundry you can not directly reserve a namespace in the OBO Foundry. 
+If your ontology is not eligible for inclusion in the OBO Foundry you can not directly reserve a prefix (Ontology ID) in the OBO Foundry. 
 However, if you want to make sure that no one uses your prefix, you can [register your prefix at the Bioregistry](https://github.com/biopragmatics/bioregistry/issues/new/choose).
 The updated [OBO policy on IDs](https://obofoundry.org/id-policy) ensures that new prefix requests must not clash with existing prefixes registered at the Bioregistry.
 


### PR DESCRIPTION
An FAQ on what to do if your ontology is _not_ eligible for OBO Foundry, but the requestor wants to ensure that the prefix is not easily snatched.