### PR TITLE
Ensure future ontologies conform to FP-001

### DIFF
--- a/util/schema/registry_schema.json
+++ b/util/schema/registry_schema.json
@@ -171,7 +171,7 @@
 			"enum": ["ontology_detail"]
 		},
 		"license": {
-			"level": "warning",
+			"level": "error",
 			"principle": "http://obofoundry.org/principles/fp-001-open.html",
 			"description": "'license' is a required property. The value is an object with a 'url' and 'label' field. The 'url' must be the full URL of the license, and the 'label' is the name of the license. It is recommended that the 'license' value is CC0 or CC-BY.",
 			"type": "object",

--- a/util/validate-metadata.py
+++ b/util/validate-metadata.py
@@ -186,10 +186,7 @@ def validate_metadata(item, schema):
                 or item.get("activity_status") == "inactive"
                 or item.get("validate") is False
             )
-            or (
-                title == "license"
-                and ont_id in LEGACY_LICENSE_PREFIXES
-            )
+            or (title == "license" and ont_id in LEGACY_LICENSE_PREFIXES)
         ):
             # get a message for displaying on terminal
             msg = ve.message

--- a/util/validate-metadata.py
+++ b/util/validate-metadata.py
@@ -16,6 +16,18 @@ SCHEMA_FILE = "util/schema/registry_schema.json"
 metadata_grid = {}
 
 
+#: These ontologies have invalid licenses, but they're grandfathered in
+LEGACY_LICENSE_PREFIXES = {
+    "gsso",
+    "hp",
+    "kisao",
+    "mamo",
+    "sbo",
+    "scdo",
+    "txpo",
+}
+
+
 def main(args):
     global metadata_grid
     parser = ArgumentParser(
@@ -163,6 +175,7 @@ def validate_metadata(item, schema):
         # - inactive ontology
         # - obsolete ontology
         # - ontology annotated with `validate: false`
+        # - ontology in legacy license exception list
         if not (
             (
                 item.get("activity_status") == "orphaned"
@@ -172,6 +185,10 @@ def validate_metadata(item, schema):
                 item.get("is_obsolete") is True
                 or item.get("activity_status") == "inactive"
                 or item.get("validate") is False
+            )
+            or (
+                title == "license"
+                and ont_id in LEGACY_LICENSE_PREFIXES
             )
         ):
             # get a message for displaying on terminal


### PR DESCRIPTION
Before this PR, the license check is marked as "warning" instead of "error" to support the fact that OBO Foundry includes some ontologies with legacy licenses. 

While I'm sure it would be awfully difficult or impossible to convince any of these ontologies' maintainers to update their respective licenses solely to be compliant with the OBO Foundry standard FP-001 (there aren't really any formal consequences with being non-conformant), this PR will ensure that no new ontologies are added to the OBO Foundry that do not conform to FP-001

This is technically accomplished by doing the following:
1. Upgrade warning to error for license checking
2. Adding a curated list of ontologies with grandfathered in invalid licenses
3. Throwing away any errors in the error report generation due to those ontologies' licenses.

Combine with the fact that #1686 is already merged, this effectively supercedes #1683 (albeit, without the benefit of the testing becoming more legible).