### PR TITLE
Update schema validation to require `tracker` and `contact.github`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ build/
 /venv
 tmp/
 *.tmp
+.venv

--- a/ontology/bto.md
+++ b/ontology/bto.md
@@ -4,6 +4,7 @@ id: bto
 contact:
   email: a.chang@tu-bs.de
   label: Antje Chang
+  github: BRENDA-Enzymes
 description: A structured controlled vocabulary for the source of an enzyme comprising tissues, cell lines, cell types and cell cultures.
 domain: anatomy
 homepage: http://www.brenda-enzymes.org

--- a/util/schema/registry_schema.json
+++ b/util/schema/registry_schema.json
@@ -379,7 +379,7 @@
 			"type": "string"
 		},
 		"tracker": {
-			"level": "warning",
+			"level": "error",
 			"description": "'tracker' is a recommended field. The value is the URI of an issue tracker for the ontology.",
 			"type": "string",
 			"format": "uri"

--- a/util/schema/registry_schema.json
+++ b/util/schema/registry_schema.json
@@ -68,7 +68,7 @@
 		"contact": {
 			"level": "error",
 			"principle": "http://obofoundry.org/principles/fp-011-locus-of-authority.html",
-			"description": "'contact' is a required property. This object must include an email and a label (the name of the contact). The contact is the person responsible for communications between the community and the ontology developers.",
+			"description": "'contact' is a required property. This object must include the contact person's name (i.e., label), their personal email, and their personal GitHub handle. The contact is the person responsible for communications between the community and the ontology developers.",
 			"type": "object",
 			"additionalProperties": false,
 			"properties": {
@@ -85,7 +85,7 @@
 					"pattern": "^[^@]+$"
 				}
 			},
-			"required": [ "email","label" ]
+			"required": [ "email","label","github" ]
 		},
 		"createdWith": {
 			"suggest": false


### PR DESCRIPTION
This PR does two things:

1. Changes the `tracker` level to `error` so it's actually validated. Luckily, all active ontologies have trackers and this requires no change.
2. Adds the "github" field to required in the contact and update the text accordingly. 
3. (cautiously) Add @BRENDA-Enzymes as the GitHub handle for Antje Chang. Unfortunately I have been unsuccessful in getting in contact with them to see if this is their personal handle that they happen to only use for maintenance of BRENDA. This was the only entry that did not have a GitHub handle at this point so at risk of being slightly incorrect, I think it's worth it to enable this check for later.