### PR TITLE
Mark `homepage` as a required property

### DIFF
--- a/ontology/epio.md
+++ b/ontology/epio.md
@@ -18,6 +18,7 @@ contact:
   email: alpha.tom.kodamullil@scai.fraunhofer.de
   label: Alpha Tom Kodamullil
   github: akodamullil
+homepage: https://github.com/SCAI-BIO/EpilepsyOntology
 repository: https://github.com/SCAI-BIO/EpilepsyOntology
 activity_status: active
 preferredPrefix: EPIO

--- a/ontology/fix.md
+++ b/ontology/fix.md
@@ -11,6 +11,7 @@ build:
   method: obo2owl
   infallible: 1
   insert_ontology_id: true
+homepage: http://www.ebi.ac.uk/chebi
 products:
   - id: fix.owl
   - id: fix.obo

--- a/util/schema/registry_schema.json
+++ b/util/schema/registry_schema.json
@@ -136,8 +136,8 @@
 			"suggest": false
 		},
 		"homepage": {
-			"level": "warning",
-			"description": "'homepage' is a recommended property. The value is the full URL to the homepage.",
+			"level": "error",
+			"description": "'homepage' is a required property. The value is the full URL to the homepage.",
 			"type": "string",
 			"format": "uri"
 		},


### PR DESCRIPTION
As a follow-up to #1668, this PR marks the `homepage` as an error-level required property, such that any future ontologies like EPIO that did not submit a homepage will cause the technical checks to fail and notify reviewers not to merge a new ontology request.

This PR also adds a stub homepage for the following repositories:
1. EPIO by duplicating its GitHub repository
2. FIX by including the ChEBI link, since it's part of ChEBI