### PR TITLE
Mark FMA as inactive

### DIFF
--- a/ontology/fma.md
+++ b/ontology/fma.md
@@ -29,7 +29,7 @@ build:
   insert_ontology_id: true
   method: obo2owl
 tracker: https://sourceforge.net/p/obo/foundational-model-of-anatomy-fma-requests/
-activity_status: active
+activity_status: inactive
 preferredPrefix: FMA
 ---
 


### PR DESCRIPTION
There are a couple lines of discussion currently going with ex-FMA people via an email chain (unfortunately it wasn't really possible to get participation on any common public channels). Most of them are retired or unable/unmotivated/not funded to do some of the things necessary to keep FMA marked as "active". There are no current maintainers and no plans to do maintenance nor participate on a public tracker, therefore this ontology should be marked as inactive. If any of those change, then it could be marked again as active.