### PR TITLE
Add ORCID identifiers to all active ontologies and update metadata schema

### DIFF
--- a/ontology/aero.md
+++ b/ontology/aero.md
@@ -2,6 +2,7 @@
 layout: ontology_detail
 id: aero
 contact:
+  orcid: 0000-0002-9551-6370
   email: mcourtot@gmail.com
   label: Melanie Courtot
 description: The Adverse Event Reporting Ontology (AERO) is an ontology aimed at supporting clinicians at the time of data entry, increasing quality and accuracy of reported adverse events

--- a/ontology/agro.md
+++ b/ontology/agro.md
@@ -16,6 +16,7 @@ contact:
   email: m.a.laporte@cgiar.org
   label: Marie-Angélique Laporte
   github: "marieALaporte"
+  orcid: 0000-0002-8461-9745
 products:
   - id: agro.owl
     title: "AgrO"

--- a/ontology/aism.md
+++ b/ontology/aism.md
@@ -10,6 +10,7 @@ contact:
   email: entiminae@gmail.com
   label: Jennifer C. Girón
   github: JCGiron
+  orcid: 0000-0002-0851-6883
 description: The AISM contains terms used in insect biodiversity research for describing structures of the exoskeleton and the skeletomuscular system. It aims to serve as the basic backbone of generalized terms to be expanded with order-specific terminology.
 domain: anatomy
 homepage: https://github.com/insect-morphology/aism

--- a/ontology/amphx.md
+++ b/ontology/amphx.md
@@ -10,6 +10,7 @@ contact:
   email: hescriva@obs-banyuls.fr
   label: Hector Escriva
   github: hescriva
+  orcid: 0000-0001-7577-5028
 description: An ontology for the development and anatomy of Amphioxus (Branchiostoma lanceolatum).
 domain: anatomy
 homepage: https://github.com/EBISPOT/amphx_ontology

--- a/ontology/apo.md
+++ b/ontology/apo.md
@@ -5,6 +5,7 @@ contact:
   email: stacia@stanford.edu
   label: Stacia R Engel
   github: srengel
+  orcid: 0000-0001-5472-917X
 tracker: https://github.com/obophenotype/ascomycete-phenotype-ontology/issues
 license:
   url: https://creativecommons.org/licenses/by/4.0/

--- a/ontology/apollo_sv.md
+++ b/ontology/apollo_sv.md
@@ -5,6 +5,7 @@ contact:
   email: MBrochhausen@uams.edu
   label: Mathias Brochhausen
   github: mbrochhausen
+  orcid: 0000-0003-1834-3856
 homepage: https://github.com/ApolloDev/apollo-sv
 description: Defines terms and relations necessary for interoperation between epidemic models and public health application software that interface with these models
 products:

--- a/ontology/aro.md
+++ b/ontology/aro.md
@@ -5,6 +5,7 @@ contact:
   email: mcarthua@mcmaster.ca
   label: Andrew G. McArthur
   github: agmcarthur
+  orcid: 0000-0002-1142-3063
 description: Antibiotic resistance genes and mutations
 homepage: https://github.com/arpcard/aro
 license:

--- a/ontology/bcgo.md
+++ b/ontology/bcgo.md
@@ -9,6 +9,7 @@ contact:
   email: jiezheng@pennmedicine.upenn.edu
   label: Jie Zheng
   github: zhengj2007
+  orcid: 0000-0002-2999-0103
 products:
   - id: bcgo.owl
 tracker: https://github.com/obi-bcgo/bcgo/issues

--- a/ontology/bco.md
+++ b/ontology/bco.md
@@ -6,6 +6,7 @@ contact:
   email: rlwalls2008@gmail.com
   label: Ramona Walls
   github: ramonawalls
+  orcid: 0000-0001-8815-0078
 license:
   url: https://creativecommons.org/publicdomain/zero/1.0/
   label: CC0 1.0

--- a/ontology/bfo.md
+++ b/ontology/bfo.md
@@ -6,6 +6,7 @@ contact:
   email: phismith@buffalo.edu
   label: Barry Smith
   github: phismith
+  orcid: 0000-0003-1384-116X
 description: The upper level ontology upon which OBO Foundry ontologies are built.
 domain: upper
 homepage: http://ifomis.org/bfo/

--- a/ontology/bspo.md
+++ b/ontology/bspo.md
@@ -5,6 +5,7 @@ contact:
   email: cjmungall@lbl.gov
   label: Chris Mungall
   github: cmungall
+  orcid: 0000-0002-6601-2165
 description: An ontology for representing spatial concepts, anatomical axes, gradients, regions, planes, sides, and surfaces
 domain: anatomy
 homepage: https://github.com/obophenotype/biological-spatial-ontology

--- a/ontology/bto.md
+++ b/ontology/bto.md
@@ -5,6 +5,7 @@ contact:
   email: c.dudek@tu-braunschweig.de
   label: Christian-Alexander Dudek
   github: chdudek
+  orcid: 0000-0001-9117-7909
 description: A structured controlled vocabulary for the source of an enzyme comprising tissues, cell lines, cell types and cell cultures.
 domain: anatomy
 homepage: http://www.brenda-enzymes.org

--- a/ontology/caro.md
+++ b/ontology/caro.md
@@ -5,6 +5,7 @@ contact:
   email: haendel@ohsu.edu
   label: Melissa Haendel
   github: mellybelly
+  orcid: 0000-0001-9114-8737
 license:
   url: https://creativecommons.org/licenses/by/3.0/
   label: CC BY 3.0

--- a/ontology/cdao.md
+++ b/ontology/cdao.md
@@ -5,6 +5,7 @@ contact:
   email: balhoff@renci.org
   label: Jim Balhoff
   github: balhoff
+  orcid: 0000-0002-8688-6599
 description: a formalization of concepts and relations relevant to evolutionary comparative analysis
 homepage: https://github.com/evoinfo/cdao
 products:

--- a/ontology/cdno.md
+++ b/ontology/cdno.md
@@ -10,6 +10,7 @@ contact:
   email: l.andres.hernandez.18@student.scu.edu.au
   label: Liliana Andres Hernandez
   github: LilyAndres
+  orcid: 0000-0002-7696-731X
 description: CDNO provides structured terminologies to describe nutritional attributes of material entities that contribute to human diet.
 domain: diet, metabolomics and nutrition
 homepage: https://github.com/Southern-Cross-Plant-Science/cdno

--- a/ontology/ceph.md
+++ b/ontology/ceph.md
@@ -11,6 +11,7 @@ contact:
   email: cjmungall@lbl.gov
   label: Chris Mungall
   github: cmungall
+  orcid: 0000-0002-6601-2165
 description: An anatomical and developmental ontology for cephalopods
 domain: anatomy
 homepage: https://github.com/obophenotype/cephalopod-ontology

--- a/ontology/chebi.md
+++ b/ontology/chebi.md
@@ -16,6 +16,7 @@ contact:
   email: amalik@ebi.ac.uk
   label: Adnan Malik
   github: "amalik01"
+  orcid: 0000-0001-8123-5351
 license:
   url: https://creativecommons.org/licenses/by/4.0/
   label: CC BY 4.0

--- a/ontology/cheminf.md
+++ b/ontology/cheminf.md
@@ -5,6 +5,7 @@ contact:
   email: egon.willighagen@gmail.com
   label: Egon Willighagen
   github: egonw
+  orcid: 0000-0001-7542-0286
 tracker: https://github.com/semanticchemistry/semanticchemistry/issues
 license:
   url: http://creativecommons.org/licenses/by/4.0/

--- a/ontology/chiro.md
+++ b/ontology/chiro.md
@@ -13,6 +13,7 @@ contact:
   email: vasilevs@ohsu.edu
   label: Nicole Vasilevsky
   github: nicolevasilevsky
+  orcid: 0000-0001-5208-3432
 description: CHEBI provides a distinct role hierarchy. Chemicals in the structural hierarchy are connected via a 'has role' relation. CHIRO provides links from these roles to useful other classes in other ontologies. This will allow direct connection between chemical structures (small molecules, drugs) and what they do. This could be formalized using 'capable of', in the same way Uberon and the Cell Ontology link structures to processes.
 domain: biochemistry
 homepage: https://github.com/obophenotype/chiro

--- a/ontology/chmo.md
+++ b/ontology/chmo.md
@@ -8,6 +8,7 @@ contact:
   email: batchelorc@rsc.org
   label: Colin Batchelor
   github: batchelorc
+  orcid: 0000-0001-5985-7429
 mailing_list: "chemistry-ontologies@googlegroups.com"
 description: CHMO, the chemical methods ontology, describes methods used to
 domain: health

--- a/ontology/cido.md
+++ b/ontology/cido.md
@@ -10,6 +10,7 @@ contact:
   email: yongqunh@med.umich.edu
   label: Yongqun Oliver He
   github: yongqunh
+  orcid: 0000-0001-9189-9661
 products:
   - id: cido.owl
 license:

--- a/ontology/cio.md
+++ b/ontology/cio.md
@@ -5,6 +5,7 @@ contact:
   label: Frédéric Bastian
   email: frederic.bastian@unil.ch
   github: fbastian
+  orcid: 0000-0002-9415-5104
 license:
   url: https://creativecommons.org/publicdomain/zero/1.0/
   label: CC0 1.0

--- a/ontology/cl.md
+++ b/ontology/cl.md
@@ -19,6 +19,7 @@ contact:
   label: Alexander Diehl
   email: addiehl@buffalo.edu
   github: addiehl
+  orcid: 0000-0001-9990-8331
 license:
   url: http://creativecommons.org/licenses/by/4.0/
   label: CC BY 4.0

--- a/ontology/clao.md
+++ b/ontology/clao.md
@@ -10,6 +10,7 @@ contact:
   email: lagonzalezmo@unal.edu.co
   label: Luis González-Montaña
   github: luis-gonzalez-m
+  orcid: 0000-0002-9136-9932
 description: "CLAO is an ontology of anatomical terms employed in morphological descriptions for the Class Collembola (Arthropoda: Hexapoda)."
 domain: anatomy
 homepage: https://github.com/luis-gonzalez-m/Collembola

--- a/ontology/clo.md
+++ b/ontology/clo.md
@@ -5,6 +5,7 @@ contact:
   email: siiraa@umich.edu
   label: Sirarat Sarntivijai
   github: siiraa
+  orcid: 0000-0002-2548-641X
 description: An ontology to standardize and integrate cell line information and to support computer-assisted reasoning.
 homepage: http://www.clo-ontology.org
 products:

--- a/ontology/clyh.md
+++ b/ontology/clyh.md
@@ -10,6 +10,7 @@ contact:
   email: lucas.leclere@obs-vlfr.fr
   label: Lucas Leclere
   github: L-Leclere
+  orcid: 0000-0002-7440-0467
 description: The Clytia hemisphaerica Development and Anatomy Ontology (CLYH) describes the anatomical and developmental features of the Clytia hemisphaerica life cycle.
 domain: anatomy
 homepage: https://github.com/EBISPOT/clyh_ontology

--- a/ontology/cmf.md
+++ b/ontology/cmf.md
@@ -3,6 +3,7 @@ layout: ontology_detail
 id: cmf
 title: CranioMaxilloFacial ontology
 contact:
+  orcid: 0000-0001-5889-4463
   email: engelsta@ohsu.edu
   label: Mark Engelstad
 homepage: https://code.google.com/p/craniomaxillofacial-ontology/

--- a/ontology/cmo.md
+++ b/ontology/cmo.md
@@ -5,6 +5,7 @@ contact:
   email: jrsmith@mcw.edu
   label: Jennifer Smith
   github: jrsjrs
+  orcid: 0000-0002-6443-9376
 license:
   url: http://creativecommons.org/publicdomain/zero/1.0/
   label: CC0 1.0

--- a/ontology/cob.md
+++ b/ontology/cob.md
@@ -5,6 +5,7 @@ contact:
   email: bpeters@lji.org
   label: Bjoern Peters
   github: bpeters42
+  orcid: 0000-0002-8457-6693
 description: COB brings together key terms from a wide range of OBO projects to improve interoperability.
 domain: upper
 homepage: https://github.com/OBOFoundry/COB

--- a/ontology/colao.md
+++ b/ontology/colao.md
@@ -6,6 +6,7 @@ contact:
   email: entiminae@gmail.com
   label: Jennifer C. Giron
   github: JCGiron
+  orcid: 0000-0002-0851-6883
 description: "The Coleoptera Anatomy Ontology contains terms used for describing the anatomy and phenotype of beetles in biodiversity research. It has been built using the Ontology Develoment Kit, with the Ontology for the Anatomy of the Insect Skeleto-Muscular system (AISM) as a backbone."
 domain: Insect Anatomy.
 homepage: https://github.com/insect-morphology/colao

--- a/ontology/cro.md
+++ b/ontology/cro.md
@@ -10,6 +10,7 @@ contact:
   email: whimar@ohsu.edu
   label: Marijane White
   github: marijane
+  orcid: 0000-0001-5059-4132
 license:
   url: https://creativecommons.org/licenses/by/2.0/
   label: CC BY 2.0

--- a/ontology/cteno.md
+++ b/ontology/cteno.md
@@ -14,6 +14,7 @@ contact:
   email: cjmungall@lbl.gov
   label: Chris Mungall
   github: cmungall
+  orcid: 0000-0002-6601-2165
 description: An anatomical and developmental ontology for ctenophores (Comb Jellies)
 domain: anatomy
 homepage: https://github.com/obophenotype/ctenophore-ontology

--- a/ontology/cto.md
+++ b/ontology/cto.md
@@ -9,6 +9,7 @@ contact:
   email: alpha.tom.kodamullil@scai.fraunhofer.de
   label: Dr. Alpha Tom Kodamullil
   github: akodamullil
+  orcid: 0000-0001-9896-3531
 products:
   - id: cto.owl
 license:

--- a/ontology/cvdo.md
+++ b/ontology/cvdo.md
@@ -5,6 +5,7 @@ contact:
   email: paul.fabry@usherbrooke.ca
   label: Paul Fabry
   github: pfabry
+  orcid: 0000-0002-3336-2476
 license:
   url: https://creativecommons.org/licenses/by/4.0/
   label: CC BY 4.0

--- a/ontology/dc_cl.md
+++ b/ontology/dc_cl.md
@@ -3,6 +3,7 @@ layout: ontology_detail
 id: dc_cl
 title: Dendritic cell
 contact:
+  orcid: 0000-0003-1617-8244
   email: Lindsay.Cowell@utsouthwestern.edu
   label: Lindsay Cowell
 taxon:

--- a/ontology/ddanat.md
+++ b/ontology/ddanat.md
@@ -5,6 +5,7 @@ contact:
   email: pfey@northwestern.edu
   label: Petra Fey
   github: pfey03
+  orcid: 0000-0002-4532-2703
 description: A structured controlled vocabulary of the anatomy of the slime-mold Dictyostelium discoideum
 domain: anatomy
 homepage: http://dictybase.org/

--- a/ontology/ddpheno.md
+++ b/ontology/ddpheno.md
@@ -5,6 +5,7 @@ contact:
   email: pfey@northwestern.edu
   label: Petra Fey
   github: pfey03
+  orcid: 0000-0002-4532-2703
 license:
   url: http://creativecommons.org/publicdomain/zero/1.0/
   label: CC0 1.0

--- a/ontology/dideo.md
+++ b/ontology/dideo.md
@@ -7,6 +7,7 @@ contact:
   email: mbrochhausen@gmail.com
   label: Mathias Brochhausen
   github: mbrochhausen
+  orcid: 0000-0003-1834-3856
 license:
   url: https://creativecommons.org/licenses/by/4.0/
   label: CC BY 4.0

--- a/ontology/disdriv.md
+++ b/ontology/disdriv.md
@@ -5,6 +5,7 @@ contact:
   email: lynn.schriml@gmail.com
   label: Lynn Schriml
   github: lschriml
+  orcid: 0000-0001-8910-9851
 description: Ontology for drivers and triggers of human diseases, built to classify ExO ontology exposure stressors. An application ontology. Built in collaboration with EnvO, ExO, ECTO and ChEBI.
 twitter: diseaseontology
 domain: disease

--- a/ontology/doid.md
+++ b/ontology/doid.md
@@ -6,6 +6,7 @@ contact:
   email: lynn.schriml@gmail.com
   label: Lynn Schriml
   github: lschriml
+  orcid: 0000-0001-8910-9851
 description: An ontology for describing the classification of human diseases organized by etiology.
 twitter: diseaseontology
 facebook: https://www.facebook.com/diseaseontology

--- a/ontology/dpo.md
+++ b/ontology/dpo.md
@@ -6,6 +6,7 @@ contact:
   email: cp390@cam.ac.uk
   label: Clare Pilgrim
   github: Clare72
+  orcid: 0000-0002-1373-1705
 description: An ontology of commonly encountered and/or high level Drosophila phenotypes.
 domain: phenotype
 homepage: http://purl.obolibrary.org/obo/fbcv

--- a/ontology/dron.md
+++ b/ontology/dron.md
@@ -5,6 +5,7 @@ contact:
   email: hoganwr@gmail.com
   label: William Hogan
   github: hoganwr
+  orcid: 0000-0002-9881-1017
 description: An ontology to support comparative effectiveness researchers studying claims data.
 domain: health
 homepage: https://github.com/ufbmi/dron

--- a/ontology/duo.md
+++ b/ontology/duo.md
@@ -13,6 +13,7 @@ contact:
   email: mcourtot@gmail.com
   label: Melanie Courtot
   github: mcourtot
+  orcid: 0000-0002-9551-6370
 description: DUO is an ontology which represent data use conditions.
 homepage: https://github.com/EBISPOT/DUO
 products:

--- a/ontology/ecao.md
+++ b/ontology/ecao.md
@@ -10,6 +10,7 @@ contact:
   email: ettensohn@cmu.edu
   label: Charles Ettensohn
   github: ettensohn
+  orcid: 0000-0002-3625-0955
 description: An ontology for the development and anatomy of the different species of the phylum Echinodermata (NCBITaxon:7586).
 domain: anatomy
 homepage: https://github.com/echinoderm-ontology/ecao_ontology

--- a/ontology/eco.md
+++ b/ontology/eco.md
@@ -21,6 +21,7 @@ contact:
   email: mgiglio@som.umaryland.edu
   label: Michelle Giglio
   github: mgiglio99
+  orcid: 0000-0001-7628-5565
 publications:
   - id: http://www.ncbi.nlm.nih.gov/pubmed/30407590
     title: "ECO, the Evidence & Conclusion Ontology: community standard for evidence information."

--- a/ontology/ecocore.md
+++ b/ontology/ecocore.md
@@ -13,6 +13,7 @@ contact:
   email: p.buttigieg@gmail.com
   label: Pier Luigi Buttigieg
   github: pbuttigieg
+  orcid: 0000-0002-4366-3088
 description: Ecocore is a community ontology for the concise and controlled description of ecological traits of organisms.
 domain: ecological functions, ecological interactions
 homepage: https://github.com/EcologicalSemantics/ecocore

--- a/ontology/ecto.md
+++ b/ontology/ecto.md
@@ -5,6 +5,7 @@ title: Environmental conditions, treatments and exposures ontology
 contact:
   email: annethessen@gmail.com
   github: diatomsRcool
+  orcid: 0000-0002-2908-3327
   label: Anne Thessen
 description: ECTO describes exposures to experimental treatments of plants and model organisms (e.g. exposures to modification of diet, lighting levels, temperature); exposures of humans or any other organisms to stressors through a variety of routes, for purposes of public health, environmental monitoring etc, stimuli, natural and experimental, any kind of environmental condition or change in condition that can be experienced by an organism or population of organisms on earth. The scope is very general and can include for example plant treatment regimens, as well as human clinical exposures (although these may better be handled by a more specialized ontology).
 domain: environment

--- a/ontology/emap.md
+++ b/ontology/emap.md
@@ -5,6 +5,7 @@ contact:
   email: Terry.Hayamizu@jax.org
   label: Terry Hayamizu
   github: tfhayamizu
+  orcid: 0000-0002-0956-8634
 description: A structured controlled vocabulary of stage-specific anatomical structures of the mouse (Mus).
 domain: anatomy
 homepage: http://emouseatlas.org

--- a/ontology/emapa.md
+++ b/ontology/emapa.md
@@ -5,6 +5,7 @@ contact:
   email: Terry.Hayamizu@jax.org
   label: Terry Hayamizu
   github: tfhayamizu
+  orcid: 0000-0002-0956-8634
 license:
   url: https://creativecommons.org/licenses/by/4.0/
   label: CC BY 4.0

--- a/ontology/envo.md
+++ b/ontology/envo.md
@@ -5,6 +5,7 @@ contact:
   email: p.buttigieg@gmail.com
   label: Pier Luigi Buttigieg
   github: pbuttigieg
+  orcid: 0000-0002-4366-3088
 description: Ontology of environmental features and habitats
 domain: environment
 homepage: http://environmentontology.org/

--- a/ontology/eo.md
+++ b/ontology/eo.md
@@ -9,6 +9,7 @@ contact:
   email: jaiswalp@science.oregonstate.edu
   label: Pankaj Jaiswal
   github: jaiswalp
+  orcid: 0000-0002-1005-8383
 description: A structured, controlled vocabulary which describes the treatments, growing conditions, and/or study types used in plant biology experiments.
 domain: environment
 homepage: http://planteome.org/

--- a/ontology/epio.md
+++ b/ontology/epio.md
@@ -18,6 +18,7 @@ contact:
   email: alpha.tom.kodamullil@scai.fraunhofer.de
   label: Alpha Tom Kodamullil
   github: akodamullil
+  orcid: 0000-0001-9896-3531
 homepage: https://github.com/SCAI-BIO/EpilepsyOntology
 repository: https://github.com/SCAI-BIO/EpilepsyOntology
 activity_status: active

--- a/ontology/eupath.md
+++ b/ontology/eupath.md
@@ -5,6 +5,7 @@ contact:
   email: stoeckrt@pennmedicine.upenn.edu
   label: Chris Stoeckert
   github: cstoeckert
+  orcid: 0000-0002-5714-991X
 license:
   url: http://creativecommons.org/licenses/by/4.0/
   label: CC BY 4.0

--- a/ontology/exo.md
+++ b/ontology/exo.md
@@ -11,6 +11,7 @@ contact:
   label: Cynthia Grondin
   email: cjgrondin@ncsu.edu
   github: cjgrondin
+  orcid: 0000-0002-4642-1738
 license:
   url: https://creativecommons.org/licenses/by/4.0/
   label: CC BY 4.0

--- a/ontology/fao.md
+++ b/ontology/fao.md
@@ -5,6 +5,7 @@ contact:
   email: vw253@cam.ac.uk
   label: Val Wood
   github: ValWood
+  orcid: 0000-0001-6330-7526
 license:
   url: http://creativecommons.org/publicdomain/zero/1.0/
   label: CC0 1.0

--- a/ontology/fbbi.md
+++ b/ontology/fbbi.md
@@ -6,6 +6,7 @@ contact:
   email: wawong@gmail.com
   label: Willy Wong
   github: wawong
+  orcid: 0000-0002-8841-5870
 license:
   url: https://creativecommons.org/licenses/by/4.0/
   label: CC BY 4.0

--- a/ontology/fbbt.md
+++ b/ontology/fbbt.md
@@ -6,6 +6,7 @@ contact:
   email: cp390@cam.ac.uk
   label: Clare Pilgrim
   github: Clare72
+  orcid: 0000-0002-1373-1705
 description: An ontology representing the gross anatomy of Drosophila melanogaster.
 domain: Drosophilid anatomy
 homepage: http://purl.obolibrary.org/obo/fbbt

--- a/ontology/fbcv.md
+++ b/ontology/fbcv.md
@@ -6,6 +6,7 @@ contact:
   email: cp390@cam.ac.uk
   label: Clare Pilgrim
   github: Clare72
+  orcid: 0000-0002-1373-1705
 description: A structured controlled vocabulary used for various aspects of annotation by FlyBase.
 domain: organisms
 homepage: http://purl.obolibrary.org/obo/fbcv

--- a/ontology/fbdv.md
+++ b/ontology/fbdv.md
@@ -6,6 +6,7 @@ contact:
   email: cp390@cam.ac.uk
   label: Clare Pilgrim
   github: Clare72
+  orcid: 0000-0002-1373-1705
 description: A structured controlled vocabulary of the development of Drosophila melanogaster.
 domain: development
 homepage: http://purl.obolibrary.org/obo/fbdv

--- a/ontology/fbsp.md
+++ b/ontology/fbsp.md
@@ -5,6 +5,7 @@ contact:
   email: cp390@cam.ac.uk
   label: Clare Pilgrim
   github: Clare72
+  orcid: 0000-0002-1373-1705
 description: The taxonomy of the family <i>Drosophilidae</i> (largely after Baechli) and of other taxa referred to in FlyBase.
 domain: taxonomy
 homepage: http://www.flybase.org/

--- a/ontology/fideo.md
+++ b/ontology/fideo.md
@@ -9,6 +9,7 @@ contact:
   email: georgeta.bordea@u-bordeaux.fr
   label: Georgeta Bordea
   github: getbordea
+  orcid: 0000-0001-9921-8234
 products:
   - id: fideo.owl
 license:

--- a/ontology/flopo.md
+++ b/ontology/flopo.md
@@ -5,6 +5,7 @@ contact:
   email: robert.hoehndorf@kaust.edu.sa
   label: Robert Hoehndorf
   github: leechuck
+  orcid: 0000-0001-8149-5890
 description: Traits and phenotypes of flowering plants occurring in digitized Floras
 domain: phenotype
 homepage: https://github.com/flora-phenotype-ontology/flopoontology

--- a/ontology/fobi.md
+++ b/ontology/fobi.md
@@ -5,6 +5,7 @@ contact:
   email: polcaes@gmail.com
   label: Pol Castellano Escuder
   github: pcastellanoescuder
+  orcid: 0000-0001-6466-877X
 description: FOBI (Food-Biomarker Ontology) is an ontology to represent food intake data and associate it with metabolomic data
 domain: metabolomics and nutrition
 license:

--- a/ontology/foodon.md
+++ b/ontology/foodon.md
@@ -5,6 +5,7 @@ contact:
   email: damion_dooley@sfu.ca
   label: Damion Dooley
   github: ddooley
+  orcid: 0000-0002-8844-9165
 description: A broadly scoped ontology representing entities which bear a “food role”. It encompasses materials in natural ecosystems and agriculture that are consumed by humans and domesticated animals. This includes any generic (unbranded) raw or processed food material found in processing plants, markets, stores or food distribution points. FoodOn also imports nutritional component and dietary pattern terms from other OBO Foundry ontologies to support interoperability in diet and nutrition research
 domain: food
 homepage: https://foodon.org/

--- a/ontology/fovt.md
+++ b/ontology/fovt.md
@@ -13,6 +13,7 @@ contact:
   email: meghan.balk@gmail.com
   label: Meghan Balk
   github: megbalk
+  orcid: 0000-0003-2699-3066
 description: FuTRES Ontology of Vertebrate Traits is an application ontology used to convert vertebrate trait data in spreadsheet to triples. FOVT leverages the BioCollections Ontology (BCO) to link observations of individual specimens to their trait values. Traits are defined in the Ontology of Biological Attributes (OBA).
 domain: vertebrate traits
 homepage: https://github.com/futres/fovt

--- a/ontology/fypo.md
+++ b/ontology/fypo.md
@@ -10,6 +10,7 @@ contact:
   email: vw253@cam.ac.uk
   label: Val Wood
   github: ValWood
+  orcid: 0000-0001-6330-7526
 description: FYPO is a formal ontology of phenotypes observed in fission yeast.
 domain: phenotype
 homepage: https://github.com/pombase/fypo

--- a/ontology/gaz.md
+++ b/ontology/gaz.md
@@ -5,6 +5,7 @@ contact:
   email: lschriml@som.umaryland.edu
   label: Lynn Schriml
   github: lschriml
+  orcid: 0000-0001-8910-9851
 homepage: http://environmentontology.github.io/gaz/
 description: A gazetteer constructed on ontological principles
 products:

--- a/ontology/gecko.md
+++ b/ontology/gecko.md
@@ -9,6 +9,7 @@ contact:
   email: rbca.jackson@gmail.com
   label: Rebecca Jackson
   github: beckyjackson
+  orcid: 0000-0003-4871-5569
 products:
   - id: gecko.owl
 license:

--- a/ontology/genepio.md
+++ b/ontology/genepio.md
@@ -5,6 +5,7 @@ contact:
   email: damion_dooley@sfu.ca
   label: Damion Dooley
   github: ddooley
+  orcid: 0000-0002-8844-9165
 description: The Genomic Epidemiology Ontology (GenEpiO) covers vocabulary necessary to identify, document and research foodborne pathogens and associated outbreaks.
 domain: health
 homepage: http://genepio.org/

--- a/ontology/geno.md
+++ b/ontology/geno.md
@@ -10,6 +10,7 @@ contact:
   email: mhb120@gmail.com
   label: Matthew Brush
   github: mbrush
+  orcid: 0000-0002-1048-5019
 license:
   url: https://creativecommons.org/licenses/by-sa/2.0/
   label: CC BY-SA 2.0

--- a/ontology/geo.md
+++ b/ontology/geo.md
@@ -5,6 +5,7 @@ contact:
   email: hoganwr@gmail.com
   label: Bill Hogan
   github: hoganwr
+  orcid: 0000-0002-9881-1017
 license:
   url: https://creativecommons.org/licenses/by/4.0/
   label: CC BY 4.0

--- a/ontology/gno.md
+++ b/ontology/gno.md
@@ -5,6 +5,7 @@ contact:
   email: nje5@georgetown.edu
   label: Nathan Edwards
   github: edwardsnj
+  orcid: 0000-0001-5168-3196
 description: GlyTouCan provides stable accessions for glycans described at varyious degrees of characterization, including compositions (no linkage) and topologies (no carbon bond positions or anomeric configurations). GNOme organizes these stable accessions for interative browsing, for text-based searching, and for automated reasoning with well-defined characterization levels.
 domain: glycan structure
 homepage: https://gnome.glyomics.org/

--- a/ontology/go.md
+++ b/ontology/go.md
@@ -6,6 +6,7 @@ contact:
   email: suzia@stanford.edu
   label: Suzi Aleksander
   github: suzialeksander
+  orcid: 0000-0001-6787-2901
 license:
   url: https://creativecommons.org/licenses/by/4.0/
   label: CC BY 4.0

--- a/ontology/gsso.md
+++ b/ontology/gsso.md
@@ -10,6 +10,7 @@ contact:
   email: kronkcj@mail.uc.edu
   label: Clair Kronk
   github: Superraptor
+  orcid: 0000-0001-8397-8810
 description: The Gender, Sex, and Sexual Orientation (GSSO) ontology has terms for annotating interdisciplinary information concerning gender, sex, and sexual orientation for primary usage in the biomedical and adjacent sciences.
 domain: organisms
 homepage: https://gsso.research.cchmc.org/

--- a/ontology/habronattus.md
+++ b/ontology/habronattus.md
@@ -3,6 +3,7 @@ layout: ontology_detail
 id: habronattus
 title: Habronattus courtship
 contact:
+  orcid: 0000-0001-6512-3296
   email: peteremidford@yahoo.com
   label: Peter Midford
 homepage: http://www.mesquiteproject.org/ontology/Habronattus/index.html

--- a/ontology/hancestro.md
+++ b/ontology/hancestro.md
@@ -5,6 +5,7 @@ contact:
   email: danielle.welter@uni.lu
   label: Danielle Welter
   github: daniwelter
+  orcid: 0000-0003-1058-2668
 title: Human Ancestry Ontology
 description: The Human Ancestry Ontology (HANCESTRO) provides a systematic description of the ancestry concepts used in the NHGRI-EBI Catalog of published genome-wide association studies.
 homepage: https://github.com/EBISPOT/ancestro

--- a/ontology/hao.md
+++ b/ontology/hao.md
@@ -5,6 +5,7 @@ contact:
   email: diapriid@gmail.com
   label: Matt Yoder
   github: mjy
+  orcid: 0000-0002-5640-5491
 tracker: https://github.com/hymao/hao/issues
 license:
   url: https://creativecommons.org/publicdomain/zero/1.0/

--- a/ontology/hom.md
+++ b/ontology/hom.md
@@ -5,6 +5,7 @@ contact:
   email: bgee@sib.swiss
   label: Frederic Bastian
   github: fbastian
+  orcid: 0000-0002-9415-5104
 description: This ontology represents concepts related to homology, as well as other concepts used to describe similarity and non-homology.
 homepage: https://github.com/BgeeDB/homology-ontology
 products:

--- a/ontology/hp.md
+++ b/ontology/hp.md
@@ -10,6 +10,7 @@ contact:
   email: dr.sebastian.koehler@gmail.com
   label: Sebastian Koehler
   github: drseb
+  orcid: 0000-0002-5316-1399
 license:
   url: https://hpo.jax.org/app/license
   label: hpo

--- a/ontology/hsapdv.md
+++ b/ontology/hsapdv.md
@@ -15,6 +15,7 @@ contact:
   label: Frédéric Bastian
   email: frederic.bastian@unil.ch
   github: fbastian
+  orcid: 0000-0002-9415-5104
 license:
   url: http://creativecommons.org/licenses/by/3.0/
   label: CC BY 3.0

--- a/ontology/hso.md
+++ b/ontology/hso.md
@@ -5,6 +5,7 @@ contact:
   email: fernanda.dorea@sva.se
   label: Fernanda Dorea
   github: nandadorea
+  orcid: 0000-0001-8638-8525
 description: The health Surveillance Ontology (HSO) focuses on "surveillance system level data", that is, data outputs from surveillance activities, such as number of samples collected, cases observed, etc. It aims to support One-Health surveillance, covering animal health, public health and food safety surveillance.
 domain: health
 homepage: https://w3id.org/hso

--- a/ontology/htn.md
+++ b/ontology/htn.md
@@ -8,6 +8,7 @@ contact:
   label: Amanda Hicks
   email: aellenhicks@gmail.com
   github: aellenhicks
+  orcid: 0000-0002-1795-5570
 license:
   label: CC BY 4.0
   url: http://creativecommons.org/licenses/by/4.0/

--- a/ontology/iao.md
+++ b/ontology/iao.md
@@ -5,6 +5,7 @@ contact:
   email: jiezheng@pennmedicine.upenn.edu
   label: Jie Zheng
   github: zhengj2007
+  orcid: 0000-0002-2999-0103
 description: "An ontology of information entities."
 domain: information
 homepage: https://github.com/information-artifact-ontology/IAO/

--- a/ontology/iceo.md
+++ b/ontology/iceo.md
@@ -9,6 +9,7 @@ contact:
   email: liumeng94@sjtu.edu.cn
   label: Meng LIU
   github: Lemon-Liu
+  orcid: 0000-0003-3781-6962
 products:
   - id: iceo.owl
 license:

--- a/ontology/ico.md
+++ b/ontology/ico.md
@@ -11,6 +11,7 @@ contact:
   email: yongqunh@med.umich.edu
   label: Yongqun Oliver He
   github: yongqunh
+  orcid: 0000-0001-9189-9661
 homepage: https://github.com/ICO-ontology/ICO
 tracker: https://github.com/ICO-ontology/ICO/issues
 products:

--- a/ontology/ido.md
+++ b/ontology/ido.md
@@ -5,6 +5,7 @@ contact:
   email: Lindsay.Cowell@utsouthwestern.edu
   label: Lindsay Cowell
   github: lgcowell
+  orcid: 0000-0003-1617-8244
 license:
   url: https://creativecommons.org/licenses/by/3.0/
   label: CC BY 3.0

--- a/ontology/ino.md
+++ b/ontology/ino.md
@@ -10,6 +10,7 @@ contact:
   email: yongqunh@med.umich.edu
   label: Yongqun Oliver He
   github: yongqunh
+  orcid: 0000-0001-9189-9661
 homepage: https://github.com/INO-ontology/ino
 tracker: https://github.com/INO-ontology/ino/issues
 products:

--- a/ontology/kisao.md
+++ b/ontology/kisao.md
@@ -5,6 +5,7 @@ contact:
   email: karr@mssm.edu
   label: Jonathan Karr
   github: jonrkarr
+  orcid: 0000-0002-2605-5080
 description: A classification of algorithms for simulating biology and their outputs
 domain: algorithms
 homepage: http://co.mbine.org/standards/kisao

--- a/ontology/labo.md
+++ b/ontology/labo.md
@@ -6,6 +6,7 @@ contact:
   email: paul.fabry@usherbrooke.ca
   label: Paul Fabry
   github: pfabry
+  orcid: 0000-0002-3336-2476
 description: LABO is an ontology of informational entities formalizing clinical laboratory tests prescriptions and reporting documents.
 domain: clinical documentation
 usages:

--- a/ontology/lepao.md
+++ b/ontology/lepao.md
@@ -6,6 +6,7 @@ contact:
   email: lagonzalezmo@unal.edu.co
   label: Luis A. Gonzalez-Montana
   github: luis-gonzalez-m
+  orcid: 0000-0002-9136-9932
 description: The Lepidoptera Anatomy Ontology contains terms used for describing the anatomy and phenotype of moths and butterflies in biodiversity research. LEPAO is developed in part by BIOfid (The Specialised Information Service Biodiversity Research).
 domain: Insect Anatomy
 homepage: https://github.com/insect-morphology/lepao

--- a/ontology/loggerhead.md
+++ b/ontology/loggerhead.md
@@ -3,6 +3,7 @@ layout: ontology_detail
 id: loggerhead
 title: Loggerhead nesting
 contact:
+  orcid: 0000-0001-6512-3296
   email: peteremidford@yahoo.com
   label: Peter Midford
 homepage: http://www.mesquiteproject.org/ontology/Loggerhead/index.html

--- a/ontology/ma.md
+++ b/ontology/ma.md
@@ -5,6 +5,7 @@ contact:
   email: Terry.Hayamizu@jax.org
   label: Terry Hayamizu
   github: tfhayamizu
+  orcid: 0000-0002-0956-8634
 license:
   url: https://creativecommons.org/licenses/by/4.0/
   label: CC BY 4.0

--- a/ontology/mamo.md
+++ b/ontology/mamo.md
@@ -4,6 +4,7 @@ id: mamo
 contact:
   email: nicolas@ascistance.co.uk
   github: gambardella
+  orcid: 0000-0002-6309-7327
   label: Nicolas Gambardella
 description: The Mathematical Modelling Ontology (MAMO) is a classification of the types of mathematical models used mostly in the life sciences, their variables, relationships and other relevant features.
 homepage: http://sourceforge.net/p/mamo-ontology/wiki/Home/

--- a/ontology/maxo.md
+++ b/ontology/maxo.md
@@ -13,6 +13,7 @@ contact:
   email: Leigh.Carmody@jax.org
   label: Leigh Carmody
   github: LCCarmody
+  orcid: 0000-0001-7941-2961
 description: Medical Action Ontology is an ontology...
 domain: medical
 homepage: https://github.com/monarch-initiative/MAxO

--- a/ontology/mco.md
+++ b/ontology/mco.md
@@ -13,6 +13,7 @@ contact:
   email: citlalli.mejiaalmonte@gmail.com
   label: Citlalli Mejía-Almonte
   github: citmejia
+  orcid: 0000-0002-0142-5591
 description: Microbial Conditions Ontology is an ontology...
 domain: experimental conditions
 homepage: https://github.com/microbial-conditions-ontology/microbial-conditions-ontology

--- a/ontology/mf.md
+++ b/ontology/mf.md
@@ -5,6 +5,7 @@ contact:
   email: janna.hastings@gmail.com
   label: Janna Hastings
   github: jannahastings
+  orcid: 0000-0002-3469-4923
 description: The Mental Functioning Ontology is an overarching ontology for all aspects of mental functioning.
 domain: health
 homepage: https://github.com/jannahastings/mental-functioning-ontology

--- a/ontology/mfmo.md
+++ b/ontology/mfmo.md
@@ -17,6 +17,7 @@ contact:
   email: druzinsk@uic.edu
   label: Robert Druzinsky
   github: RDruzinsky
+  orcid: 0000-0002-1572-1316
 dependencies:
   - id: uberon
 products:

--- a/ontology/mfoem.md
+++ b/ontology/mfoem.md
@@ -5,6 +5,7 @@ contact:
   email: janna.hastings@gmail.com
   label: Janna Hastings
   github: jannahastings
+  orcid: 0000-0002-3469-4923
 description: An ontology of affective phenomena such as emotions, moods, appraisals and subjective feelings.
 domain: health
 homepage: https://github.com/jannahastings/emotion-ontology

--- a/ontology/mfomd.md
+++ b/ontology/mfomd.md
@@ -5,6 +5,7 @@ contact:
   email: janna.hastings@gmail.com
   label: Janna Hastings
   github: jannahastings
+  orcid: 0000-0002-3469-4923
 title: Mental Disease Ontology
 description: An ontology to describe and classify mental diseases such as schizophrenia, annotated with DSM-IV and ICD codes where applicable
 domain: health

--- a/ontology/mi.md
+++ b/ontology/mi.md
@@ -5,6 +5,7 @@ contact:
   email: pporras@ebi.ac.uk
   label: Pablo Porras Millán
   github: pporrasebi
+  orcid: 0000-0002-8429-8793
 tracker: https://github.com/HUPO-PSI/psi-mi-CV/issues
 license:
   url: https://creativecommons.org/licenses/by/4.0/

--- a/ontology/miapa.md
+++ b/ontology/miapa.md
@@ -5,6 +5,7 @@ contact:
   email: hilmar.lapp@duke.edu
   label: Hilmar Lapp
   github: hlapp
+  orcid: 0000-0001-9107-0714
 description: An application ontology to formalize annotation of phylogenetic data.
 homepage: http://www.evoio.org/wiki/MIAPA
 products:

--- a/ontology/micro.md
+++ b/ontology/micro.md
@@ -5,6 +5,7 @@ contact:
   email: carrine.blank@umontana.edu
   label: Carrine Blank
   github: carrineblank
+  orcid: 0000-0002-2100-6351
 description: An ontology of prokaryotic phenotypic and metabolic characters
 title: Ontology of Prokaryotic Phenotypic and Metabolic Characters
 domain: phenotype

--- a/ontology/mmo.md
+++ b/ontology/mmo.md
@@ -5,6 +5,7 @@ contact:
   email: jrsmith@mcw.edu
   label: Jennifer Smith
   github: jrsjrs
+  orcid: 0000-0002-6443-9376
 license:
   url: https://creativecommons.org/publicdomain/zero/1.0/
   label: CC0 1.0

--- a/ontology/mmusdv.md
+++ b/ontology/mmusdv.md
@@ -14,6 +14,7 @@ contact:
   label: Frédéric Bastian
   email: frederic.bastian@unil.ch
   github: fbastian
+  orcid: 0000-0002-9415-5104
 license:
   url: http://creativecommons.org/licenses/by/3.0/
   label: CC BY 3.0

--- a/ontology/mo.md
+++ b/ontology/mo.md
@@ -2,6 +2,7 @@
 layout: ontology_detail
 id: mo
 contact:
+  orcid: 0000-0002-5714-991X
   email: stoeckrt@pcbi.upenn.edu
   label: Chris Stoeckert
 description: A standardized description of a microarray experiment in support of MAGE v.1.

--- a/ontology/mod.md
+++ b/ontology/mod.md
@@ -5,6 +5,7 @@ contact:
   email: pierre-alain.binz@chuv.ch
   label: Pierre-Alain Binz
   github: pabinz
+  orcid: 0000-0002-0045-7698
 license:
   url: https://creativecommons.org/licenses/by/4.0/
   label: CC BY 4.0

--- a/ontology/mondo.md
+++ b/ontology/mondo.md
@@ -12,6 +12,7 @@ contact:
   email: nicole@tislab.org
   label: Nicole Vasilevsky
   github: nicolevasilevsky
+  orcid: 0000-0001-5208-3432
 depicted_by: https://raw.githubusercontent.com/monarch-initiative/mondo/master/docs/images/mondo_logo_black-stacked-small.png
 taxon:
   id: NCBITaxon:33208

--- a/ontology/mop.md
+++ b/ontology/mop.md
@@ -5,6 +5,7 @@ contact:
   email: batchelorc@rsc.org
   label: Colin Batchelor
   github: batchelorc
+  orcid: 0000-0001-5985-7429
 license:
   url: https://creativecommons.org/licenses/by/4.0/
   label: CC BY 4.0

--- a/ontology/mp.md
+++ b/ontology/mp.md
@@ -16,6 +16,7 @@ contact:
   email: drsbello@gmail.com
   label: Sue Bello
   github: sbello
+  orcid: 0000-0003-4606-0597
 domain: phenotype
 products:
   - id: mp.owl

--- a/ontology/mpath.md
+++ b/ontology/mpath.md
@@ -5,6 +5,7 @@ contact:
   email: pns12@hermes.cam.ac.uk
   label: Paul Schofield
   github: PaulNSchofield
+  orcid: 0000-0002-5111-7263
 description: A structured controlled vocabulary of mutant and transgenic mouse pathology phenotypes
 domain: health
 homepage: http://www.pathbase.net

--- a/ontology/mpio.md
+++ b/ontology/mpio.md
@@ -6,6 +6,7 @@ contact:
   email: mbrochhausen@uams.edu
   label: Mathias Brochhausen
   github: mbrochhausen
+  orcid: 0000-0003-1834-3856
 description: An ontology of minimum information regarding potential drug-drug interaction information.
 domain: health
 homepage: https://github.com/MPIO-Developers/MPIO

--- a/ontology/mro.md
+++ b/ontology/mro.md
@@ -10,6 +10,7 @@ contact:
   label: Bjoern Peters
   email: bpeters@lji.org
   github: bpeters42
+  orcid: 0000-0002-8457-6693
 license:
   url: https://creativecommons.org/licenses/by/3.0/
   label: CC BY 3.0

--- a/ontology/ms.md
+++ b/ontology/ms.md
@@ -9,6 +9,7 @@ contact:
   email: gerhard.mayer@rub.de
   label: Gerhard Mayer
   github: germa
+  orcid: 0000-0002-1767-2343
 integration_server: https://raw.githubusercontent.com/HUPO-PSI/psi-ms-CV/master
 domain: MS experiments
 mailing_list: psidev-ms-vocab@lists.sourceforge.net

--- a/ontology/nbo.md
+++ b/ontology/nbo.md
@@ -5,6 +5,7 @@ contact:
   email: g.gkoutos@bham.ac.uk
   label: George Gkoutos
   github: gkoutos
+  orcid: 0000-0002-2061-091X
 description: An ontology of human and animal behaviours and behavioural phenotypes
 domain: behavior
 homepage: https://github.com/obo-behavior/behavior-ontology/

--- a/ontology/ncbitaxon.md
+++ b/ontology/ncbitaxon.md
@@ -12,6 +12,7 @@ contact:
   email: frederic.bastian@unil.ch
   label: Frederic Bastian
   github: fbastian
+  orcid: 0000-0002-9415-5104
 description: An ontology representation of the NCBI organismal taxonomy
 source: http://www.ncbi.nlm.nih.gov/taxonomy
 wasDerivedFrom: ftp://ftp.ebi.ac.uk/pub/databases/taxonomy/taxonomy.dat

--- a/ontology/ncit.md
+++ b/ontology/ncit.md
@@ -6,6 +6,7 @@ contact:
   email: haendel@ohsu.edu
   label: Melissa Haendel
   github: mellybelly
+  orcid: 0000-0001-9114-8737
 license:
   url: https://creativecommons.org/licenses/by/4.0/
   label: CC BY 4.0

--- a/ontology/ncro.md
+++ b/ontology/ncro.md
@@ -11,6 +11,7 @@ contact:
   label: Jingshan Huang
   email: huang@southalabama.edu
   github: Huang-OMIT
+  orcid: 0000-0003-2408-2883
 license:
   url: https://creativecommons.org/licenses/by/4.0/
   label: CC BY 4.0

--- a/ontology/nomen.md
+++ b/ontology/nomen.md
@@ -8,6 +8,7 @@ contact:
   email: diapriid@gmail.com
   label: Matt Yoder
   github: mjy
+  orcid: 0000-0002-5640-5491
 license:
   url: https://creativecommons.org/publicdomain/zero/1.0/
   label: CC0 1.0

--- a/ontology/oae.md
+++ b/ontology/oae.md
@@ -5,6 +5,7 @@ contact:
   email: yongqunh@med.umich.edu
   label: Yongqunh He
   github: yongqunh
+  orcid: 0000-0001-9189-9661
 description: A biomedical ontology in the domain of adverse events
 domain: adverse events, health
 homepage: https://github.com/OAE-ontology/OAE/

--- a/ontology/oarcs.md
+++ b/ontology/oarcs.md
@@ -8,6 +8,7 @@ contact:
   email: mjyoder@illinois.edu
   label: Matt Yoder
   github: mjy
+  orcid: 0000-0002-5640-5491
 domain: anatomy
 repository: https://github.com/aszool/oarcs
 license:

--- a/ontology/oba.md
+++ b/ontology/oba.md
@@ -5,6 +5,7 @@ contact:
   email: cjmungall@lbl.gov
   label: Chris Mungall
   github: cmungall
+  orcid: 0000-0002-6601-2165
 license:
   url: http://creativecommons.org/publicdomain/zero/1.0/
   label: CC0 1.0

--- a/ontology/obcs.md
+++ b/ontology/obcs.md
@@ -8,6 +8,7 @@ contact:
   email: jiezheng@pennmedicine.upenn.edu
   label: Jie Zheng
   github: zhengj2007
+  orcid: 0000-0002-2999-0103
 domain: statistics
 homepage: https://github.com/obcs/obcs
 products:

--- a/ontology/obi.md
+++ b/ontology/obi.md
@@ -18,6 +18,7 @@ contact:
   label: Bjoern Peters
   email: bpeters@lji.org
   github: bpeters42
+  orcid: 0000-0002-8457-6693
 license:
   url: https://creativecommons.org/licenses/by/4.0/
   label: CC BY 4.0

--- a/ontology/obib.md
+++ b/ontology/obib.md
@@ -6,6 +6,7 @@ contact:
   email: jiezheng@pennmedicine.upenn.edu
   label: Jie Zheng
   github: zhengj2007
+  orcid: 0000-0002-2999-0103
 description: An ontology built for annotation and modeling of biobank repository and biobanking administration
 domain: biobanking, specimens, bio-repository, biocuration
 homepage: https://github.com/biobanking/biobanking

--- a/ontology/obo_rel.md
+++ b/ontology/obo_rel.md
@@ -3,6 +3,7 @@ layout: ontology_detail
 id: obo_rel
 title: OBO relationship types (legacy)
 contact:
+  orcid: 0000-0002-6601-2165
   email: cjmungall@lbl.gov
   label: Chris Mungall
 homepage: http://www.obofoundry.org/ro

--- a/ontology/ogg.md
+++ b/ontology/ogg.md
@@ -5,6 +5,7 @@ contact:
   email: yongqunh@med.umich.edu
   label: Yongqun Oliver He
   github: yongqunh
+  orcid: 0000-0001-9189-9661
 description: A formal ontology of genes and genomes of biological organisms.
 homepage: https://bitbucket.org/hegroup/ogg
 repository: https://bitbucket.org/hegroup/ogg

--- a/ontology/ogms.md
+++ b/ontology/ogms.md
@@ -5,6 +5,7 @@ contact:
   email: baeverma@jcvi.org
   label: Brian Aevermann
   github: BAevermann
+  orcid: 0000-0003-1346-1327
 license:
   url: http://creativecommons.org/licenses/by/4.0/
   label: CC BY 4.0

--- a/ontology/ogsf.md
+++ b/ontology/ogsf.md
@@ -7,6 +7,7 @@ contact:
   label: Asiyah Yu Lin
   email: linikujp@gmail.com
   github: linikujp
+  orcid: 0000-0002-5379-5359
 license:
   url: https://creativecommons.org/licenses/by/3.0/
   label: CC BY 3.0

--- a/ontology/ohd.md
+++ b/ontology/ohd.md
@@ -5,6 +5,7 @@ contact:
   email: alanruttenberg@gmail.com
   label: Alan Ruttenberg
   github: alanruttenberg
+  orcid: 0000-0002-1604-3078
 description: "The Oral Health and Disease Ontology was created, initially, to represent the content of dental practice health records."
 domain: health
 homepage: https://purl.obolibrary.org/obo/ohd/home

--- a/ontology/ohmi.md
+++ b/ontology/ohmi.md
@@ -10,6 +10,7 @@ contact:
   email: yongqunh@med.umich.edu
   label: Yongqun Oliver He
   github: yongqunh
+  orcid: 0000-0001-9189-9661
 products:
   - id: ohmi.owl
 license:

--- a/ontology/ohpi.md
+++ b/ontology/ohpi.md
@@ -10,6 +10,7 @@ contact:
   email: edong@umich.edu
   label: Edison Ong
   github: e4ong1031
+  orcid: 0000-0002-5159-414X
 products:
   - id: ohpi.owl
 license:

--- a/ontology/olatdv.md
+++ b/ontology/olatdv.md
@@ -17,6 +17,7 @@ contact:
   label: Frédéric Bastian
   email: frederic.bastian@unil.ch
   github: fbastian
+  orcid: 0000-0002-9415-5104
 license:
   url: http://creativecommons.org/licenses/by/3.0/
   label: CC BY 3.0

--- a/ontology/omiabis.md
+++ b/ontology/omiabis.md
@@ -3,6 +3,7 @@ layout: ontology_detail
 id: omiabis
 title: Ontologized MIABIS
 contact:
+  orcid: 0000-0003-1834-3856
   email: mbrochhausen@gmail.com
   label: Mathias Brochhausen
 description: An ontological version of MIABIS (Minimum Information About BIobank data Sharing)

--- a/ontology/omit.md
+++ b/ontology/omit.md
@@ -6,6 +6,7 @@ contact:
   email: huang@southalabama.edu
   label: Jingshan Huang
   github: Huang-OMIT
+  orcid: 0000-0003-2408-2883
 license:
   url: https://creativecommons.org/licenses/by/3.0/
   label: CC BY 3.0

--- a/ontology/omo.md
+++ b/ontology/omo.md
@@ -5,6 +5,7 @@ contact:
   email: cjmungall@lbl.gov
   label: Chris Mungall
   github: cmungall
+  orcid: 0000-0002-6601-2165
 description: An ontology specifies terms that are used to annotate ontology terms for all OBO ontologies. The ontology was developed as part of Information Artifact Ontology (IAO).
 domain: ontology term annotation
 homepage: https://github.com/information-artifact-ontology/ontology-metadata

--- a/ontology/omp.md
+++ b/ontology/omp.md
@@ -5,6 +5,7 @@ contact:
   email: jimhu@tamu.edu
   label: James C. Hu
   github: jimhu-tamu
+  orcid: 0000-0001-9016-2684
 description: An ontology of phenotypes covering microbes
 domain: phenotype
 homepage: http://microbialphenotypes.org

--- a/ontology/omrse.md
+++ b/ontology/omrse.md
@@ -5,6 +5,7 @@ contact:
   email: hoganwr@gmail.com
   label: Bill Hogan
   github: hoganwr
+  orcid: 0000-0002-9881-1017
 license:
   url: https://creativecommons.org/licenses/by/4.0/
   label: CC BY 4.0

--- a/ontology/one.md
+++ b/ontology/one.md
@@ -7,6 +7,7 @@ contact:
   email: chenyangnutrition@gmail.com
   label: Chen Yang
   github: cyang0128
+  orcid: 0000-0001-9202-5309
 description: An ontology to standardize research output of nutritional epidemiologic studies.
 domain: nutritional epidemiology, observational studies, dietary surveys
 homepage: https://github.com/cyang0128/Nutritional-epidemiologic-ontologies

--- a/ontology/ons.md
+++ b/ontology/ons.md
@@ -7,6 +7,7 @@ contact:
   email: francesco.vitali@ibba.cnr.it
   label: Francesco Vitali
   github: FrancescoVit
+  orcid: 0000-0001-9125-4337
 description: An ontology for description of concepts in the nutritional studies domain.
 domain: nutrition, nutritional studies, nutrition professionals
 homepage: https://github.com/enpadasi/Ontology-for-Nutritional-Studies

--- a/ontology/ontoavida.md
+++ b/ontology/ontoavida.md
@@ -6,6 +6,7 @@ contact:
   email: fortuna@ebd.csic.es
   label: Miguel A. Fortuna
   github: miguelfortuna
+  orcid: 0000-0002-8374-1941
 description: "OntoAvida develops an integrated vocabulary for the description of the most widely-used computational approach for studying evolution using digital organisms (i.e., self-replicating computer programs that evolve within a user-defined computational environment)."
 domain: digital evolution, a branch of Artificial Life.
 homepage: https://gitlab.com/fortunalab/ontoavida

--- a/ontology/ontoneo.md
+++ b/ontology/ontoneo.md
@@ -6,6 +6,7 @@ contact:
   email: fernanda.farinelli@gmail.com
   label: Fernanda Farinelli
   github: FernandaFarinelli
+  orcid: 0000-0003-2338-8872
 description: The Obstetric and Neonatal Ontology is a structured controlled vocabulary to provide a representation of the data from electronic health records (EHRs) involved in the care of the pregnant woman, and of her baby.
 license:
   url: http://creativecommons.org/licenses/by/3.0/

--- a/ontology/oostt.md
+++ b/ontology/oostt.md
@@ -6,6 +6,7 @@ contact:
   email: mbrochhausen@gmail.com
   label: Mathias Brochhausen
   github: mbrochhausen
+  orcid: 0000-0003-1834-3856
 description: An ontology built for representating the organizational components of trauma centers and trauma systems.
 domain: health
 homepage: https://github.com/OOSTT/OOSTT

--- a/ontology/opl.md
+++ b/ontology/opl.md
@@ -5,6 +5,7 @@ contact:
   email: jiezheng@pennmedicine.upenn.edu
   label: Jie Zheng
   github: zhengj2007
+  orcid: 0000-0002-2999-0103
 license:
   url: https://creativecommons.org/licenses/by/4.0/
   label: CC BY 4.0

--- a/ontology/opmi.md
+++ b/ontology/opmi.md
@@ -10,6 +10,7 @@ contact:
   email: yongqunh@med.umich.edu
   label: Yongqun Oliver He
   github: yongqunh
+  orcid: 0000-0001-9189-9661
 products:
   - id: opmi.owl
 license:

--- a/ontology/ornaseq.md
+++ b/ontology/ornaseq.md
@@ -6,6 +6,7 @@ contact:
   email: safisher@upenn.edu
   label: Stephen Fisher
   github: safisher
+  orcid: 0000-0001-8034-7685
 description: An application ontology designed to annotate next-generation sequencing experiments performed on RNA.
 domain: experiments
 homepage: http://kim.bio.upenn.edu/software/ornaseq.shtml

--- a/ontology/ovae.md
+++ b/ontology/ovae.md
@@ -6,6 +6,7 @@ contact:
   email: yongqunh@med.umich.edu
   label: Yongqunh He
   github: yongqunh
+  orcid: 0000-0001-9189-9661
 homepage: http://www.violinet.org/ovae/
 tracker: https://github.com/OVAE-Ontology/ovae/issues
 description: "A biomedical ontology in the domain of vaccine adverse events."

--- a/ontology/pao.md
+++ b/ontology/pao.md
@@ -6,6 +6,7 @@ contact:
   email: jaiswalp@science.oregonstate.edu
   label: Pankaj Jaiswal
   github: jaiswalp
+  orcid: 0000-0002-1005-8383
 taxon:
   id: NCBITaxon:33090
   label: Viridiplantae

--- a/ontology/pato.md
+++ b/ontology/pato.md
@@ -14,6 +14,7 @@ contact:
   email: g.gkoutos@gmail.com
   label: George Gkoutos
   github: gkoutos
+  orcid: 0000-0002-2061-091X
 domain: phenotype
 homepage: https://github.com/pato-ontology/pato/
 repository: https://github.com/pato-ontology/pato

--- a/ontology/pcl.md
+++ b/ontology/pcl.md
@@ -6,6 +6,7 @@ contact:
   email: davidos@ebi.ac.uk
   label: David Osumi-Sutherland
   github: dosumis
+  orcid: 0000-0002-7073-9172
 description: "Cell types that are provisionally defined by experimental techniques such as single cell or single nucleus transcriptomics rather than a straightforward & coherent set of properties."
 domain: phenotype
 homepage: https://github.com/obophenotype/provisional_cell_ontology

--- a/ontology/pco.md
+++ b/ontology/pco.md
@@ -13,6 +13,7 @@ contact:
   email: rlwalls2008@gmail.com
   label: Ramona Walls
   github: ramonawalls
+  orcid: 0000-0001-8815-0078
 description: An ontology about groups of interacting organisms such as populations and communities
 domain: collections of organisms
 homepage: https://github.com/PopulationAndCommunityOntology/pco

--- a/ontology/pdro.md
+++ b/ontology/pdro.md
@@ -5,6 +5,7 @@ contact:
   email: paul.fabry@usherbrooke.ca
   label: Paul Fabry
   github: pfabry
+  orcid: 0000-0002-3336-2476
 license:
   url: https://creativecommons.org/licenses/by/4.0/
   label: CC BY 4.0

--- a/ontology/pdumdv.md
+++ b/ontology/pdumdv.md
@@ -17,6 +17,7 @@ contact:
   label: Frédéric Bastian
   email: frederic.bastian@unil.ch
   github: fbastian
+  orcid: 0000-0002-9415-5104
 license:
   url: http://creativecommons.org/licenses/by/3.0/
   label: CC BY 3.0

--- a/ontology/peco.md
+++ b/ontology/peco.md
@@ -6,6 +6,7 @@ contact:
   email: jaiswalp@science.oregonstate.edu
   label: Pankaj Jaiswal
   github: jaiswalp
+  orcid: 0000-0002-1005-8383
 description: A structured, controlled vocabulary which describes the treatments, growing conditions, and/or study types used in plant biology experiments.
 domain: experimental conditions
 homepage: http://planteome.org/

--- a/ontology/phipo.md
+++ b/ontology/phipo.md
@@ -13,6 +13,7 @@ contact:
   email: alayne.cuzick@rothamsted.ac.uk
   label: Alayne Cuzick
   github: CuzickA
+  orcid: 0000-0001-8941-3984
 description: PHIPO is a formal ontology of species-neutral phenotypes observed in pathogen-host interactions.
 domain: phenotype
 homepage: https://github.com/PHI-base/phipo

--- a/ontology/plana.md
+++ b/ontology/plana.md
@@ -13,6 +13,7 @@ contact:
   email: smr@stowers.org
   label: Sofia Robb
   github: srobb1
+  orcid: 0000-0002-3528-5267
 description: PLANA, the planarian anatomy ontology, encompasses the anatomy and life cycle stages for both __Schmidtea mediterranea__ biotypes.
 domain: anatomy
 homepage: https://github.com/obophenotype/planaria-ontology

--- a/ontology/planp.md
+++ b/ontology/planp.md
@@ -13,6 +13,7 @@ contact:
   email: smr@stowers.org
   label: Sofia Robb
   github: srobb1
+  orcid: 0000-0002-3528-5267
 description: Planarian Phenotype Ontology is an ontology of phenotypes observed in the planarian Schmidtea mediterranea.
 domain: phenotype
 homepage: https://github.com/obophenotype/planarian-phenotype-ontology

--- a/ontology/po.md
+++ b/ontology/po.md
@@ -20,6 +20,7 @@ contact:
   email: jaiswalp@science.oregonstate.edu
   label: Pankaj Jaiswal
   github: jaiswalp
+  orcid: 0000-0002-1005-8383
 description: "The Plant Ontology is a structured vocabulary and database resource that links plant anatomy, morphology and growth and development to plant genomics data."
 domain: anatomy and development
 homepage: http://browser.planteome.org/amigo

--- a/ontology/poro.md
+++ b/ontology/poro.md
@@ -5,6 +5,7 @@ contact:
   email: robert.thacker@stonybrook.edu
   label: Bob Thacker
   github: bobthacker
+  orcid: 0000-0002-9654-0073
 description: An ontology covering the anatomy of the taxon Porifera (sponges)
 domain: anatomy
 homepage: https://github.com/obophenotype/porifera-ontology

--- a/ontology/ppo.md
+++ b/ontology/ppo.md
@@ -9,6 +9,7 @@ contact:
   email: rlwalls2008@gmail.com
   label: Ramona Walls
   github: ramonawalls
+  orcid: 0000-0001-8815-0078
 mailing_list: ppo-discuss@googlegroups.com
 tracker: https://github.com/PlantPhenoOntology/PPO/issues
 license:

--- a/ontology/pr.md
+++ b/ontology/pr.md
@@ -6,6 +6,7 @@ contact:
   email: dan5@georgetown.edu
   label: Darren Natale
   github: nataled
+  orcid: 0000-0001-5809-9523
 description: An ontological representation of protein-related entities
 domain: proteins
 homepage: http://proconsortium.org

--- a/ontology/psdo.md
+++ b/ontology/psdo.md
@@ -10,6 +10,7 @@ contact:
   email: zachll@umich.edu
   label: Zach Landis-Lewis
   github: zachll
+  orcid: 0000-0002-9117-9338
 description: Ontology to reproducibly study visualizations of clinical performance
 domain: learning systems
 homepage: https://github.com/Display-Lab/psdo

--- a/ontology/pso.md
+++ b/ontology/pso.md
@@ -13,6 +13,7 @@ contact:
   email: cooperl@science.oregonstate.edu
   label: Laurel Cooper
   github: cooperl09
+  orcid: 0000-0002-6379-8932
 description: The Plant Stress Ontology describes...
 domain: plant disease and abiotic stress
 homepage: https://github.com/Planteome/plant-stress-ontology

--- a/ontology/pw.md
+++ b/ontology/pw.md
@@ -5,6 +5,7 @@ contact:
   email: gthayman@mcw.edu
   label: G. Thomas Hayman
   github: gthayman
+  orcid: 0000-0002-9553-7227
 license:
   url: https://creativecommons.org/licenses/by/4.0/
   label: CC BY 4.0

--- a/ontology/rbo.md
+++ b/ontology/rbo.md
@@ -13,6 +13,7 @@ contact:
   email: daniel.c.berrios@nasa.gov
   label: Daniel C. Berrios
   github: DanBerrios
+  orcid: 0000-0003-4312-9552
 description: RBO is an ontology for the effects of radiation on biota in terrestrial and space environments.
 domain: radiation biology, the study of the effects of radiation on biological systems
 homepage: https://github.com/Radiobiology-Informatics-Consortium/RBO

--- a/ontology/rnao.md
+++ b/ontology/rnao.md
@@ -2,6 +2,7 @@
 layout: ontology_detail
 id: rnao
 contact:
+  orcid: 0000-0001-5985-7429
   email: BatchelorC@rsc.org
   label: Colin Batchelor
 license:

--- a/ontology/ro.md
+++ b/ontology/ro.md
@@ -19,6 +19,7 @@ contact:
   email: cjmungall@lbl.gov
   label: Chris Mungall
   github: cmungall
+  orcid: 0000-0002-6601-2165
 jobs:
   - id: https://travis-ci.org/oborel/obo-relations
     type: travis-ci

--- a/ontology/rs.md
+++ b/ontology/rs.md
@@ -5,6 +5,7 @@ contact:
   email: sjwang@mcw.edu
   label: Shur-Jen Wang
   github: shurjenw
+  orcid: 0000-0001-5256-8683
 license:
   url: https://creativecommons.org/licenses/by/4.0/
   label: CC BY 4.0

--- a/ontology/rxno.md
+++ b/ontology/rxno.md
@@ -5,6 +5,7 @@ contact:
   email: batchelorc@rsc.org
   label: Colin Batchelor
   github: batchelorc
+  orcid: 0000-0001-5985-7429
 license:
   url: https://creativecommons.org/licenses/by/4.0/
   label: CC BY 4.0

--- a/ontology/sbo.md
+++ b/ontology/sbo.md
@@ -5,6 +5,7 @@ contact:
   email: sheriff@ebi.ac.uk
   label: Rahuman Sheriff
   github: rsmsheriff
+  orcid: 0000-0003-0705-9809
 description: Terms commonly used in Systems Biology, and in particular in computational modeling.
 domain: biochemistry
 homepage: http://www.ebi.ac.uk/sbo/

--- a/ontology/scdo.md
+++ b/ontology/scdo.md
@@ -10,6 +10,7 @@ contact:
   email: giant.plankton@gmail.com
   label: Jade Hotchkiss
   github: JadeHotchkiss
+  orcid: 0000-0002-2193-0704
 description: An ontology for the standardization of terminology and integration of knowledge about Sickle Cell Disease.
 domain: disease
 homepage: https://scdontology.h3abionet.org/

--- a/ontology/sepio.md
+++ b/ontology/sepio.md
@@ -10,6 +10,7 @@ contact:
   email: mhb120@gmail.com
   label: Matthew Brush
   github: mbrush
+  orcid: 0000-0002-1048-5019
 license:
   url: https://creativecommons.org/licenses/by/3.0/
   label: CC BY 3.0

--- a/ontology/sibo.md
+++ b/ontology/sibo.md
@@ -2,6 +2,7 @@
 layout: ontology_detail
 id: sibo
 contact:
+  orcid: 0000-0002-6601-2165
   email: cjmungall@lbl.gov
   label: Chris Mungall
 description: Social Behavior in insects

--- a/ontology/so.md
+++ b/ontology/so.md
@@ -5,6 +5,7 @@ contact:
   email: keilbeck@genetics.utah.edu
   label: Karen Eilbeck
   github: keilbeck
+  orcid: 0000-0002-0831-6427
 license:
   url: https://creativecommons.org/licenses/by/4.0/
   label: CC BY 4.0

--- a/ontology/spd.md
+++ b/ontology/spd.md
@@ -5,6 +5,7 @@ contact:
   email: ramirez@macn.gov.ar
   label: Martin Ramirez
   github: martinjramirez
+  orcid: 0000-0002-0358-0130
 license:
   url: https://creativecommons.org/licenses/by/3.0/
   label: CC BY 3.0

--- a/ontology/stato.md
+++ b/ontology/stato.md
@@ -8,6 +8,7 @@ contact:
   email: alejandra.gonzalez.beltran@gmail.com
   label: Alejandra Gonzalez-Beltran
   github: agbeltran
+  orcid: 0000-0003-3499-8262
 domain: statistics
 homepage: http://stato-ontology.org/
 products:

--- a/ontology/swo.md
+++ b/ontology/swo.md
@@ -5,6 +5,7 @@ contact:
   email: allyson.lister@oerc.ox.ac.uk
   label: Allyson Lister
   github: allysonlister
+  orcid: 0000-0002-7702-4495
 license:
   url: https://creativecommons.org/licenses/by/4.0/
   label: CC BY 4.0

--- a/ontology/symp.md
+++ b/ontology/symp.md
@@ -5,6 +5,7 @@ contact:
   email: lynn.schriml@gmail.com
   label: Lynn Schriml
   github: lschriml
+  orcid: 0000-0001-8910-9851
 description: An ontology of disease symptoms, with symptoms encompasing perceived changes in function, sensations or appearance reported by a patient indicative of a disease.
 domain: disease
 homepage: http://symptomontologywiki.igs.umaryland.edu/mediawiki/index.php/Main_Page

--- a/ontology/tao.md
+++ b/ontology/tao.md
@@ -2,6 +2,7 @@
 layout: ontology_detail
 id: tao
 contact:
+  orcid: 0000-0003-3162-7490
   email: wasila.dahdul@usd.edu
   label: Wasila Dahdul
 description: Multispecies fish anatomy ontology. Originally seeded from ZFA, but intended to cover terms relevant to other taxa

--- a/ontology/taxrank.md
+++ b/ontology/taxrank.md
@@ -5,6 +5,7 @@ contact:
   email: balhoff@renci.org
   label: Jim Balhoff
   github: balhoff
+  orcid: 0000-0002-8688-6599
 description: A vocabulary of taxonomic ranks (species, family, phylum, etc)
 domain: taxonomy
 homepage: https://github.com/phenoscape/taxrank

--- a/ontology/to.md
+++ b/ontology/to.md
@@ -5,6 +5,7 @@ contact:
   email: jaiswalp@science.oregonstate.edu
   label: Pankaj Jaiswal
   github: jaiswalp
+  orcid: 0000-0002-1005-8383
 description: A controlled vocabulary to describe phenotypic traits in plants.
 domain: phenotype
 homepage: http://browser.planteome.org/amigo

--- a/ontology/trans.md
+++ b/ontology/trans.md
@@ -5,6 +5,7 @@ contact:
   email: lynn.schriml@gmail.com
   label: Lynn Schriml
   github: lschriml
+  orcid: 0000-0001-8910-9851
 description: "An ontology representing the disease transmission process during which the pathogen is transmitted directly or indirectly from its natural reservoir, a susceptible host or source to a new host."
 domain: disease
 homepage: https://github.com/DiseaseOntology/PathogenTransmissionOntology

--- a/ontology/tto.md
+++ b/ontology/tto.md
@@ -5,6 +5,7 @@ contact:
   email: balhoff@renci.org
   label: Jim Balhoff
   github: balhoff
+  orcid: 0000-0002-8688-6599
 description: An ontology covering the taxonomy of teleosts (bony fish)
 domain: taxonomy
 homepage: https://github.com/phenoscape/teleost-taxonomy-ontology

--- a/ontology/txpo.md
+++ b/ontology/txpo.md
@@ -5,6 +5,7 @@ contact:
   email: yuki.yamagata@riken.jp
   label: Yuki Yamagata
   github: yuki-yamagata
+  orcid: 0000-0002-9673-1283
 description: TOXic Process Ontology (TXPO) systematizes a wide variety of terms involving toxicity courses and processes. The first version of TXPO focuses on liver toxicity.
 domain: toxicity
 homepage: https://toxpilot.nibiohn.go.jp/

--- a/ontology/uberon.md
+++ b/ontology/uberon.md
@@ -88,6 +88,7 @@ contact:
   email: cjmungall@lbl.gov
   label: Chris Mungall
   github: cmungall
+  orcid: 0000-0002-6601-2165
 publications:
   - id: http://www.ncbi.nlm.nih.gov/pubmed/22293552
     title: "Uberon, an integrative multi-species anatomy ontology"

--- a/ontology/uo.md
+++ b/ontology/uo.md
@@ -6,6 +6,7 @@ contact:
   email: g.gkoutos@gmail.com
   label: George Gkoutos
   github: gkoutos
+  orcid: 0000-0002-2061-091X
 description: Metrical units for use in conjunction with PATO
 domain: phenotype
 homepage: https://github.com/bio-ontology-research-group/unit-ontology

--- a/ontology/upa.md
+++ b/ontology/upa.md
@@ -16,6 +16,7 @@ contact:
   email: "Anne.Morgat@sib.swiss"
   label: "Anne Morgat"
   github: amorgat
+  orcid: 0000-0002-1216-2969
 description: "A manually curated resource for the representation and annotation of metabolic pathways"
 domain: pathways
 homepage: https://github.com/geneontology/unipathway

--- a/ontology/upheno.md
+++ b/ontology/upheno.md
@@ -12,6 +12,7 @@ contact:
   label: Nicole Vasilevsky
   email: vasilevs@ohsu.edu
   github: nicolevasilevsky
+  orcid: 0000-0001-5208-3432
 mailing_list: https://groups.google.com/forum/#!forum/phenotype-ontologies-editors
 products:
   - id: upheno.owl

--- a/ontology/vo.md
+++ b/ontology/vo.md
@@ -9,6 +9,7 @@ contact:
   email: yongqunh@med.umich.edu
   label: Yongqunh He
   github: yongqunh
+  orcid: 0000-0001-9189-9661
 domain: health
 products:
   - id: vo.owl

--- a/ontology/vsao.md
+++ b/ontology/vsao.md
@@ -2,6 +2,7 @@
 layout: ontology_detail
 id: vsao
 contact:
+  orcid: 0000-0003-3162-7490
   email: wasila.dahdul@usd.edu
   label: Wasila Dahdul
 description: Vertebrate skeletal anatomy ontology.

--- a/ontology/vt.md
+++ b/ontology/vt.md
@@ -10,6 +10,7 @@ contact:
   label: Carissa Park
   email: caripark@iastate.edu
   github: caripark
+  orcid: 0000-0002-2346-5201
 license:
   url: https://creativecommons.org/licenses/by/4.0/
   label: CC BY 4.0

--- a/ontology/vto.md
+++ b/ontology/vto.md
@@ -15,6 +15,7 @@ contact:
   label: Jim Balhoff
   email: balhoff@renci.org
   github: balhoff
+  orcid: 0000-0002-8688-6599
 license:
   url: http://creativecommons.org/publicdomain/zero/1.0/
   label: CC0 1.0

--- a/ontology/wbbt.md
+++ b/ontology/wbbt.md
@@ -6,6 +6,7 @@ contact:
   email: raymond@caltech.edu
   label: Raymond Lee
   github: raymond91125
+  orcid: 0000-0002-8151-7479
 license:
   url: https://creativecommons.org/licenses/by/4.0/
   label: CC BY 4.0

--- a/ontology/wbls.md
+++ b/ontology/wbls.md
@@ -6,6 +6,7 @@ contact:
   email: cgrove@caltech.edu
   label: Chris Grove
   github: chris-grove
+  orcid: 0000-0001-9076-6015
 license:
   url: https://creativecommons.org/licenses/by/4.0/
   label: CC BY 4.0

--- a/ontology/wbphenotype.md
+++ b/ontology/wbphenotype.md
@@ -6,6 +6,7 @@ contact:
   email: cgrove@caltech.edu
   label: Chris Grove
   github: chris-grove
+  orcid: 0000-0001-9076-6015
 license:
   url: http://creativecommons.org/licenses/by/4.0/
   label: CC BY 4.0

--- a/ontology/xao.md
+++ b/ontology/xao.md
@@ -8,6 +8,7 @@ contact:
   label: Erik Segerdell
   email: esegerd3@gmail.com
   github: seger
+  orcid: 0000-0002-9611-1279
 in_foundry_order: 1
 products:
   - id: xao.owl

--- a/ontology/xco.md
+++ b/ontology/xco.md
@@ -4,6 +4,7 @@ contact:
   email: jrsmith@mcw.edu
   label: Jennifer Smith
   github: jrsjrs
+  orcid: 0000-0002-6443-9376
 license:
   url: https://creativecommons.org/publicdomain/zero/1.0/
   label: CC0 1.0

--- a/ontology/xlmod.md
+++ b/ontology/xlmod.md
@@ -9,6 +9,7 @@ contact:
   email: gerhard.mayer@rub.de
   label: Gerhard Mayer
   github: germa
+  orcid: 0000-0002-1767-2343
 integration_server: https://raw.githubusercontent.com/HUPO-PSI/mzIdentML/tree/master/cv
 domain: MS cross-linker reagents
 mailing_list: psidev-ms-vocab@lists.sourceforge.net

--- a/ontology/xpo.md
+++ b/ontology/xpo.md
@@ -13,6 +13,7 @@ contact:
   email: esegerd3@gmail.com
   label: Erik Segerdell
   github: seger
+  orcid: 0000-0002-9611-1279
 description: XPO represents anatomical, cellular, and gene function phenotypes occurring throughout the development of the African frogs Xenopus laevis and tropicalis.
 domain: phenotype
 homepage: https://github.com/obophenotype/xenopus-phenotype-ontology

--- a/ontology/ypo.md
+++ b/ontology/ypo.md
@@ -3,6 +3,7 @@ layout: ontology_detail
 id: ypo
 title: Yeast phenotypes
 contact:
+  orcid: 0000-0001-9163-5180
   email: cherry@genome.stanford.edu
   label: Mike Cherry
 taxon:

--- a/ontology/zea.md
+++ b/ontology/zea.md
@@ -3,6 +3,7 @@ layout: ontology_detail
 id: zea
 title: Maize gross anatomy
 contact:
+  orcid: 0000-0002-9316-2919
   email: Leszek@missouri.edu
   label: Leszek Vincent
 taxon:

--- a/ontology/zeco.md
+++ b/ontology/zeco.md
@@ -9,6 +9,7 @@ contact:
   email: ybradford@zfin.org
   label: Yvonne Bradford
   github: ybradford
+  orcid: 0000-0002-9900-7880
 products:
   - id: zeco.obo
   - id: zeco.owl

--- a/ontology/zfa.md
+++ b/ontology/zfa.md
@@ -6,6 +6,7 @@ contact:
   email: van_slyke@zfin.org
   label: Ceri Van Slyke
   github: cerivs
+  orcid: 0000-0002-2244-7917
 description: A structured controlled vocabulary of the anatomy and development of the Zebrafish
 domain: anatomy
 homepage: https://wiki.zfin.org/display/general/Anatomy+Atlases+and+Resources

--- a/ontology/zfs.md
+++ b/ontology/zfs.md
@@ -6,6 +6,7 @@ contact:
   email: van_slyke@zfin.org
   label: Ceri Van Slyke
   github: cerivs
+  orcid: 0000-0002-2244-7917
 description: Developmental stages of the Zebrafish
 domain: anatomy
 homepage: https://wiki.zfin.org/display/general/Anatomy+Atlases+and+Resources

--- a/ontology/zp.md
+++ b/ontology/zp.md
@@ -13,6 +13,7 @@ contact:
   email: ybradford@zfin.org
   label: Yvonne Bradford
   github: ybradford
+  orcid: 0000-0002-9900-7880
 description: The Zebrafish Phenotype Ontology formally defines all phenotypes of the Zebrafish model organism.
 domain: phenotype
 homepage: https://github.com/obophenotype/zebrafish-phenotype-ontology

--- a/util/populate_orcid.py
+++ b/util/populate_orcid.py
@@ -1,0 +1,74 @@
+"""This script annotates an ORCID identifier to each ontology's contact person.
+
+Run with: ``python annotate_orcid.py``. However, it makes sense to update the mapping at
+https://github.com/cthoyt/obo-community-health first in case there are new mappings available.
+
+Author: `Charles Tapley Hoyt <https://cthoyt.com>`_.
+"""
+
+import pathlib
+from functools import cache
+from io import StringIO
+from typing import Union
+
+import click
+import pandas as pd
+import yaml
+from tqdm import tqdm
+
+HERE = pathlib.Path(__file__).parent.resolve()
+ONTOLOGY_DIRECTORY = HERE.parent.joinpath("ontology").resolve()
+
+
+def update_orcid(path: Union[str, pathlib.Path]) -> None:
+    """Update the given markdown file."""
+    with open(path) as file:
+        lines = [line.rstrip("\n") for line in file]
+
+    assert lines[0] == "---"
+    idx = min(i for i, line in enumerate(lines[1:], start=1) if line == "---")
+
+    # Load the data like it is YAML
+    data = yaml.safe_load(StringIO("\n".join(lines[1:idx])))
+
+    contact = data.get("contact", {})
+    if "orcid" in contact:
+        return  # already available!
+
+    github_handle = contact.get("github")
+    if github_handle is None:
+        tqdm.write(f"Issue getting GitHub handle for {data['id']}")
+        return
+
+    orcid = get_github_to_orcid().get(github_handle)
+    if orcid is None:
+        tqdm.write(f"Issue getting ORCID for {data['id']} with GitHub handle @{github_handle}")
+        return
+
+    with open(path, "w") as file:
+        print("---", file=file)
+        for line in lines[1:idx]:
+            print(line, file=file)
+            if line.startswith("  github:"):
+                print(f"  orcid: {orcid}", file=file)
+        print("---", file=file)
+        for line in lines[idx + 1:]:
+            print(line, file=file)
+
+
+@cache
+def get_github_to_orcid() -> dict[str, str]:
+    """Get a mapping from GitHub to ORCID identifiers."""
+    url = "https://raw.githubusercontent.com/cthoyt/obo-community-health/main/data/contacts_table.tsv"
+    df = pd.read_csv(url, sep='\t')
+    return dict(df[["github", "orcid"]].values)
+
+
+@click.command()
+def main():
+    for path in tqdm(ONTOLOGY_DIRECTORY.glob("*.md")):
+        update_orcid(path)
+
+
+if __name__ == "__main__":
+    main()

--- a/util/populate_orcid.py
+++ b/util/populate_orcid.py
@@ -37,12 +37,16 @@ def update_orcid(path: Union[str, pathlib.Path]) -> None:
 
     github_handle = contact.get("github")
     if github_handle is None:
-        tqdm.write(f"Issue getting GitHub handle for {data['id']}")
+        tqdm.write(
+            f"Issue getting GitHub handle for {data['id']} for {contact.get('label')} ({contact.get('email')})"
+        )
         return
 
     orcid = get_github_to_orcid().get(github_handle)
     if orcid is None:
-        tqdm.write(f"Issue getting ORCID for {data['id']} with GitHub handle @{github_handle}")
+        tqdm.write(
+            f"Issue getting ORCID for {data['id']} with GitHub handle @{github_handle}"
+        )
         return
 
     with open(path, "w") as file:
@@ -52,7 +56,7 @@ def update_orcid(path: Union[str, pathlib.Path]) -> None:
             if line.startswith("  github:"):
                 print(f"  orcid: {orcid}", file=file)
         print("---", file=file)
-        for line in lines[idx + 1:]:
+        for line in lines[idx + 1 :]:
             print(line, file=file)
 
 
@@ -60,7 +64,7 @@ def update_orcid(path: Union[str, pathlib.Path]) -> None:
 def get_github_to_orcid() -> dict[str, str]:
     """Get a mapping from GitHub to ORCID identifiers."""
     url = "https://raw.githubusercontent.com/cthoyt/obo-community-health/main/data/contacts_table.tsv"
-    df = pd.read_csv(url, sep='\t')
+    df = pd.read_csv(url, sep="\t")
     return dict(df[["github", "orcid"]].values)
 
 

--- a/util/schema/registry_schema.json
+++ b/util/schema/registry_schema.json
@@ -90,6 +90,10 @@
         "github": {
           "type": "string",
           "pattern": "^[^@]+$"
+        },
+        "orcid": {
+          "type": "string",
+          "pattern": "^\\d{4}-\\d{4}-\\d{4}-\\d{3}(\\d|X)$"
         }
       },
       "required": [


### PR DESCRIPTION
References #1719

This PR does the following:

1. Adds the ORCID identifier as an **optional** element in the metadata schema
2. Implements a script `util/populate_orcid.py` that reads the GitHub-ORCID mapping from https://github.com/cthoyt/obo-community-health and can re-write ontology metadata files that are missing an ORCID. This script doesn't *really* need to get committed since it's a one-off, but it could potentially be useful later if more curation is done on the 20+ non-active ontologies that contain references to authors (which I will personally invest effort into in a separate PR).
3. Apply the script and update 190 ontologies with ORCID identifiers for their respective responsible people that were automatically mapped this way and 14 additionally manually curated based on name/email combination

**Note:** all GitHub-ORCID mappings were painstakingly manually curated by me in Wikidata, so there *shouldn't* be any mistakes.

This PR does not close the referenced issue because it does not yet make ORCID required. That requires a bit more discussion. This PR should not be blocked by the discussion of whether ORCID should be required or not.