### PR TITLE
Require ORCID for active ontologies

### DIFF
--- a/util/schema/registry_schema.json
+++ b/util/schema/registry_schema.json
@@ -54,7 +54,7 @@
     "contact": {
       "level": "error",
       "principle": "http://obofoundry.org/principles/fp-011-locus-of-authority.html",
-      "description": "'contact' is a required property. This object must include the contact person's name (i.e., label), their personal email, and their personal GitHub handle. The contact is the person responsible for communications between the community and the ontology developers.",
+      "description": "'contact' is a required property. This object must include the contact person's name (i.e., label), their personal email, their ORCID, and their personal GitHub handle. The contact is the person responsible for communications between the community and the ontology developers.",
       "type": "object",
       "additionalProperties": false,
       "properties": {
@@ -78,7 +78,8 @@
       "required": [
         "email",
         "label",
-        "github"
+        "github",
+        "orcid"
       ]
     },
     "description": {


### PR DESCRIPTION
Closes #1719

In #1793, we added ORCID identifiers to all active ontologies' contact people. There was supposed to be a follow-up vote for whether ORCID identifiers should become **required** for the contact person of each active ontology [here](https://github.com/OBOFoundry/OBOFoundry.github.io/issues/1719#issuecomment-1033560715). The vote didn't get any attention, so this PR provides the technical check and a not-so-subtle bump for potential stakeholders to state their opinion.

As a reminder, the curation is already done, and this PR would not require anyone to do any additional work. It would, however, ensure that any new ontologies should have this information available on submission.