### PR TITLE
Harmonising domains for all ontologies

### DIFF
--- a/ontology/aeo.md
+++ b/ontology/aeo.md
@@ -8,7 +8,7 @@ license:
   url: https://creativecommons.org/licenses/by/4.0/
   label: CC BY 4.0
 description: AEO is an ontology of anatomical structures that expands CARO, the Common Anatomy Reference Ontology
-domain: anatomy and development
+domain: anatomy
 homepage: https://github.com/obophenotype/human-developmental-anatomy-ontology/
 tracker: https://github.com/obophenotype/human-developmental-anatomy-ontology/issues
 products:

--- a/ontology/aeo.md
+++ b/ontology/aeo.md
@@ -8,7 +8,7 @@ license:
   url: https://creativecommons.org/licenses/by/4.0/
   label: CC BY 4.0
 description: AEO is an ontology of anatomical structures that expands CARO, the Common Anatomy Reference Ontology
-domain: anatomy
+domain: anatomy and development
 homepage: https://github.com/obophenotype/human-developmental-anatomy-ontology/
 tracker: https://github.com/obophenotype/human-developmental-anatomy-ontology/issues
 products:

--- a/ontology/agro.md
+++ b/ontology/agro.md
@@ -5,7 +5,9 @@ title: Agronomy Ontology
 license:
   url: https://creativecommons.org/licenses/by/4.0/
   label: CC BY 4.0
-domain: agronomy
+domain: agriculture
+tags:
+  - agronomy
 build:
   checkout: git clone  https://github.com/AgriculturalSemantics/agro.git
   system: git

--- a/ontology/agro.md
+++ b/ontology/agro.md
@@ -5,9 +5,7 @@ title: Agronomy Ontology
 license:
   url: https://creativecommons.org/licenses/by/4.0/
   label: CC BY 4.0
-domain: agriculture
-tags:
- - agronomy
+domain: agronomy
 build:
   checkout: git clone  https://github.com/AgriculturalSemantics/agro.git
   system: git

--- a/ontology/agro.md
+++ b/ontology/agro.md
@@ -5,7 +5,9 @@ title: Agronomy Ontology
 license:
   url: https://creativecommons.org/licenses/by/4.0/
   label: CC BY 4.0
-domain: agronomy
+domain: agriculture
+tags:
+ - agronomy
 build:
   checkout: git clone  https://github.com/AgriculturalSemantics/agro.git
   system: git

--- a/ontology/aism.md
+++ b/ontology/aism.md
@@ -12,7 +12,7 @@ contact:
   github: JCGiron
   orcid: 0000-0002-0851-6883
 description: The AISM contains terms used in insect biodiversity research for describing structures of the exoskeleton and the skeletomuscular system. It aims to serve as the basic backbone of generalized terms to be expanded with order-specific terminology.
-domain: anatomy
+domain: anatomy and development
 homepage: https://github.com/insect-morphology/aism
 products:
   - id: aism.owl

--- a/ontology/aism.md
+++ b/ontology/aism.md
@@ -12,7 +12,7 @@ contact:
   github: JCGiron
   orcid: 0000-0002-0851-6883
 description: The AISM contains terms used in insect biodiversity research for describing structures of the exoskeleton and the skeletomuscular system. It aims to serve as the basic backbone of generalized terms to be expanded with order-specific terminology.
-domain: anatomy and development
+domain: anatomy
 homepage: https://github.com/insect-morphology/aism
 products:
   - id: aism.owl

--- a/ontology/amphx.md
+++ b/ontology/amphx.md
@@ -12,7 +12,7 @@ contact:
   github: hescriva
   orcid: 0000-0001-7577-5028
 description: An ontology for the development and anatomy of Amphioxus (Branchiostoma lanceolatum).
-domain: anatomy
+domain: anatomy and development
 homepage: https://github.com/EBISPOT/amphx_ontology
 products:
   - id: amphx.owl

--- a/ontology/amphx.md
+++ b/ontology/amphx.md
@@ -12,7 +12,7 @@ contact:
   github: hescriva
   orcid: 0000-0001-7577-5028
 description: An ontology for the development and anatomy of Amphioxus (Branchiostoma lanceolatum).
-domain: anatomy and development
+domain: anatomy
 homepage: https://github.com/EBISPOT/amphx_ontology
 products:
   - id: amphx.owl

--- a/ontology/bco.md
+++ b/ontology/bco.md
@@ -11,9 +11,7 @@ license:
   url: https://creativecommons.org/publicdomain/zero/1.0/
   label: CC0 1.0
 description: An ontology to support the interoperability of biodiversity data, including data on museum collections, environmental/metagenomic samples, and ecological surveys.
-domain: organisms
-tags:
- - biodiversity collections
+domain: biodiversity collections
 homepage: https://github.com/BiodiversityOntologies/bco
 products:
   - id: bco.owl

--- a/ontology/bco.md
+++ b/ontology/bco.md
@@ -11,7 +11,9 @@ license:
   url: https://creativecommons.org/publicdomain/zero/1.0/
   label: CC0 1.0
 description: An ontology to support the interoperability of biodiversity data, including data on museum collections, environmental/metagenomic samples, and ecological surveys.
-domain: biodiversity collections
+domain: organisms
+tags:
+ - biodiversity collections
 homepage: https://github.com/BiodiversityOntologies/bco
 products:
   - id: bco.owl

--- a/ontology/bco.md
+++ b/ontology/bco.md
@@ -11,7 +11,9 @@ license:
   url: https://creativecommons.org/publicdomain/zero/1.0/
   label: CC0 1.0
 description: An ontology to support the interoperability of biodiversity data, including data on museum collections, environmental/metagenomic samples, and ecological surveys.
-domain: biodiversity collections
+domain: organisms
+tags:
+  - biodiversity collections
 homepage: https://github.com/BiodiversityOntologies/bco
 products:
   - id: bco.owl

--- a/ontology/bila.md
+++ b/ontology/bila.md
@@ -4,7 +4,7 @@ id: bila
 contact:
   email: henrich@embl.de
   label: Thorsten Heinrich
-domain: anatomy and development
+domain: anatomy
 homepage: http://4dx.embl.de/4DXpress
 products:
   - id: bila.owl

--- a/ontology/bila.md
+++ b/ontology/bila.md
@@ -4,7 +4,7 @@ id: bila
 contact:
   email: henrich@embl.de
   label: Thorsten Heinrich
-domain: anatomy
+domain: anatomy and development
 homepage: http://4dx.embl.de/4DXpress
 products:
   - id: bila.owl

--- a/ontology/bspo.md
+++ b/ontology/bspo.md
@@ -7,7 +7,7 @@ contact:
   github: cmungall
   orcid: 0000-0002-6601-2165
 description: An ontology for representing spatial concepts, anatomical axes, gradients, regions, planes, sides, and surfaces
-domain: anatomy and development
+domain: anatomy
 homepage: https://github.com/obophenotype/biological-spatial-ontology
 products:
   - id: bspo.owl

--- a/ontology/bspo.md
+++ b/ontology/bspo.md
@@ -7,7 +7,7 @@ contact:
   github: cmungall
   orcid: 0000-0002-6601-2165
 description: An ontology for representing spatial concepts, anatomical axes, gradients, regions, planes, sides, and surfaces
-domain: anatomy
+domain: anatomy and development
 homepage: https://github.com/obophenotype/biological-spatial-ontology
 products:
   - id: bspo.owl

--- a/ontology/bto.md
+++ b/ontology/bto.md
@@ -7,7 +7,7 @@ contact:
   github: chdudek
   orcid: 0000-0001-9117-7909
 description: A structured controlled vocabulary for the source of an enzyme comprising tissues, cell lines, cell types and cell cultures.
-domain: anatomy
+domain: anatomy and development
 homepage: http://www.brenda-enzymes.org
 tracker: https://github.com/BRENDA-Enzymes/BTO/issues
 page: https://en.wikipedia.org/wiki/BRENDA_tissue_ontology

--- a/ontology/bto.md
+++ b/ontology/bto.md
@@ -7,7 +7,7 @@ contact:
   github: chdudek
   orcid: 0000-0001-9117-7909
 description: A structured controlled vocabulary for the source of an enzyme comprising tissues, cell lines, cell types and cell cultures.
-domain: anatomy and development
+domain: anatomy
 homepage: http://www.brenda-enzymes.org
 tracker: https://github.com/BRENDA-Enzymes/BTO/issues
 page: https://en.wikipedia.org/wiki/BRENDA_tissue_ontology

--- a/ontology/caro.md
+++ b/ontology/caro.md
@@ -10,7 +10,7 @@ license:
   url: https://creativecommons.org/licenses/by/3.0/
   label: CC BY 3.0
 description: An upper level ontology to facilitate interoperability between existing anatomy ontologies for different species
-domain: anatomy and development
+domain: anatomy
 homepage: https://github.com/obophenotype/caro/
 products:
   - id: caro.owl

--- a/ontology/caro.md
+++ b/ontology/caro.md
@@ -10,7 +10,7 @@ license:
   url: https://creativecommons.org/licenses/by/3.0/
   label: CC BY 3.0
 description: An upper level ontology to facilitate interoperability between existing anatomy ontologies for different species
-domain: anatomy
+domain: anatomy and development
 homepage: https://github.com/obophenotype/caro/
 products:
   - id: caro.owl

--- a/ontology/cdno.md
+++ b/ontology/cdno.md
@@ -12,7 +12,7 @@ contact:
   github: LilyAndres
   orcid: 0000-0002-7696-731X
 description: CDNO provides structured terminologies to describe nutritional attributes of material entities that contribute to human diet.
-domain: diet, metabolomics and nutrition
+domain: diet, metabolomics, and nutrition
 homepage: https://github.com/Southern-Cross-Plant-Science/cdno
 products:
   - id: cdno.owl

--- a/ontology/ceph.md
+++ b/ontology/ceph.md
@@ -13,7 +13,7 @@ contact:
   github: cmungall
   orcid: 0000-0002-6601-2165
 description: An anatomical and developmental ontology for cephalopods
-domain: anatomy and development
+domain: anatomy
 homepage: https://github.com/obophenotype/cephalopod-ontology
 products:
   - id: ceph.owl

--- a/ontology/ceph.md
+++ b/ontology/ceph.md
@@ -13,7 +13,7 @@ contact:
   github: cmungall
   orcid: 0000-0002-6601-2165
 description: An anatomical and developmental ontology for cephalopods
-domain: anatomy
+domain: anatomy and development
 homepage: https://github.com/obophenotype/cephalopod-ontology
 products:
   - id: ceph.owl

--- a/ontology/cl.md
+++ b/ontology/cl.md
@@ -26,7 +26,9 @@ license:
 taxon:
   id: NCBITaxon:33208
   label: Metazoa
-domain: cells
+domain: anatomy and development
+tags:
+  - cells
 tracker: https://github.com/obophenotype/cell-ontology/issues
 mailing_list: https://groups.google.com/g/cl_edit
 publications:

--- a/ontology/cl.md
+++ b/ontology/cl.md
@@ -26,7 +26,9 @@ license:
 taxon:
   id: NCBITaxon:33208
   label: Metazoa
-domain: cells
+domain: anatomy and development
+tags:
+ - cells
 tracker: https://github.com/obophenotype/cell-ontology/issues
 mailing_list: https://groups.google.com/g/cl_edit
 publications:

--- a/ontology/cl.md
+++ b/ontology/cl.md
@@ -26,9 +26,7 @@ license:
 taxon:
   id: NCBITaxon:33208
   label: Metazoa
-domain: anatomy and development
-tags:
- - cells
+domain: cells
 tracker: https://github.com/obophenotype/cell-ontology/issues
 mailing_list: https://groups.google.com/g/cl_edit
 publications:

--- a/ontology/clao.md
+++ b/ontology/clao.md
@@ -12,7 +12,7 @@ contact:
   github: luis-gonzalez-m
   orcid: 0000-0002-9136-9932
 description: "CLAO is an ontology of anatomical terms employed in morphological descriptions for the Class Collembola (Arthropoda: Hexapoda)."
-domain: anatomy and development
+domain: anatomy
 homepage: https://github.com/luis-gonzalez-m/Collembola
 products:
   - id: clao.owl

--- a/ontology/clao.md
+++ b/ontology/clao.md
@@ -12,7 +12,7 @@ contact:
   github: luis-gonzalez-m
   orcid: 0000-0002-9136-9932
 description: "CLAO is an ontology of anatomical terms employed in morphological descriptions for the Class Collembola (Arthropoda: Hexapoda)."
-domain: anatomy
+domain: anatomy and development
 homepage: https://github.com/luis-gonzalez-m/Collembola
 products:
   - id: clao.owl

--- a/ontology/clyh.md
+++ b/ontology/clyh.md
@@ -12,7 +12,7 @@ contact:
   github: L-Leclere
   orcid: 0000-0002-7440-0467
 description: The Clytia hemisphaerica Development and Anatomy Ontology (CLYH) describes the anatomical and developmental features of the Clytia hemisphaerica life cycle.
-domain: anatomy
+domain: anatomy and development
 homepage: https://github.com/EBISPOT/clyh_ontology
 products:
   - id: clyh.owl

--- a/ontology/clyh.md
+++ b/ontology/clyh.md
@@ -12,7 +12,7 @@ contact:
   github: L-Leclere
   orcid: 0000-0002-7440-0467
 description: The Clytia hemisphaerica Development and Anatomy Ontology (CLYH) describes the anatomical and developmental features of the Clytia hemisphaerica life cycle.
-domain: anatomy and development
+domain: anatomy
 homepage: https://github.com/EBISPOT/clyh_ontology
 products:
   - id: clyh.owl

--- a/ontology/cmo.md
+++ b/ontology/cmo.md
@@ -10,9 +10,7 @@ license:
   url: http://creativecommons.org/publicdomain/zero/1.0/
   label: CC0 1.0
 description: Morphological and physiological measurement records generated from clinical and model organism research and health programs.
-domain: health
-tags:
- - clinical
+domain: clinical
 homepage: http://rgd.mcw.edu/rgdweb/ontology/search.html
 tracker: https://github.com/rat-genome-database/CMO-Clinical-Measurement-Ontology/issues
 page: https://download.rgd.mcw.edu/ontology/clinical_measurement/

--- a/ontology/cmo.md
+++ b/ontology/cmo.md
@@ -10,7 +10,9 @@ license:
   url: http://creativecommons.org/publicdomain/zero/1.0/
   label: CC0 1.0
 description: Morphological and physiological measurement records generated from clinical and model organism research and health programs.
-domain: clinical
+domain: health
+tags:
+ - clinical
 homepage: http://rgd.mcw.edu/rgdweb/ontology/search.html
 tracker: https://github.com/rat-genome-database/CMO-Clinical-Measurement-Ontology/issues
 page: https://download.rgd.mcw.edu/ontology/clinical_measurement/

--- a/ontology/cmo.md
+++ b/ontology/cmo.md
@@ -10,7 +10,9 @@ license:
   url: http://creativecommons.org/publicdomain/zero/1.0/
   label: CC0 1.0
 description: Morphological and physiological measurement records generated from clinical and model organism research and health programs.
-domain: clinical
+domain: health
+tags:
+  - clinical
 homepage: http://rgd.mcw.edu/rgdweb/ontology/search.html
 tracker: https://github.com/rat-genome-database/CMO-Clinical-Measurement-Ontology/issues
 page: https://download.rgd.mcw.edu/ontology/clinical_measurement/

--- a/ontology/colao.md
+++ b/ontology/colao.md
@@ -8,9 +8,7 @@ contact:
   github: JCGiron
   orcid: 0000-0002-0851-6883
 description: "The Coleoptera Anatomy Ontology contains terms used for describing the anatomy and phenotype of beetles in biodiversity research. It has been built using the Ontology Develoment Kit, with the Ontology for the Anatomy of the Insect Skeleto-Muscular system (AISM) as a backbone."
-domain: anatomy and development
-tags:
- - Insect Anatomy.
+domain: Insect Anatomy.
 homepage: https://github.com/insect-morphology/colao
 products:
   - id: colao.owl

--- a/ontology/colao.md
+++ b/ontology/colao.md
@@ -8,7 +8,9 @@ contact:
   github: JCGiron
   orcid: 0000-0002-0851-6883
 description: "The Coleoptera Anatomy Ontology contains terms used for describing the anatomy and phenotype of beetles in biodiversity research. It has been built using the Ontology Develoment Kit, with the Ontology for the Anatomy of the Insect Skeleto-Muscular system (AISM) as a backbone."
-domain: Insect Anatomy.
+domain: anatomy and development
+tags:
+ - Insect Anatomy.
 homepage: https://github.com/insect-morphology/colao
 products:
   - id: colao.owl

--- a/ontology/colao.md
+++ b/ontology/colao.md
@@ -8,7 +8,9 @@ contact:
   github: JCGiron
   orcid: 0000-0002-0851-6883
 description: "The Coleoptera Anatomy Ontology contains terms used for describing the anatomy and phenotype of beetles in biodiversity research. It has been built using the Ontology Develoment Kit, with the Ontology for the Anatomy of the Insect Skeleto-Muscular system (AISM) as a backbone."
-domain: Insect Anatomy.
+domain: anatomy and development
+tags:
+  - Insect Anatomy.
 homepage: https://github.com/insect-morphology/colao
 products:
   - id: colao.owl

--- a/ontology/colao.md
+++ b/ontology/colao.md
@@ -10,7 +10,7 @@ contact:
 description: "The Coleoptera Anatomy Ontology contains terms used for describing the anatomy and phenotype of beetles in biodiversity research. It has been built using the Ontology Develoment Kit, with the Ontology for the Anatomy of the Insect Skeleto-Muscular system (AISM) as a backbone."
 domain: anatomy and development
 tags:
-  - Insect Anatomy.
+  - insect anatomy
 homepage: https://github.com/insect-morphology/colao
 products:
   - id: colao.owl

--- a/ontology/cro.md
+++ b/ontology/cro.md
@@ -3,7 +3,9 @@ layout: ontology_detail
 id: cro
 title: Contributor Role Ontology
 description: A classification of the diverse roles performed in the work leading to a published research output in the sciences. Its purpose to provide transparency in contributions to scholarly published work, to enable improved systems of attribution, credit, and accountability.
-domain: scholarly contribution roles
+domain: information
+tags:
+ - scholarly contribution roles
 homepage: https://github.com/data2health/contributor-role-ontology
 tracker: https://github.com/data2health/contributor-role-ontology/issues
 contact:

--- a/ontology/cro.md
+++ b/ontology/cro.md
@@ -3,9 +3,7 @@ layout: ontology_detail
 id: cro
 title: Contributor Role Ontology
 description: A classification of the diverse roles performed in the work leading to a published research output in the sciences. Its purpose to provide transparency in contributions to scholarly published work, to enable improved systems of attribution, credit, and accountability.
-domain: information
-tags:
- - scholarly contribution roles
+domain: scholarly contribution roles
 homepage: https://github.com/data2health/contributor-role-ontology
 tracker: https://github.com/data2health/contributor-role-ontology/issues
 contact:

--- a/ontology/cro.md
+++ b/ontology/cro.md
@@ -3,7 +3,9 @@ layout: ontology_detail
 id: cro
 title: Contributor Role Ontology
 description: A classification of the diverse roles performed in the work leading to a published research output in the sciences. Its purpose to provide transparency in contributions to scholarly published work, to enable improved systems of attribution, credit, and accountability.
-domain: scholarly contribution roles
+domain: information
+tags:
+  - scholarly contribution roles
 homepage: https://github.com/data2health/contributor-role-ontology
 tracker: https://github.com/data2health/contributor-role-ontology/issues
 contact:

--- a/ontology/cteno.md
+++ b/ontology/cteno.md
@@ -16,7 +16,7 @@ contact:
   github: cmungall
   orcid: 0000-0002-6601-2165
 description: An anatomical and developmental ontology for ctenophores (Comb Jellies)
-domain: anatomy
+domain: anatomy and development
 homepage: https://github.com/obophenotype/ctenophore-ontology
 products:
   - id: cteno.owl

--- a/ontology/cteno.md
+++ b/ontology/cteno.md
@@ -16,7 +16,7 @@ contact:
   github: cmungall
   orcid: 0000-0002-6601-2165
 description: An anatomical and developmental ontology for ctenophores (Comb Jellies)
-domain: anatomy and development
+domain: anatomy
 homepage: https://github.com/obophenotype/ctenophore-ontology
 products:
   - id: cteno.owl

--- a/ontology/ddanat.md
+++ b/ontology/ddanat.md
@@ -7,7 +7,7 @@ contact:
   github: pfey03
   orcid: 0000-0002-4532-2703
 description: A structured controlled vocabulary of the anatomy of the slime-mold Dictyostelium discoideum
-domain: anatomy
+domain: anatomy and development
 homepage: http://dictybase.org/
 twitter: dictybase
 license:

--- a/ontology/ddanat.md
+++ b/ontology/ddanat.md
@@ -7,7 +7,7 @@ contact:
   github: pfey03
   orcid: 0000-0002-4532-2703
 description: A structured controlled vocabulary of the anatomy of the slime-mold Dictyostelium discoideum
-domain: anatomy and development
+domain: anatomy
 homepage: http://dictybase.org/
 twitter: dictybase
 license:

--- a/ontology/ddpheno.md
+++ b/ontology/ddpheno.md
@@ -10,7 +10,7 @@ license:
   url: http://creativecommons.org/publicdomain/zero/1.0/
   label: CC0 1.0
 description: A structured controlled vocabulary of phenotypes of the slime-mould <i>Dictyostelium discoideum</i>.
-domain: anatomy and development
+domain: anatomy
 homepage: http://dictybase.org/
 tracker: https://github.com/obophenotype/dicty-phenotype-ontology/issues
 twitter: dictybase

--- a/ontology/ddpheno.md
+++ b/ontology/ddpheno.md
@@ -10,7 +10,7 @@ license:
   url: http://creativecommons.org/publicdomain/zero/1.0/
   label: CC0 1.0
 description: A structured controlled vocabulary of phenotypes of the slime-mould <i>Dictyostelium discoideum</i>.
-domain: anatomy
+domain: anatomy and development
 homepage: http://dictybase.org/
 tracker: https://github.com/obophenotype/dicty-phenotype-ontology/issues
 twitter: dictybase

--- a/ontology/disdriv.md
+++ b/ontology/disdriv.md
@@ -8,9 +8,7 @@ contact:
   orcid: 0000-0001-8910-9851
 description: Ontology for drivers and triggers of human diseases, built to classify ExO ontology exposure stressors. An application ontology. Built in collaboration with EnvO, ExO, ECTO and ChEBI.
 twitter: diseaseontology
-domain: health
-tags:
- - disease
+domain: disease
 homepage: http://www.disease-ontology.org
 products:
   - id: disdriv.owl

--- a/ontology/disdriv.md
+++ b/ontology/disdriv.md
@@ -8,7 +8,9 @@ contact:
   orcid: 0000-0001-8910-9851
 description: Ontology for drivers and triggers of human diseases, built to classify ExO ontology exposure stressors. An application ontology. Built in collaboration with EnvO, ExO, ECTO and ChEBI.
 twitter: diseaseontology
-domain: disease
+domain: health
+tags:
+  - disease
 homepage: http://www.disease-ontology.org
 products:
   - id: disdriv.owl

--- a/ontology/disdriv.md
+++ b/ontology/disdriv.md
@@ -8,7 +8,9 @@ contact:
   orcid: 0000-0001-8910-9851
 description: Ontology for drivers and triggers of human diseases, built to classify ExO ontology exposure stressors. An application ontology. Built in collaboration with EnvO, ExO, ECTO and ChEBI.
 twitter: diseaseontology
-domain: disease
+domain: health
+tags:
+ - disease
 homepage: http://www.disease-ontology.org
 products:
   - id: disdriv.owl

--- a/ontology/doid.md
+++ b/ontology/doid.md
@@ -9,7 +9,9 @@ contact:
   orcid: 0000-0001-8910-9851
 description: An ontology for describing the classification of human diseases organized by etiology.
 twitter: diseaseontology
-domain: disease
+domain: health
+tags:
+ - disease
 homepage: http://www.disease-ontology.org
 products:
   - id: doid.owl

--- a/ontology/doid.md
+++ b/ontology/doid.md
@@ -9,7 +9,9 @@ contact:
   orcid: 0000-0001-8910-9851
 description: An ontology for describing the classification of human diseases organized by etiology.
 twitter: diseaseontology
-domain: disease
+domain: health
+tags:
+  - disease
 homepage: http://www.disease-ontology.org
 products:
   - id: doid.owl

--- a/ontology/doid.md
+++ b/ontology/doid.md
@@ -9,9 +9,7 @@ contact:
   orcid: 0000-0001-8910-9851
 description: An ontology for describing the classification of human diseases organized by etiology.
 twitter: diseaseontology
-domain: health
-tags:
- - disease
+domain: disease
 homepage: http://www.disease-ontology.org
 products:
   - id: doid.owl

--- a/ontology/ecao.md
+++ b/ontology/ecao.md
@@ -12,7 +12,7 @@ contact:
   github: ettensohn
   orcid: 0000-0002-3625-0955
 description: An ontology for the development and anatomy of the different species of the phylum Echinodermata (NCBITaxon:7586).
-domain: anatomy and development
+domain: anatomy
 homepage: https://github.com/echinoderm-ontology/ecao_ontology
 products:
   - id: ecao.owl

--- a/ontology/ecao.md
+++ b/ontology/ecao.md
@@ -12,7 +12,7 @@ contact:
   github: ettensohn
   orcid: 0000-0002-3625-0955
 description: An ontology for the development and anatomy of the different species of the phylum Echinodermata (NCBITaxon:7586).
-domain: anatomy
+domain: anatomy and development
 homepage: https://github.com/echinoderm-ontology/ecao_ontology
 products:
   - id: ecao.owl

--- a/ontology/eco.md
+++ b/ontology/eco.md
@@ -2,7 +2,7 @@
 layout: ontology_detail
 id: eco
 description: An ontology for experimental and other evidence statements.
-domain: experiments
+domain: investigations
 homepage: https://github.com/evidenceontology/evidenceontology/
 tracker: https://github.com/evidenceontology/evidenceontology/issues
 products:

--- a/ontology/ecocore.md
+++ b/ontology/ecocore.md
@@ -17,7 +17,8 @@ contact:
 description: Ecocore is a community ontology for the concise and controlled description of ecological traits of organisms.
 domain: environment
 tags:
-  - ecological functions, ecological interactions
+  - ecological functions
+  - ecological interactions 
 homepage: https://github.com/EcologicalSemantics/ecocore
 products:
   - id: ecocore.owl

--- a/ontology/ecocore.md
+++ b/ontology/ecocore.md
@@ -18,7 +18,7 @@ description: Ecocore is a community ontology for the concise and controlled desc
 domain: environment
 tags:
   - ecological functions
-  - ecological interactions 
+  - ecological interactions
 homepage: https://github.com/EcologicalSemantics/ecocore
 products:
   - id: ecocore.owl

--- a/ontology/ecocore.md
+++ b/ontology/ecocore.md
@@ -15,7 +15,9 @@ contact:
   github: pbuttigieg
   orcid: 0000-0002-4366-3088
 description: Ecocore is a community ontology for the concise and controlled description of ecological traits of organisms.
-domain: ecological functions, ecological interactions
+domain: environment
+tags:
+  - ecological functions, ecological interactions
 homepage: https://github.com/EcologicalSemantics/ecocore
 products:
   - id: ecocore.owl

--- a/ontology/ecocore.md
+++ b/ontology/ecocore.md
@@ -15,7 +15,9 @@ contact:
   github: pbuttigieg
   orcid: 0000-0002-4366-3088
 description: Ecocore is a community ontology for the concise and controlled description of ecological traits of organisms.
-domain: ecological functions, ecological interactions
+domain: environment
+tags:
+ - ecological functions, ecological interactions
 homepage: https://github.com/EcologicalSemantics/ecocore
 products:
   - id: ecocore.owl

--- a/ontology/ecocore.md
+++ b/ontology/ecocore.md
@@ -15,9 +15,7 @@ contact:
   github: pbuttigieg
   orcid: 0000-0002-4366-3088
 description: Ecocore is a community ontology for the concise and controlled description of ecological traits of organisms.
-domain: environment
-tags:
- - ecological functions, ecological interactions
+domain: ecological functions, ecological interactions
 homepage: https://github.com/EcologicalSemantics/ecocore
 products:
   - id: ecocore.owl

--- a/ontology/ehdaa2.md
+++ b/ontology/ehdaa2.md
@@ -9,7 +9,7 @@ license:
   label: CC BY 4.0
 description: A structured controlled vocabulary of stage-specific anatomical structures of the developing human.
 tracker: https://github.com/obophenotype/human-developmental-anatomy-ontology/issues
-domain: anatomy and development
+domain: anatomy
 homepage: https://github.com/obophenotype/human-developmental-anatomy-ontology
 products:
   - id: ehdaa2.owl

--- a/ontology/ehdaa2.md
+++ b/ontology/ehdaa2.md
@@ -9,7 +9,7 @@ license:
   label: CC BY 4.0
 description: A structured controlled vocabulary of stage-specific anatomical structures of the developing human.
 tracker: https://github.com/obophenotype/human-developmental-anatomy-ontology/issues
-domain: anatomy
+domain: anatomy and development
 homepage: https://github.com/obophenotype/human-developmental-anatomy-ontology
 products:
   - id: ehdaa2.owl

--- a/ontology/emap.md
+++ b/ontology/emap.md
@@ -7,7 +7,7 @@ contact:
   github: tfhayamizu
   orcid: 0000-0002-0956-8634
 description: A structured controlled vocabulary of stage-specific anatomical structures of the mouse (Mus).
-domain: anatomy and development
+domain: anatomy
 homepage: http://emouseatlas.org
 page: https://www.emouseatlas.org/emap/about/what_is_emap.html
 products:

--- a/ontology/emap.md
+++ b/ontology/emap.md
@@ -7,7 +7,7 @@ contact:
   github: tfhayamizu
   orcid: 0000-0002-0956-8634
 description: A structured controlled vocabulary of stage-specific anatomical structures of the mouse (Mus).
-domain: anatomy
+domain: anatomy and development
 homepage: http://emouseatlas.org
 page: https://www.emouseatlas.org/emap/about/what_is_emap.html
 products:

--- a/ontology/emapa.md
+++ b/ontology/emapa.md
@@ -10,7 +10,7 @@ license:
   url: https://creativecommons.org/licenses/by/4.0/
   label: CC BY 4.0
 description: "An ontology for mouse anatomy covering embryonic development and postnatal stages."
-domain: anatomy and development
+domain: anatomy
 homepage: http://www.informatics.jax.org/expression.shtml
 tracker: https://github.com/obophenotype/mouse-anatomy-ontology/issues
 products:

--- a/ontology/emapa.md
+++ b/ontology/emapa.md
@@ -10,7 +10,7 @@ license:
   url: https://creativecommons.org/licenses/by/4.0/
   label: CC BY 4.0
 description: "An ontology for mouse anatomy covering embryonic development and postnatal stages."
-domain: anatomy
+domain: anatomy and development
 homepage: http://www.informatics.jax.org/expression.shtml
 tracker: https://github.com/obophenotype/mouse-anatomy-ontology/issues
 products:

--- a/ontology/epio.md
+++ b/ontology/epio.md
@@ -4,7 +4,9 @@ id: epio
 label: Epilepsy Ontology
 title: Epilepsy Ontology
 description: A application driven Epilepsy Ontology with official terms from the ILAE.
-domain: disease
+domain: health
+tags:
+ - disease
 license:
   url: http://creativecommons.org/licenses/by/4.0/
   label: CC BY 4.0

--- a/ontology/epio.md
+++ b/ontology/epio.md
@@ -4,9 +4,7 @@ id: epio
 label: Epilepsy Ontology
 title: Epilepsy Ontology
 description: A application driven Epilepsy Ontology with official terms from the ILAE.
-domain: health
-tags:
- - disease
+domain: disease
 license:
   url: http://creativecommons.org/licenses/by/4.0/
   label: CC BY 4.0

--- a/ontology/epio.md
+++ b/ontology/epio.md
@@ -4,7 +4,9 @@ id: epio
 label: Epilepsy Ontology
 title: Epilepsy Ontology
 description: A application driven Epilepsy Ontology with official terms from the ILAE.
-domain: disease
+domain: health
+tags:
+  - disease
 license:
   url: http://creativecommons.org/licenses/by/4.0/
   label: CC BY 4.0

--- a/ontology/ero.md
+++ b/ontology/ero.md
@@ -8,7 +8,9 @@ license:
   url: https://creativecommons.org/licenses/by/2.0/
   label: CC BY 2.0
 description: An ontology of research resources such as instruments. protocols, reagents, animal models and biospecimens.
-domain: resources
+domain: information
+tags:
+ - resources
 homepage: https://open.med.harvard.edu/wiki/display/eaglei/Ontology
 documentation: https://open.med.harvard.edu/wiki/display/eaglei/Ontology
 products:

--- a/ontology/ero.md
+++ b/ontology/ero.md
@@ -8,7 +8,9 @@ license:
   url: https://creativecommons.org/licenses/by/2.0/
   label: CC BY 2.0
 description: An ontology of research resources such as instruments. protocols, reagents, animal models and biospecimens.
-domain: resources
+domain: information
+tags:
+  - resources
 homepage: https://open.med.harvard.edu/wiki/display/eaglei/Ontology
 documentation: https://open.med.harvard.edu/wiki/display/eaglei/Ontology
 products:

--- a/ontology/ero.md
+++ b/ontology/ero.md
@@ -8,9 +8,7 @@ license:
   url: https://creativecommons.org/licenses/by/2.0/
   label: CC BY 2.0
 description: An ontology of research resources such as instruments. protocols, reagents, animal models and biospecimens.
-domain: information
-tags:
- - resources
+domain: resources
 homepage: https://open.med.harvard.edu/wiki/display/eaglei/Ontology
 documentation: https://open.med.harvard.edu/wiki/display/eaglei/Ontology
 products:

--- a/ontology/eupath.md
+++ b/ontology/eupath.md
@@ -10,7 +10,9 @@ license:
   url: http://creativecommons.org/licenses/by/4.0/
   label: CC BY 4.0
 depicted_by: https://raw.githubusercontent.com/EuPathDB/communitysite/master/assets/images/VEuPathDB-logo-s.png
-domain: functional genomics, population biology, clinical epidemiology, and microbiomes
+domain: organisms
+tags:
+ - functional genomics, population biology, clinical epidemiology, and microbiomes
 description: An ontology is developed to support Eukaryotic Pathogen, Host & Vector Genomics Resource (VEuPathDB; https://veupathdb.org).
 homepage: https://github.com/VEuPathDB-ontology/VEuPathDB-ontology
 products:

--- a/ontology/eupath.md
+++ b/ontology/eupath.md
@@ -10,7 +10,9 @@ license:
   url: http://creativecommons.org/licenses/by/4.0/
   label: CC BY 4.0
 depicted_by: https://raw.githubusercontent.com/EuPathDB/communitysite/master/assets/images/VEuPathDB-logo-s.png
-domain: functional genomics, population biology, clinical epidemiology, and microbiomes
+domain: organisms
+tags:
+  - functional genomics, population biology, clinical epidemiology, and microbiomes
 description: An ontology is developed to support Eukaryotic Pathogen, Host & Vector Genomics Resource (VEuPathDB; https://veupathdb.org).
 homepage: https://github.com/VEuPathDB-ontology/VEuPathDB-ontology
 products:

--- a/ontology/eupath.md
+++ b/ontology/eupath.md
@@ -12,7 +12,10 @@ license:
 depicted_by: https://raw.githubusercontent.com/EuPathDB/communitysite/master/assets/images/VEuPathDB-logo-s.png
 domain: organisms
 tags:
-  - functional genomics, population biology, clinical epidemiology, and microbiomes
+  - functional genomics
+  - population biology
+  - clinical epidemiology
+  - microbiomes
 description: An ontology is developed to support Eukaryotic Pathogen, Host & Vector Genomics Resource (VEuPathDB; https://veupathdb.org).
 homepage: https://github.com/VEuPathDB-ontology/VEuPathDB-ontology
 products:

--- a/ontology/eupath.md
+++ b/ontology/eupath.md
@@ -10,9 +10,7 @@ license:
   url: http://creativecommons.org/licenses/by/4.0/
   label: CC BY 4.0
 depicted_by: https://raw.githubusercontent.com/EuPathDB/communitysite/master/assets/images/VEuPathDB-logo-s.png
-domain: organisms
-tags:
- - functional genomics, population biology, clinical epidemiology, and microbiomes
+domain: functional genomics, population biology, clinical epidemiology, and microbiomes
 description: An ontology is developed to support Eukaryotic Pathogen, Host & Vector Genomics Resource (VEuPathDB; https://veupathdb.org).
 homepage: https://github.com/VEuPathDB-ontology/VEuPathDB-ontology
 products:

--- a/ontology/fao.md
+++ b/ontology/fao.md
@@ -10,7 +10,7 @@ license:
   url: http://creativecommons.org/publicdomain/zero/1.0/
   label: CC0 1.0
 description: A structured controlled vocabulary for the anatomy of fungi.
-domain: anatomy and development
+domain: anatomy
 tracker: https://github.com/obophenotype/fungal-anatomy-ontology/issues
 homepage: https://github.com/obophenotype/fungal-anatomy-ontology/
 products:

--- a/ontology/fao.md
+++ b/ontology/fao.md
@@ -10,7 +10,7 @@ license:
   url: http://creativecommons.org/publicdomain/zero/1.0/
   label: CC0 1.0
 description: A structured controlled vocabulary for the anatomy of fungi.
-domain: anatomy
+domain: anatomy and development
 tracker: https://github.com/obophenotype/fungal-anatomy-ontology/issues
 homepage: https://github.com/obophenotype/fungal-anatomy-ontology/
 products:

--- a/ontology/fbbi.md
+++ b/ontology/fbbi.md
@@ -11,9 +11,7 @@ license:
   url: https://creativecommons.org/licenses/by/4.0/
   label: CC BY 4.0
 description: A structured controlled vocabulary of sample preparation, visualization and imaging methods used in biomedical research.
-domain: experiments
-tags:
- - imaging experiments
+domain: imaging experiments
 homepage: http://cellimagelibrary.org/
 tracker: https://github.com/CRBS/Biological_Imaging_Methods_Ontology/issues
 products:

--- a/ontology/fbbi.md
+++ b/ontology/fbbi.md
@@ -11,7 +11,9 @@ license:
   url: https://creativecommons.org/licenses/by/4.0/
   label: CC BY 4.0
 description: A structured controlled vocabulary of sample preparation, visualization and imaging methods used in biomedical research.
-domain: imaging experiments
+domain: experiments
+tags:
+  - imaging experiments
 homepage: http://cellimagelibrary.org/
 tracker: https://github.com/CRBS/Biological_Imaging_Methods_Ontology/issues
 products:

--- a/ontology/fbbi.md
+++ b/ontology/fbbi.md
@@ -11,7 +11,7 @@ license:
   url: https://creativecommons.org/licenses/by/4.0/
   label: CC BY 4.0
 description: A structured controlled vocabulary of sample preparation, visualization and imaging methods used in biomedical research.
-domain: experiments
+domain: investigations
 tags:
   - imaging experiments
 homepage: http://cellimagelibrary.org/

--- a/ontology/fbbi.md
+++ b/ontology/fbbi.md
@@ -11,7 +11,9 @@ license:
   url: https://creativecommons.org/licenses/by/4.0/
   label: CC BY 4.0
 description: A structured controlled vocabulary of sample preparation, visualization and imaging methods used in biomedical research.
-domain: imaging experiments
+domain: experiments
+tags:
+ - imaging experiments
 homepage: http://cellimagelibrary.org/
 tracker: https://github.com/CRBS/Biological_Imaging_Methods_Ontology/issues
 products:

--- a/ontology/fbbt.md
+++ b/ontology/fbbt.md
@@ -8,9 +8,7 @@ contact:
   github: Clare72
   orcid: 0000-0002-1373-1705
 description: An ontology representing the gross anatomy of Drosophila melanogaster.
-domain: anatomy and development
-tags:
- - Drosophilid anatomy
+domain: Drosophilid anatomy
 homepage: http://purl.obolibrary.org/obo/fbbt
 repository: https://github.com/FlyBase/drosophila-anatomy-developmental-ontology
 products:

--- a/ontology/fbbt.md
+++ b/ontology/fbbt.md
@@ -8,7 +8,9 @@ contact:
   github: Clare72
   orcid: 0000-0002-1373-1705
 description: An ontology representing the gross anatomy of Drosophila melanogaster.
-domain: Drosophilid anatomy
+domain: anatomy and development
+tags:
+ - Drosophilid anatomy
 homepage: http://purl.obolibrary.org/obo/fbbt
 repository: https://github.com/FlyBase/drosophila-anatomy-developmental-ontology
 products:

--- a/ontology/fbbt.md
+++ b/ontology/fbbt.md
@@ -8,7 +8,9 @@ contact:
   github: Clare72
   orcid: 0000-0002-1373-1705
 description: An ontology representing the gross anatomy of Drosophila melanogaster.
-domain: Drosophilid anatomy
+domain: anatomy and development
+tags:
+  - Drosophilid anatomy
 homepage: http://purl.obolibrary.org/obo/fbbt
 repository: https://github.com/FlyBase/drosophila-anatomy-developmental-ontology
 products:

--- a/ontology/fbdv.md
+++ b/ontology/fbdv.md
@@ -8,7 +8,7 @@ contact:
   github: Clare72
   orcid: 0000-0002-1373-1705
 description: A structured controlled vocabulary of the development of Drosophila melanogaster.
-domain: anatomy and development
+domain: development
 homepage: http://purl.obolibrary.org/obo/fbdv
 repository: https://github.com/FlyBase/drosophila-developmental-ontology
 products:

--- a/ontology/fbdv.md
+++ b/ontology/fbdv.md
@@ -8,7 +8,7 @@ contact:
   github: Clare72
   orcid: 0000-0002-1373-1705
 description: A structured controlled vocabulary of the development of Drosophila melanogaster.
-domain: development
+domain: anatomy and development
 homepage: http://purl.obolibrary.org/obo/fbdv
 repository: https://github.com/FlyBase/drosophila-developmental-ontology
 products:

--- a/ontology/fbsp.md
+++ b/ontology/fbsp.md
@@ -7,7 +7,9 @@ contact:
   github: Clare72
   orcid: 0000-0002-1373-1705
 description: The taxonomy of the family <i>Drosophilidae</i> (largely after Baechli) and of other taxa referred to in FlyBase.
-domain: taxonomy
+domain: organisms
+tags:
+ - taxonomy
 homepage: http://www.flybase.org/
 products:
   - id: fbsp.owl

--- a/ontology/fbsp.md
+++ b/ontology/fbsp.md
@@ -7,9 +7,7 @@ contact:
   github: Clare72
   orcid: 0000-0002-1373-1705
 description: The taxonomy of the family <i>Drosophilidae</i> (largely after Baechli) and of other taxa referred to in FlyBase.
-domain: organisms
-tags:
- - taxonomy
+domain: taxonomy
 homepage: http://www.flybase.org/
 products:
   - id: fbsp.owl

--- a/ontology/fbsp.md
+++ b/ontology/fbsp.md
@@ -7,7 +7,9 @@ contact:
   github: Clare72
   orcid: 0000-0002-1373-1705
 description: The taxonomy of the family <i>Drosophilidae</i> (largely after Baechli) and of other taxa referred to in FlyBase.
-domain: taxonomy
+domain: organisms
+tags:
+  - taxonomy
 homepage: http://www.flybase.org/
 products:
   - id: fbsp.owl

--- a/ontology/fideo.md
+++ b/ontology/fideo.md
@@ -3,7 +3,7 @@ layout: ontology_detail
 id: fideo
 title: Food Interactions with Drugs Evidence Ontology
 description: Food-Drug interactions automatically extracted from scientific literature
-domain: diet, metabolomics and nutrition
+domain: diet, metabolomics, and nutrition
 homepage: https://gitub.u-bordeaux.fr/erias/fideo
 contact:
   email: georgeta.bordea@u-bordeaux.fr

--- a/ontology/fma.md
+++ b/ontology/fma.md
@@ -8,7 +8,7 @@ license:
   url: https://creativecommons.org/licenses/by/3.0/
   label: CC BY 3.0
 description: This is currently a slimmed down version of FMA
-domain: anatomy and development
+domain: anatomy
 homepage: http://si.washington.edu/projects/fma
 page: http://en.wikipedia.org/wiki/Foundational_Model_of_Anatomy
 publications:

--- a/ontology/fma.md
+++ b/ontology/fma.md
@@ -8,7 +8,7 @@ license:
   url: https://creativecommons.org/licenses/by/3.0/
   label: CC BY 3.0
 description: This is currently a slimmed down version of FMA
-domain: anatomy
+domain: anatomy and development
 homepage: http://si.washington.edu/projects/fma
 page: http://en.wikipedia.org/wiki/Foundational_Model_of_Anatomy
 publications:

--- a/ontology/fobi.md
+++ b/ontology/fobi.md
@@ -7,7 +7,7 @@ contact:
   github: pcastellanoescuder
   orcid: 0000-0001-6466-877X
 description: FOBI (Food-Biomarker Ontology) is an ontology to represent food intake data and associate it with metabolomic data
-domain: diet, metabolomics and nutrition
+domain: metabolomics and nutrition
 license:
   url: http://creativecommons.org/licenses/by/3.0/
   label: CC BY 3.0

--- a/ontology/fobi.md
+++ b/ontology/fobi.md
@@ -7,7 +7,7 @@ contact:
   github: pcastellanoescuder
   orcid: 0000-0001-6466-877X
 description: FOBI (Food-Biomarker Ontology) is an ontology to represent food intake data and associate it with metabolomic data
-domain: diet, metabolomics and nutrition
+domain: diet, metabolomics, and nutrition
 license:
   url: http://creativecommons.org/licenses/by/3.0/
   label: CC BY 3.0

--- a/ontology/fobi.md
+++ b/ontology/fobi.md
@@ -7,7 +7,7 @@ contact:
   github: pcastellanoescuder
   orcid: 0000-0001-6466-877X
 description: FOBI (Food-Biomarker Ontology) is an ontology to represent food intake data and associate it with metabolomic data
-domain: metabolomics and nutrition
+domain: diet, metabolomics and nutrition
 license:
   url: http://creativecommons.org/licenses/by/3.0/
   label: CC BY 3.0

--- a/ontology/foodon.md
+++ b/ontology/foodon.md
@@ -7,7 +7,9 @@ contact:
   github: ddooley
   orcid: 0000-0002-8844-9165
 description: A broadly scoped ontology representing entities which bear a “food role”. It encompasses materials in natural ecosystems and agriculture that are consumed by humans and domesticated animals. This includes any generic (unbranded) raw or processed food material found in processing plants, markets, stores or food distribution points. FoodOn also imports nutritional component and dietary pattern terms from other OBO Foundry ontologies to support interoperability in diet and nutrition research
-domain: food
+domain: diet, metabolomics and nutrition
+tags:
+  - food
 homepage: https://foodon.org/
 license:
   url: http://creativecommons.org/licenses/by/3.0/

--- a/ontology/foodon.md
+++ b/ontology/foodon.md
@@ -7,7 +7,7 @@ contact:
   github: ddooley
   orcid: 0000-0002-8844-9165
 description: A broadly scoped ontology representing entities which bear a “food role”. It encompasses materials in natural ecosystems and agriculture that are consumed by humans and domesticated animals. This includes any generic (unbranded) raw or processed food material found in processing plants, markets, stores or food distribution points. FoodOn also imports nutritional component and dietary pattern terms from other OBO Foundry ontologies to support interoperability in diet and nutrition research
-domain: diet, metabolomics and nutrition
+domain: diet, metabolomics, and nutrition
 tags:
   - food
 homepage: https://foodon.org/

--- a/ontology/foodon.md
+++ b/ontology/foodon.md
@@ -7,9 +7,7 @@ contact:
   github: ddooley
   orcid: 0000-0002-8844-9165
 description: A broadly scoped ontology representing entities which bear a “food role”. It encompasses materials in natural ecosystems and agriculture that are consumed by humans and domesticated animals. This includes any generic (unbranded) raw or processed food material found in processing plants, markets, stores or food distribution points. FoodOn also imports nutritional component and dietary pattern terms from other OBO Foundry ontologies to support interoperability in diet and nutrition research
-domain: diet, metabolomics and nutrition
-tags:
- - food
+domain: food
 homepage: https://foodon.org/
 license:
   url: http://creativecommons.org/licenses/by/3.0/

--- a/ontology/foodon.md
+++ b/ontology/foodon.md
@@ -7,7 +7,9 @@ contact:
   github: ddooley
   orcid: 0000-0002-8844-9165
 description: A broadly scoped ontology representing entities which bear a “food role”. It encompasses materials in natural ecosystems and agriculture that are consumed by humans and domesticated animals. This includes any generic (unbranded) raw or processed food material found in processing plants, markets, stores or food distribution points. FoodOn also imports nutritional component and dietary pattern terms from other OBO Foundry ontologies to support interoperability in diet and nutrition research
-domain: food
+domain: diet, metabolomics and nutrition
+tags:
+ - food
 homepage: https://foodon.org/
 license:
   url: http://creativecommons.org/licenses/by/3.0/

--- a/ontology/fovt.md
+++ b/ontology/fovt.md
@@ -15,9 +15,7 @@ contact:
   github: megbalk
   orcid: 0000-0003-2699-3066
 description: FuTRES Ontology of Vertebrate Traits is an application ontology used to convert vertebrate trait data in spreadsheet to triples. FOVT leverages the BioCollections Ontology (BCO) to link observations of individual specimens to their trait values. Traits are defined in the Ontology of Biological Attributes (OBA).
-domain: phenotype
-tags:
- - vertebrate traits
+domain: vertebrate traits
 homepage: https://github.com/futres/fovt
 products:
   - id: fovt.owl

--- a/ontology/fovt.md
+++ b/ontology/fovt.md
@@ -15,7 +15,9 @@ contact:
   github: megbalk
   orcid: 0000-0003-2699-3066
 description: FuTRES Ontology of Vertebrate Traits is an application ontology used to convert vertebrate trait data in spreadsheet to triples. FOVT leverages the BioCollections Ontology (BCO) to link observations of individual specimens to their trait values. Traits are defined in the Ontology of Biological Attributes (OBA).
-domain: vertebrate traits
+domain: phenotype
+tags:
+ - vertebrate traits
 homepage: https://github.com/futres/fovt
 products:
   - id: fovt.owl

--- a/ontology/fovt.md
+++ b/ontology/fovt.md
@@ -15,7 +15,9 @@ contact:
   github: megbalk
   orcid: 0000-0003-2699-3066
 description: FuTRES Ontology of Vertebrate Traits is an application ontology used to convert vertebrate trait data in spreadsheet to triples. FOVT leverages the BioCollections Ontology (BCO) to link observations of individual specimens to their trait values. Traits are defined in the Ontology of Biological Attributes (OBA).
-domain: vertebrate traits
+domain: phenotype
+tags:
+  - vertebrate traits
 homepage: https://github.com/futres/fovt
 products:
   - id: fovt.owl

--- a/ontology/gecko.md
+++ b/ontology/gecko.md
@@ -3,7 +3,9 @@ layout: ontology_detail
 id: gecko
 title: Genomics Cohorts Knowledge Ontology
 description: An ontology to represent genomics cohort attributes
-domain: cohort studies
+domain: organisms
+tags:
+ - cohort studies
 homepage: https://github.com/IHCC-cohorts/GECKO
 contact:
   email: rbca.jackson@gmail.com

--- a/ontology/gecko.md
+++ b/ontology/gecko.md
@@ -3,7 +3,9 @@ layout: ontology_detail
 id: gecko
 title: Genomics Cohorts Knowledge Ontology
 description: An ontology to represent genomics cohort attributes
-domain: cohort studies
+domain: organisms
+tags:
+  - cohort studies
 homepage: https://github.com/IHCC-cohorts/GECKO
 contact:
   email: rbca.jackson@gmail.com

--- a/ontology/gecko.md
+++ b/ontology/gecko.md
@@ -3,9 +3,7 @@ layout: ontology_detail
 id: gecko
 title: Genomics Cohorts Knowledge Ontology
 description: An ontology to represent genomics cohort attributes
-domain: organisms
-tags:
- - cohort studies
+domain: cohort studies
 homepage: https://github.com/IHCC-cohorts/GECKO
 contact:
   email: rbca.jackson@gmail.com

--- a/ontology/geno.md
+++ b/ontology/geno.md
@@ -3,7 +3,9 @@ layout: ontology_detail
 id: geno
 title: Genotype Ontology
 description: An integrated ontology for representing the genetic variations described in genotypes, and their causal relationships to phenotype and diseases.
-domain: genotype-to-phenotype associations
+domain: biological systems
+tags:
+  - genotype-to-phenotype associations
 homepage: https://github.com/monarch-initiative/GENO-ontology/
 tracker: https://github.com/monarch-initiative/GENO-ontology/issues
 contact:

--- a/ontology/geno.md
+++ b/ontology/geno.md
@@ -3,9 +3,7 @@ layout: ontology_detail
 id: geno
 title: Genotype Ontology
 description: An integrated ontology for representing the genetic variations described in genotypes, and their causal relationships to phenotype and diseases.
-domain: biological systems
-tags:
- - genotype-to-phenotype associations
+domain: genotype-to-phenotype associations
 homepage: https://github.com/monarch-initiative/GENO-ontology/
 tracker: https://github.com/monarch-initiative/GENO-ontology/issues
 contact:

--- a/ontology/geno.md
+++ b/ontology/geno.md
@@ -3,7 +3,9 @@ layout: ontology_detail
 id: geno
 title: Genotype Ontology
 description: An integrated ontology for representing the genetic variations described in genotypes, and their causal relationships to phenotype and diseases.
-domain: genotype-to-phenotype associations
+domain: biological systems
+tags:
+ - genotype-to-phenotype associations
 homepage: https://github.com/monarch-initiative/GENO-ontology/
 tracker: https://github.com/monarch-initiative/GENO-ontology/issues
 contact:

--- a/ontology/gno.md
+++ b/ontology/gno.md
@@ -7,7 +7,9 @@ contact:
   github: edwardsnj
   orcid: 0000-0001-5168-3196
 description: GlyTouCan provides stable accessions for glycans described at varyious degrees of characterization, including compositions (no linkage) and topologies (no carbon bond positions or anomeric configurations). GNOme organizes these stable accessions for interative browsing, for text-based searching, and for automated reasoning with well-defined characterization levels.
-domain: glycan structure
+domain: biochemistry
+tags:
+  - glycan structure
 homepage: https://gnome.glyomics.org/
 products:
   - id: gno.owl

--- a/ontology/gno.md
+++ b/ontology/gno.md
@@ -7,9 +7,7 @@ contact:
   github: edwardsnj
   orcid: 0000-0001-5168-3196
 description: GlyTouCan provides stable accessions for glycans described at varyious degrees of characterization, including compositions (no linkage) and topologies (no carbon bond positions or anomeric configurations). GNOme organizes these stable accessions for interative browsing, for text-based searching, and for automated reasoning with well-defined characterization levels.
-domain: biochemistry
-tags:
- - glycan structure
+domain: glycan structure
 homepage: https://gnome.glyomics.org/
 products:
   - id: gno.owl

--- a/ontology/gno.md
+++ b/ontology/gno.md
@@ -7,7 +7,9 @@ contact:
   github: edwardsnj
   orcid: 0000-0001-5168-3196
 description: GlyTouCan provides stable accessions for glycans described at varyious degrees of characterization, including compositions (no linkage) and topologies (no carbon bond positions or anomeric configurations). GNOme organizes these stable accessions for interative browsing, for text-based searching, and for automated reasoning with well-defined characterization levels.
-domain: glycan structure
+domain: biochemistry
+tags:
+ - glycan structure
 homepage: https://gnome.glyomics.org/
 products:
   - id: gno.owl

--- a/ontology/go.md
+++ b/ontology/go.md
@@ -21,9 +21,7 @@ tracker: https://github.com/geneontology/go-ontology/issues/
 taxon:
   id: NCBITaxon:1
   label: All life
-domain: biological systems
-tags:
- - biology
+domain: biology
 integration_server: http://build.berkeleybop.org/view/GO
 dependencies:
   - id: uberon

--- a/ontology/go.md
+++ b/ontology/go.md
@@ -21,7 +21,9 @@ tracker: https://github.com/geneontology/go-ontology/issues/
 taxon:
   id: NCBITaxon:1
   label: All life
-domain: biology
+domain: biological systems
+tags:
+  - biology
 integration_server: http://build.berkeleybop.org/view/GO
 dependencies:
   - id: uberon

--- a/ontology/go.md
+++ b/ontology/go.md
@@ -21,7 +21,9 @@ tracker: https://github.com/geneontology/go-ontology/issues/
 taxon:
   id: NCBITaxon:1
   label: All life
-domain: biology
+domain: biological systems
+tags:
+ - biology
 integration_server: http://build.berkeleybop.org/view/GO
 dependencies:
   - id: uberon

--- a/ontology/hancestro.md
+++ b/ontology/hancestro.md
@@ -10,7 +10,9 @@ title: Human Ancestry Ontology
 description: The Human Ancestry Ontology (HANCESTRO) provides a systematic description of the ancestry concepts used in the NHGRI-EBI Catalog of published genome-wide association studies.
 homepage: https://github.com/EBISPOT/ancestro
 tracker: https://github.com/EBISPOT/ancestro/issues
-domain: ancestry
+domain: organisms
+tags:
+  - ancestry
 products:
   - id: hancestro.owl
     description: The full version of HANCESTRO in OWL format

--- a/ontology/hancestro.md
+++ b/ontology/hancestro.md
@@ -10,9 +10,7 @@ title: Human Ancestry Ontology
 description: The Human Ancestry Ontology (HANCESTRO) provides a systematic description of the ancestry concepts used in the NHGRI-EBI Catalog of published genome-wide association studies.
 homepage: https://github.com/EBISPOT/ancestro
 tracker: https://github.com/EBISPOT/ancestro/issues
-domain: organisms
-tags:
- - ancestry
+domain: ancestry
 products:
   - id: hancestro.owl
     description: The full version of HANCESTRO in OWL format

--- a/ontology/hancestro.md
+++ b/ontology/hancestro.md
@@ -10,7 +10,9 @@ title: Human Ancestry Ontology
 description: The Human Ancestry Ontology (HANCESTRO) provides a systematic description of the ancestry concepts used in the NHGRI-EBI Catalog of published genome-wide association studies.
 homepage: https://github.com/EBISPOT/ancestro
 tracker: https://github.com/EBISPOT/ancestro/issues
-domain: ancestry
+domain: organisms
+tags:
+ - ancestry
 products:
   - id: hancestro.owl
     description: The full version of HANCESTRO in OWL format

--- a/ontology/hao.md
+++ b/ontology/hao.md
@@ -11,7 +11,7 @@ license:
   url: https://creativecommons.org/publicdomain/zero/1.0/
   label: CC0 1.0
 description: A structured controlled vocabulary of the anatomy of the Hymenoptera (bees, wasps, and ants)
-domain: anatomy and development
+domain: anatomy
 homepage: http://hymao.org
 products:
   - id: hao.owl

--- a/ontology/hao.md
+++ b/ontology/hao.md
@@ -11,7 +11,7 @@ license:
   url: https://creativecommons.org/publicdomain/zero/1.0/
   label: CC0 1.0
 description: A structured controlled vocabulary of the anatomy of the Hymenoptera (bees, wasps, and ants)
-domain: anatomy
+domain: anatomy and development
 homepage: http://hymao.org
 products:
   - id: hao.owl

--- a/ontology/ico.md
+++ b/ontology/ico.md
@@ -3,7 +3,9 @@ layout: ontology_detail
 id: ico
 title: Informed Consent Ontology
 description: An ontology of clinical informed consents
-domain: informed consent
+domain: experiments
+tags:
+ - informed consent
 license:
   url: http://creativecommons.org/licenses/by/3.0/
   label: CC BY 3.0

--- a/ontology/ico.md
+++ b/ontology/ico.md
@@ -3,9 +3,7 @@ layout: ontology_detail
 id: ico
 title: Informed Consent Ontology
 description: An ontology of clinical informed consents
-domain: experiments
-tags:
- - informed consent
+domain: informed consent
 license:
   url: http://creativecommons.org/licenses/by/3.0/
   label: CC BY 3.0

--- a/ontology/ico.md
+++ b/ontology/ico.md
@@ -3,7 +3,7 @@ layout: ontology_detail
 id: ico
 title: Informed Consent Ontology
 description: An ontology of clinical informed consents
-domain: experiments
+domain: investigations
 tags:
   - informed consent
 license:

--- a/ontology/ico.md
+++ b/ontology/ico.md
@@ -3,7 +3,9 @@ layout: ontology_detail
 id: ico
 title: Informed Consent Ontology
 description: An ontology of clinical informed consents
-domain: informed consent
+domain: experiments
+tags:
+  - informed consent
 license:
   url: http://creativecommons.org/licenses/by/3.0/
   label: CC BY 3.0

--- a/ontology/kisao.md
+++ b/ontology/kisao.md
@@ -7,7 +7,9 @@ contact:
   github: jonrkarr
   orcid: 0000-0002-2605-5080
 description: A classification of algorithms for simulating biology and their outputs
-domain: algorithms
+domain: information technology
+tags:
+ - algorithms
 homepage: http://co.mbine.org/standards/kisao
 tracker: https://github.com/SED-ML/KiSAO/issues
 products:

--- a/ontology/kisao.md
+++ b/ontology/kisao.md
@@ -7,7 +7,9 @@ contact:
   github: jonrkarr
   orcid: 0000-0002-2605-5080
 description: A classification of algorithms for simulating biology and their outputs
-domain: algorithms
+domain: information technology
+tags:
+  - algorithms
 homepage: http://co.mbine.org/standards/kisao
 tracker: https://github.com/SED-ML/KiSAO/issues
 products:

--- a/ontology/kisao.md
+++ b/ontology/kisao.md
@@ -7,9 +7,7 @@ contact:
   github: jonrkarr
   orcid: 0000-0002-2605-5080
 description: A classification of algorithms for simulating biology and their outputs
-domain: information technology
-tags:
- - algorithms
+domain: algorithms
 homepage: http://co.mbine.org/standards/kisao
 tracker: https://github.com/SED-ML/KiSAO/issues
 products:

--- a/ontology/labo.md
+++ b/ontology/labo.md
@@ -8,7 +8,9 @@ contact:
   github: pfabry
   orcid: 0000-0002-3336-2476
 description: LABO is an ontology of informational entities formalizing clinical laboratory tests prescriptions and reporting documents.
-domain: clinical documentation
+domain: information
+tags:
+  - clinical documentation
 usages:
   - user: https://griis.ca/
     type: database architecture

--- a/ontology/labo.md
+++ b/ontology/labo.md
@@ -8,9 +8,7 @@ contact:
   github: pfabry
   orcid: 0000-0002-3336-2476
 description: LABO is an ontology of informational entities formalizing clinical laboratory tests prescriptions and reporting documents.
-domain: information
-tags:
- - clinical documentation
+domain: clinical documentation
 usages:
   - user: https://griis.ca/
     type: database architecture

--- a/ontology/labo.md
+++ b/ontology/labo.md
@@ -8,7 +8,9 @@ contact:
   github: pfabry
   orcid: 0000-0002-3336-2476
 description: LABO is an ontology of informational entities formalizing clinical laboratory tests prescriptions and reporting documents.
-domain: clinical documentation
+domain: information
+tags:
+ - clinical documentation
 usages:
   - user: https://griis.ca/
     type: database architecture

--- a/ontology/lepao.md
+++ b/ontology/lepao.md
@@ -8,9 +8,7 @@ contact:
   github: luis-gonzalez-m
   orcid: 0000-0002-9136-9932
 description: The Lepidoptera Anatomy Ontology contains terms used for describing the anatomy and phenotype of moths and butterflies in biodiversity research. LEPAO is developed in part by BIOfid (The Specialised Information Service Biodiversity Research).
-domain: anatomy and development
-tags:
- - Insect Anatomy
+domain: Insect Anatomy
 homepage: https://github.com/insect-morphology/lepao
 products:
   - id: lepao.owl

--- a/ontology/lepao.md
+++ b/ontology/lepao.md
@@ -8,7 +8,9 @@ contact:
   github: luis-gonzalez-m
   orcid: 0000-0002-9136-9932
 description: The Lepidoptera Anatomy Ontology contains terms used for describing the anatomy and phenotype of moths and butterflies in biodiversity research. LEPAO is developed in part by BIOfid (The Specialised Information Service Biodiversity Research).
-domain: Insect Anatomy
+domain: anatomy and development
+tags:
+  - Insect Anatomy
 homepage: https://github.com/insect-morphology/lepao
 products:
   - id: lepao.owl

--- a/ontology/lepao.md
+++ b/ontology/lepao.md
@@ -8,7 +8,9 @@ contact:
   github: luis-gonzalez-m
   orcid: 0000-0002-9136-9932
 description: The Lepidoptera Anatomy Ontology contains terms used for describing the anatomy and phenotype of moths and butterflies in biodiversity research. LEPAO is developed in part by BIOfid (The Specialised Information Service Biodiversity Research).
-domain: Insect Anatomy
+domain: anatomy and development
+tags:
+ - Insect Anatomy
 homepage: https://github.com/insect-morphology/lepao
 products:
   - id: lepao.owl

--- a/ontology/lepao.md
+++ b/ontology/lepao.md
@@ -10,7 +10,7 @@ contact:
 description: The Lepidoptera Anatomy Ontology contains terms used for describing the anatomy and phenotype of moths and butterflies in biodiversity research. LEPAO is developed in part by BIOfid (The Specialised Information Service Biodiversity Research).
 domain: anatomy and development
 tags:
-  - Insect Anatomy
+  - insect anatomy
 homepage: https://github.com/insect-morphology/lepao
 products:
   - id: lepao.owl

--- a/ontology/lipro.md
+++ b/ontology/lipro.md
@@ -6,7 +6,9 @@ contact:
   email: bakerc@unb.ca
   label: Christipher Baker
 description: An ontology representation of the LIPIDMAPS nomenclature classification.
-domain: lipids
+domain: biochemistry
+tags:
+  - lipids
 title: Lipid Ontology
 build:
   source_url: http://www.lipidprofiles.com/LipidOntology

--- a/ontology/lipro.md
+++ b/ontology/lipro.md
@@ -6,7 +6,9 @@ contact:
   email: bakerc@unb.ca
   label: Christipher Baker
 description: An ontology representation of the LIPIDMAPS nomenclature classification.
-domain: lipids
+domain: biochemistry
+tags:
+ - lipids
 title: Lipid Ontology
 build:
   source_url: http://www.lipidprofiles.com/LipidOntology

--- a/ontology/lipro.md
+++ b/ontology/lipro.md
@@ -6,9 +6,7 @@ contact:
   email: bakerc@unb.ca
   label: Christipher Baker
 description: An ontology representation of the LIPIDMAPS nomenclature classification.
-domain: biochemistry
-tags:
- - lipids
+domain: lipids
 title: Lipid Ontology
 build:
   source_url: http://www.lipidprofiles.com/LipidOntology

--- a/ontology/ma.md
+++ b/ontology/ma.md
@@ -10,7 +10,7 @@ license:
   url: https://creativecommons.org/licenses/by/4.0/
   label: CC BY 4.0
 description: A structured controlled vocabulary of the adult anatomy of the mouse (Mus).
-domain: anatomy and development
+domain: anatomy
 homepage: https://github.com/obophenotype/mouse-anatomy-ontology
 page: http://www.informatics.jax.org/searches/AMA_form.shtml
 products:

--- a/ontology/ma.md
+++ b/ontology/ma.md
@@ -10,7 +10,7 @@ license:
   url: https://creativecommons.org/licenses/by/4.0/
   label: CC BY 4.0
 description: A structured controlled vocabulary of the adult anatomy of the mouse (Mus).
-domain: anatomy
+domain: anatomy and development
 homepage: https://github.com/obophenotype/mouse-anatomy-ontology
 page: http://www.informatics.jax.org/searches/AMA_form.shtml
 products:

--- a/ontology/maxo.md
+++ b/ontology/maxo.md
@@ -15,7 +15,9 @@ contact:
   github: LCCarmody
   orcid: 0000-0001-7941-2961
 description: Medical Action Ontology is an ontology...
-domain: medical
+domain: health
+tags:
+ - medical
 homepage: https://github.com/monarch-initiative/MAxO
 products:
   - id: maxo.owl

--- a/ontology/maxo.md
+++ b/ontology/maxo.md
@@ -15,7 +15,9 @@ contact:
   github: LCCarmody
   orcid: 0000-0001-7941-2961
 description: Medical Action Ontology is an ontology...
-domain: medical
+domain: health
+tags:
+  - medical
 homepage: https://github.com/monarch-initiative/MAxO
 products:
   - id: maxo.owl

--- a/ontology/maxo.md
+++ b/ontology/maxo.md
@@ -15,9 +15,7 @@ contact:
   github: LCCarmody
   orcid: 0000-0001-7941-2961
 description: Medical Action Ontology is an ontology...
-domain: health
-tags:
- - medical
+domain: medical
 homepage: https://github.com/monarch-initiative/MAxO
 products:
   - id: maxo.owl

--- a/ontology/mco.md
+++ b/ontology/mco.md
@@ -15,7 +15,7 @@ contact:
   github: citmejia
   orcid: 0000-0002-0142-5591
 description: Microbial Conditions Ontology is an ontology...
-domain: experiments
+domain: investigations
 tags:
   - experimental conditions
 homepage: https://github.com/microbial-conditions-ontology/microbial-conditions-ontology

--- a/ontology/mco.md
+++ b/ontology/mco.md
@@ -15,7 +15,9 @@ contact:
   github: citmejia
   orcid: 0000-0002-0142-5591
 description: Microbial Conditions Ontology is an ontology...
-domain: experimental conditions
+domain: experiments
+tags:
+ - experimental conditions
 homepage: https://github.com/microbial-conditions-ontology/microbial-conditions-ontology
 products:
   - id: mco.owl

--- a/ontology/mco.md
+++ b/ontology/mco.md
@@ -15,9 +15,7 @@ contact:
   github: citmejia
   orcid: 0000-0002-0142-5591
 description: Microbial Conditions Ontology is an ontology...
-domain: experiments
-tags:
- - experimental conditions
+domain: experimental conditions
 homepage: https://github.com/microbial-conditions-ontology/microbial-conditions-ontology
 products:
   - id: mco.owl

--- a/ontology/mco.md
+++ b/ontology/mco.md
@@ -15,7 +15,9 @@ contact:
   github: citmejia
   orcid: 0000-0002-0142-5591
 description: Microbial Conditions Ontology is an ontology...
-domain: experimental conditions
+domain: experiments
+tags:
+  - experimental conditions
 homepage: https://github.com/microbial-conditions-ontology/microbial-conditions-ontology
 products:
   - id: mco.owl

--- a/ontology/mfmo.md
+++ b/ontology/mfmo.md
@@ -10,7 +10,7 @@ license:
 taxon:
   id: NCBITaxon:40674
   label: Mammalian
-domain: anatomy
+domain: anatomy and development
 repository: https://github.com/RDruzinsky/feedontology
 tracker: https://github.com/RDruzinsky/feedontology/issues
 contact:

--- a/ontology/mfmo.md
+++ b/ontology/mfmo.md
@@ -10,7 +10,7 @@ license:
 taxon:
   id: NCBITaxon:40674
   label: Mammalian
-domain: anatomy and development
+domain: anatomy
 repository: https://github.com/RDruzinsky/feedontology
 tracker: https://github.com/RDruzinsky/feedontology/issues
 contact:

--- a/ontology/mfo.md
+++ b/ontology/mfo.md
@@ -5,7 +5,7 @@ contact:
   email: Thorsten.Henrich@embl-heidelberg.de
   label: Thorsten Henrich
 description: A structured controlled vocabulary of the anatomy and development of the Japanese medaka fish, <i>Oryzias latipes</i>.
-domain: anatomy and development
+domain: anatomy
 products:
   - id: mfo.owl
 taxon:

--- a/ontology/mfo.md
+++ b/ontology/mfo.md
@@ -5,7 +5,7 @@ contact:
   email: Thorsten.Henrich@embl-heidelberg.de
   label: Thorsten Henrich
 description: A structured controlled vocabulary of the anatomy and development of the Japanese medaka fish, <i>Oryzias latipes</i>.
-domain: anatomy
+domain: anatomy and development
 products:
   - id: mfo.owl
 taxon:

--- a/ontology/mi.md
+++ b/ontology/mi.md
@@ -11,7 +11,7 @@ license:
   url: https://creativecommons.org/licenses/by/4.0/
   label: CC BY 4.0
 description: A structured controlled vocabulary for the annotation of experiments concerned with protein-protein interactions.
-domain: experiments
+domain: investigations
 homepage: https://github.com/HUPO-PSI/psi-mi-CV
 page: https://github.com/HUPO-PSI/psi-mi-CV
 products:

--- a/ontology/mmo.md
+++ b/ontology/mmo.md
@@ -10,7 +10,9 @@ license:
   url: https://creativecommons.org/publicdomain/zero/1.0/
   label: CC0 1.0
 description: "A representation of the variety of methods used to make clinical and phenotype measurements. "
-domain: clinical
+domain: health
+tags:
+  - clinical
 homepage: https://rgd.mcw.edu/rgdweb/ontology/view.html?acc_id=MMO:0000000
 tracker: https://github.com/rat-genome-database/MMO-Measurement-Method-Ontology/issues
 page: https://download.rgd.mcw.edu/ontology/measurement_method/

--- a/ontology/mmo.md
+++ b/ontology/mmo.md
@@ -10,7 +10,9 @@ license:
   url: https://creativecommons.org/publicdomain/zero/1.0/
   label: CC0 1.0
 description: "A representation of the variety of methods used to make clinical and phenotype measurements. "
-domain: clinical
+domain: health
+tags:
+ - clinical
 homepage: https://rgd.mcw.edu/rgdweb/ontology/view.html?acc_id=MMO:0000000
 tracker: https://github.com/rat-genome-database/MMO-Measurement-Method-Ontology/issues
 page: https://download.rgd.mcw.edu/ontology/measurement_method/

--- a/ontology/mmo.md
+++ b/ontology/mmo.md
@@ -10,9 +10,7 @@ license:
   url: https://creativecommons.org/publicdomain/zero/1.0/
   label: CC0 1.0
 description: "A representation of the variety of methods used to make clinical and phenotype measurements. "
-domain: health
-tags:
- - clinical
+domain: clinical
 homepage: https://rgd.mcw.edu/rgdweb/ontology/view.html?acc_id=MMO:0000000
 tracker: https://github.com/rat-genome-database/MMO-Measurement-Method-Ontology/issues
 page: https://download.rgd.mcw.edu/ontology/measurement_method/

--- a/ontology/mo.md
+++ b/ontology/mo.md
@@ -6,7 +6,7 @@ contact:
   email: stoeckrt@pcbi.upenn.edu
   label: Chris Stoeckert
 description: A standardized description of a microarray experiment in support of MAGE v.1.
-domain: experiments
+domain: investigations
 homepage: http://mged.sourceforge.net/ontologies/MGEDontology.php
 page: http://mged.sourceforge.net/software/downloads.php
 products:

--- a/ontology/mod.md
+++ b/ontology/mod.md
@@ -13,7 +13,9 @@ publications:
   - id: https://pubmed.ncbi.nlm.nih.gov/18688235/
     title: "The PSI-MOD community standard for representation of protein modification data"
 description: PSI-MOD is an ontology consisting of terms that describe protein chemical modifications
-domain: proteins
+domain: biochemistry
+tags:
+  - proteins
 homepage: http://www.psidev.info/MOD
 tracker: https://github.com/HUPO-PSI/psi-mod-CV/issues
 products:

--- a/ontology/mod.md
+++ b/ontology/mod.md
@@ -13,7 +13,9 @@ publications:
   - id: https://pubmed.ncbi.nlm.nih.gov/18688235/
     title: "The PSI-MOD community standard for representation of protein modification data"
 description: PSI-MOD is an ontology consisting of terms that describe protein chemical modifications
-domain: proteins
+domain: biochemistry
+tags:
+ - proteins
 homepage: http://www.psidev.info/MOD
 tracker: https://github.com/HUPO-PSI/psi-mod-CV/issues
 products:

--- a/ontology/mod.md
+++ b/ontology/mod.md
@@ -13,9 +13,7 @@ publications:
   - id: https://pubmed.ncbi.nlm.nih.gov/18688235/
     title: "The PSI-MOD community standard for representation of protein modification data"
 description: PSI-MOD is an ontology consisting of terms that describe protein chemical modifications
-domain: biochemistry
-tags:
- - proteins
+domain: proteins
 homepage: http://www.psidev.info/MOD
 tracker: https://github.com/HUPO-PSI/psi-mod-CV/issues
 products:

--- a/ontology/mondo.md
+++ b/ontology/mondo.md
@@ -17,7 +17,9 @@ depicted_by: https://raw.githubusercontent.com/monarch-initiative/mondo/master/d
 taxon:
   id: NCBITaxon:33208
   label: Metazoa
-domain: disease
+domain: health
+tags:
+ - disease
 tracker: https://github.com/monarch-initiative/mondo/issues
 mailing_list: https://groups.google.com/group/mondo-users
 canonical: mondo.owl

--- a/ontology/mondo.md
+++ b/ontology/mondo.md
@@ -17,7 +17,9 @@ depicted_by: https://raw.githubusercontent.com/monarch-initiative/mondo/master/d
 taxon:
   id: NCBITaxon:33208
   label: Metazoa
-domain: disease
+domain: health
+tags:
+  - disease
 tracker: https://github.com/monarch-initiative/mondo/issues
 mailing_list: https://groups.google.com/group/mondo-users
 canonical: mondo.owl

--- a/ontology/mondo.md
+++ b/ontology/mondo.md
@@ -17,9 +17,7 @@ depicted_by: https://raw.githubusercontent.com/monarch-initiative/mondo/master/d
 taxon:
   id: NCBITaxon:33208
   label: Metazoa
-domain: health
-tags:
- - disease
+domain: disease
 tracker: https://github.com/monarch-initiative/mondo/issues
 mailing_list: https://groups.google.com/group/mondo-users
 canonical: mondo.owl

--- a/ontology/mro.md
+++ b/ontology/mro.md
@@ -5,7 +5,9 @@ title: MHC Restriction Ontology
 description: An ontology for Major Histocompatibility Complex (MHC) restriction in experiments
 tracker: https://github.com/IEDB/MRO/issues
 homepage: https://github.com/IEDB/MRO
-domain: Major Histocompatibility Complex
+domain: biochemistry
+tags:
+  - Major Histocompatibility Complex
 contact:
   label: Bjoern Peters
   email: bpeters@lji.org

--- a/ontology/mro.md
+++ b/ontology/mro.md
@@ -5,7 +5,9 @@ title: MHC Restriction Ontology
 description: An ontology for Major Histocompatibility Complex (MHC) restriction in experiments
 tracker: https://github.com/IEDB/MRO/issues
 homepage: https://github.com/IEDB/MRO
-domain: Major Histocompatibility Complex
+domain: biochemistry
+tags:
+ - Major Histocompatibility Complex
 contact:
   label: Bjoern Peters
   email: bpeters@lji.org

--- a/ontology/mro.md
+++ b/ontology/mro.md
@@ -5,9 +5,7 @@ title: MHC Restriction Ontology
 description: An ontology for Major Histocompatibility Complex (MHC) restriction in experiments
 tracker: https://github.com/IEDB/MRO/issues
 homepage: https://github.com/IEDB/MRO
-domain: biochemistry
-tags:
- - Major Histocompatibility Complex
+domain: Major Histocompatibility Complex
 contact:
   label: Bjoern Peters
   email: bpeters@lji.org

--- a/ontology/ms.md
+++ b/ontology/ms.md
@@ -10,7 +10,9 @@ contact:
   github: germa
   orcid: 0000-0002-1767-2343
 integration_server: https://raw.githubusercontent.com/HUPO-PSI/psi-ms-CV/master
-domain: MS experiments
+domain: experiments
+tags:
+  - MS experiments
 mailing_list: psidev-ms-vocab@lists.sourceforge.net
 homepage: http://www.psidev.info/groups/controlled-vocabularies
 tracker: https://github.com/HUPO-PSI/psi-ms-CV/issues

--- a/ontology/ms.md
+++ b/ontology/ms.md
@@ -10,9 +10,7 @@ contact:
   github: germa
   orcid: 0000-0002-1767-2343
 integration_server: https://raw.githubusercontent.com/HUPO-PSI/psi-ms-CV/master
-domain: experiments
-tags:
- - MS experiments
+domain: MS experiments
 mailing_list: psidev-ms-vocab@lists.sourceforge.net
 homepage: http://www.psidev.info/groups/controlled-vocabularies
 tracker: https://github.com/HUPO-PSI/psi-ms-CV/issues

--- a/ontology/ms.md
+++ b/ontology/ms.md
@@ -10,7 +10,7 @@ contact:
   github: germa
   orcid: 0000-0002-1767-2343
 integration_server: https://raw.githubusercontent.com/HUPO-PSI/psi-ms-CV/master
-domain: experiments
+domain: investigations
 tags:
   - MS experiments
 mailing_list: psidev-ms-vocab@lists.sourceforge.net

--- a/ontology/ms.md
+++ b/ontology/ms.md
@@ -10,7 +10,9 @@ contact:
   github: germa
   orcid: 0000-0002-1767-2343
 integration_server: https://raw.githubusercontent.com/HUPO-PSI/psi-ms-CV/master
-domain: MS experiments
+domain: experiments
+tags:
+ - MS experiments
 mailing_list: psidev-ms-vocab@lists.sourceforge.net
 homepage: http://www.psidev.info/groups/controlled-vocabularies
 tracker: https://github.com/HUPO-PSI/psi-ms-CV/issues

--- a/ontology/nbo.md
+++ b/ontology/nbo.md
@@ -7,9 +7,7 @@ contact:
   github: gkoutos
   orcid: 0000-0002-2061-091X
 description: An ontology of human and animal behaviours and behavioural phenotypes
-domain: biological systems
-tags:
- - behavior
+domain: behavior
 homepage: https://github.com/obo-behavior/behavior-ontology/
 products:
   - id: nbo.owl

--- a/ontology/nbo.md
+++ b/ontology/nbo.md
@@ -7,7 +7,9 @@ contact:
   github: gkoutos
   orcid: 0000-0002-2061-091X
 description: An ontology of human and animal behaviours and behavioural phenotypes
-domain: behavior
+domain: biological systems
+tags:
+ - behavior
 homepage: https://github.com/obo-behavior/behavior-ontology/
 products:
   - id: nbo.owl

--- a/ontology/nbo.md
+++ b/ontology/nbo.md
@@ -7,7 +7,9 @@ contact:
   github: gkoutos
   orcid: 0000-0002-2061-091X
 description: An ontology of human and animal behaviours and behavioural phenotypes
-domain: behavior
+domain: biological systems
+tags:
+  - behavior
 homepage: https://github.com/obo-behavior/behavior-ontology/
 products:
   - id: nbo.owl

--- a/ontology/ncbitaxon.md
+++ b/ontology/ncbitaxon.md
@@ -15,7 +15,9 @@ contact:
   orcid: 0000-0002-9415-5104
 description: An ontology representation of the NCBI organismal taxonomy
 wasDerivedFrom: ftp://ftp.ebi.ac.uk/pub/databases/taxonomy/taxonomy.dat
-domain: taxonomy
+domain: organisms
+tags:
+ - taxonomy
 homepage: https://github.com/obophenotype/ncbitaxon
 page: http://www.ncbi.nlm.nih.gov/taxonomy
 tracker: https://github.com/obophenotype/ncbitaxon/issues

--- a/ontology/ncbitaxon.md
+++ b/ontology/ncbitaxon.md
@@ -15,7 +15,9 @@ contact:
   orcid: 0000-0002-9415-5104
 description: An ontology representation of the NCBI organismal taxonomy
 wasDerivedFrom: ftp://ftp.ebi.ac.uk/pub/databases/taxonomy/taxonomy.dat
-domain: taxonomy
+domain: organisms
+tags:
+  - taxonomy
 homepage: https://github.com/obophenotype/ncbitaxon
 page: http://www.ncbi.nlm.nih.gov/taxonomy
 tracker: https://github.com/obophenotype/ncbitaxon/issues

--- a/ontology/ncbitaxon.md
+++ b/ontology/ncbitaxon.md
@@ -15,9 +15,7 @@ contact:
   orcid: 0000-0002-9415-5104
 description: An ontology representation of the NCBI organismal taxonomy
 wasDerivedFrom: ftp://ftp.ebi.ac.uk/pub/databases/taxonomy/taxonomy.dat
-domain: organisms
-tags:
- - taxonomy
+domain: taxonomy
 homepage: https://github.com/obophenotype/ncbitaxon
 page: http://www.ncbi.nlm.nih.gov/taxonomy
 tracker: https://github.com/obophenotype/ncbitaxon/issues

--- a/ontology/ncro.md
+++ b/ontology/ncro.md
@@ -3,7 +3,7 @@ layout: ontology_detail
 id: ncro
 title: Non-Coding RNA Ontology
 description: An ontology for non-coding RNA, both of biological origin, and engineered.
-domain: experiments
+domain: investigations
 homepage: http://omnisearch.soc.southalabama.edu/w/index.php/Ontology
 mailing_list: ncro-devel@googlegroups.com, ncro-discuss@googlegroups.com
 tracker: https://github.com/OmniSearch/ncro/issues

--- a/ontology/nmr.md
+++ b/ontology/nmr.md
@@ -5,7 +5,7 @@ contact:
   email: schober@imbi.uni-freiburg.de
   label: Schober Daniel
 description: Descriptors relevant to the experimental conditions of the Nuclear Magnetic Resonance (NMR) component in a metabolomics investigation.
-domain: experiments
+domain: investigations
 homepage: http://msi-ontology.sourceforge.net/
 page: http://msi-ontology.sourceforge.net/ontology/NMR.owlDocument.doc
 products:

--- a/ontology/nomen.md
+++ b/ontology/nomen.md
@@ -12,7 +12,9 @@ license:
   url: https://creativecommons.org/publicdomain/zero/1.0/
   label: CC0 1.0
 description: NOMEN is a nomenclatural ontology for biological names (not concepts).  It encodes the goverened rules of nomenclature.
-domain: biological nomenclature
+domain: information
+tags:
+ - biological nomenclature
 homepage: https://github.com/SpeciesFileGroup/nomen
 products:
   - id: nomen.owl

--- a/ontology/nomen.md
+++ b/ontology/nomen.md
@@ -12,7 +12,9 @@ license:
   url: https://creativecommons.org/publicdomain/zero/1.0/
   label: CC0 1.0
 description: NOMEN is a nomenclatural ontology for biological names (not concepts).  It encodes the goverened rules of nomenclature.
-domain: biological nomenclature
+domain: information
+tags:
+  - biological nomenclature
 homepage: https://github.com/SpeciesFileGroup/nomen
 products:
   - id: nomen.owl

--- a/ontology/nomen.md
+++ b/ontology/nomen.md
@@ -12,9 +12,7 @@ license:
   url: https://creativecommons.org/publicdomain/zero/1.0/
   label: CC0 1.0
 description: NOMEN is a nomenclatural ontology for biological names (not concepts).  It encodes the goverened rules of nomenclature.
-domain: information
-tags:
- - biological nomenclature
+domain: biological nomenclature
 homepage: https://github.com/SpeciesFileGroup/nomen
 products:
   - id: nomen.owl

--- a/ontology/oae.md
+++ b/ontology/oae.md
@@ -7,7 +7,9 @@ contact:
   github: yongqunh
   orcid: 0000-0001-9189-9661
 description: A biomedical ontology in the domain of adverse events
-domain: adverse events, health
+domain: health
+tags:
+ - adverse events, health
 homepage: https://github.com/OAE-ontology/OAE/
 tracker: https://github.com/OAE-ontology/OAE/issues
 products:

--- a/ontology/oae.md
+++ b/ontology/oae.md
@@ -9,7 +9,7 @@ contact:
 description: A biomedical ontology in the domain of adverse events
 domain: health
 tags:
-  - adverse events, health
+  - adverse events
 homepage: https://github.com/OAE-ontology/OAE/
 tracker: https://github.com/OAE-ontology/OAE/issues
 products:

--- a/ontology/oae.md
+++ b/ontology/oae.md
@@ -7,9 +7,7 @@ contact:
   github: yongqunh
   orcid: 0000-0001-9189-9661
 description: A biomedical ontology in the domain of adverse events
-domain: health
-tags:
- - adverse events, health
+domain: adverse events, health
 homepage: https://github.com/OAE-ontology/OAE/
 tracker: https://github.com/OAE-ontology/OAE/issues
 products:

--- a/ontology/oae.md
+++ b/ontology/oae.md
@@ -7,7 +7,9 @@ contact:
   github: yongqunh
   orcid: 0000-0001-9189-9661
 description: A biomedical ontology in the domain of adverse events
-domain: adverse events, health
+domain: health
+tags:
+  - adverse events, health
 homepage: https://github.com/OAE-ontology/OAE/
 tracker: https://github.com/OAE-ontology/OAE/issues
 products:

--- a/ontology/oarcs.md
+++ b/ontology/oarcs.md
@@ -9,7 +9,7 @@ contact:
   label: Matt Yoder
   github: mjy
   orcid: 0000-0002-5640-5491
-domain: anatomy and development
+domain: anatomy
 repository: https://github.com/aszool/oarcs
 license:
   url: http://creativecommons.org/licenses/by/3.0/

--- a/ontology/oarcs.md
+++ b/ontology/oarcs.md
@@ -9,7 +9,7 @@ contact:
   label: Matt Yoder
   github: mjy
   orcid: 0000-0002-5640-5491
-domain: anatomy
+domain: anatomy and development
 repository: https://github.com/aszool/oarcs
 license:
   url: http://creativecommons.org/licenses/by/3.0/

--- a/ontology/obcs.md
+++ b/ontology/obcs.md
@@ -9,7 +9,9 @@ contact:
   label: Jie Zheng
   github: zhengj2007
   orcid: 0000-0002-2999-0103
-domain: statistics
+domain: information technology
+tags:
+ - statistics
 homepage: https://github.com/obcs/obcs
 products:
   - id: obcs.owl

--- a/ontology/obcs.md
+++ b/ontology/obcs.md
@@ -9,9 +9,7 @@ contact:
   label: Jie Zheng
   github: zhengj2007
   orcid: 0000-0002-2999-0103
-domain: information technology
-tags:
- - statistics
+domain: statistics
 homepage: https://github.com/obcs/obcs
 products:
   - id: obcs.owl

--- a/ontology/obcs.md
+++ b/ontology/obcs.md
@@ -9,7 +9,9 @@ contact:
   label: Jie Zheng
   github: zhengj2007
   orcid: 0000-0002-2999-0103
-domain: statistics
+domain: information technology
+tags:
+  - statistics
 homepage: https://github.com/obcs/obcs
 products:
   - id: obcs.owl

--- a/ontology/obi.md
+++ b/ontology/obi.md
@@ -9,7 +9,7 @@ review:
     label: PDF
     link: https://drive.google.com/open?id=0B8vqEgF1N0NIMFlSM3RvdUxGTnc
 description: An integrated ontology for the description of life-science and clinical investigations
-domain: experiments
+domain: investigations
 homepage: http://obi-ontology.org
 mailing_list: http://groups.google.com/group/obi-users
 tracker: http://purl.obolibrary.org/obo/obi/tracker

--- a/ontology/obib.md
+++ b/ontology/obib.md
@@ -8,9 +8,7 @@ contact:
   github: zhengj2007
   orcid: 0000-0002-2999-0103
 description: An ontology built for annotation and modeling of biobank repository and biobanking administration
-domain: experiments
-tags:
- - biobanking, specimens, bio-repository, biocuration
+domain: biobanking, specimens, bio-repository, biocuration
 homepage: https://github.com/biobanking/biobanking
 products:
   - id: obib.owl

--- a/ontology/obib.md
+++ b/ontology/obib.md
@@ -8,7 +8,9 @@ contact:
   github: zhengj2007
   orcid: 0000-0002-2999-0103
 description: An ontology built for annotation and modeling of biobank repository and biobanking administration
-domain: biobanking, specimens, bio-repository, biocuration
+domain: experiments
+tags:
+ - biobanking, specimens, bio-repository, biocuration
 homepage: https://github.com/biobanking/biobanking
 products:
   - id: obib.owl

--- a/ontology/obib.md
+++ b/ontology/obib.md
@@ -8,7 +8,9 @@ contact:
   github: zhengj2007
   orcid: 0000-0002-2999-0103
 description: An ontology built for annotation and modeling of biobank repository and biobanking administration
-domain: biobanking, specimens, bio-repository, biocuration
+domain: experiments
+tags:
+  - biobanking, specimens, bio-repository, biocuration
 homepage: https://github.com/biobanking/biobanking
 products:
   - id: obib.owl

--- a/ontology/obib.md
+++ b/ontology/obib.md
@@ -8,7 +8,7 @@ contact:
   github: zhengj2007
   orcid: 0000-0002-2999-0103
 description: An ontology built for annotation and modeling of biobank repository and biobanking administration
-domain: experiments
+domain: investigations
 tags:
   - biobanking
   - specimens

--- a/ontology/obib.md
+++ b/ontology/obib.md
@@ -10,7 +10,9 @@ contact:
 description: An ontology built for annotation and modeling of biobank repository and biobanking administration
 domain: experiments
 tags:
-  - biobanking, specimens, bio-repository, biocuration
+  - biobanking
+  - specimens
+  - bio-repository
 homepage: https://github.com/biobanking/biobanking
 products:
   - id: obib.owl

--- a/ontology/ogms.md
+++ b/ontology/ogms.md
@@ -10,7 +10,9 @@ license:
   url: http://creativecommons.org/licenses/by/4.0/
   label: CC BY 4.0
 description: An ontology for representing treatment of disease and diagnosis and on carcinomas and other pathological entities
-domain: medicine
+domain: health
+tags:
+  - medicine
 homepage: https://github.com/OGMS/ogms
 products:
   - id: ogms.owl

--- a/ontology/ogms.md
+++ b/ontology/ogms.md
@@ -10,9 +10,7 @@ license:
   url: http://creativecommons.org/licenses/by/4.0/
   label: CC BY 4.0
 description: An ontology for representing treatment of disease and diagnosis and on carcinomas and other pathological entities
-domain: health
-tags:
- - medicine
+domain: medicine
 homepage: https://github.com/OGMS/ogms
 products:
   - id: ogms.owl

--- a/ontology/ogms.md
+++ b/ontology/ogms.md
@@ -10,7 +10,9 @@ license:
   url: http://creativecommons.org/licenses/by/4.0/
   label: CC BY 4.0
 description: An ontology for representing treatment of disease and diagnosis and on carcinomas and other pathological entities
-domain: medicine
+domain: health
+tags:
+ - medicine
 homepage: https://github.com/OGMS/ogms
 products:
   - id: ogms.owl

--- a/ontology/omo.md
+++ b/ontology/omo.md
@@ -7,9 +7,7 @@ contact:
   github: cmungall
   orcid: 0000-0002-6601-2165
 description: An ontology specifies terms that are used to annotate ontology terms for all OBO ontologies. The ontology was developed as part of Information Artifact Ontology (IAO).
-domain: information
-tags:
- - ontology term annotation
+domain: ontology term annotation
 homepage: https://github.com/information-artifact-ontology/ontology-metadata
 tracker: https://github.com/information-artifact-ontology/ontology-metadata/issues
 products:

--- a/ontology/omo.md
+++ b/ontology/omo.md
@@ -7,7 +7,9 @@ contact:
   github: cmungall
   orcid: 0000-0002-6601-2165
 description: An ontology specifies terms that are used to annotate ontology terms for all OBO ontologies. The ontology was developed as part of Information Artifact Ontology (IAO).
-domain: ontology term annotation
+domain: information
+tags:
+ - ontology term annotation
 homepage: https://github.com/information-artifact-ontology/ontology-metadata
 tracker: https://github.com/information-artifact-ontology/ontology-metadata/issues
 products:

--- a/ontology/omo.md
+++ b/ontology/omo.md
@@ -7,7 +7,9 @@ contact:
   github: cmungall
   orcid: 0000-0002-6601-2165
 description: An ontology specifies terms that are used to annotate ontology terms for all OBO ontologies. The ontology was developed as part of Information Artifact Ontology (IAO).
-domain: ontology term annotation
+domain: information
+tags:
+  - ontology term annotation
 homepage: https://github.com/information-artifact-ontology/ontology-metadata
 tracker: https://github.com/information-artifact-ontology/ontology-metadata/issues
 products:

--- a/ontology/omrse.md
+++ b/ontology/omrse.md
@@ -10,7 +10,9 @@ license:
   url: https://creativecommons.org/licenses/by/4.0/
   label: CC BY 4.0
 description: This ontology covers the domain of social entities that are related to health care, such as demographic information and the roles of various individuals and organizations.
-domain: medicine
+domain: health
+tags:
+ - medicine
 homepage: https://github.com/ufbmi/OMRSE/wiki/OMRSE-Overview
 tracker: https://github.com/ufbmi/OMRSE/issues
 products:

--- a/ontology/omrse.md
+++ b/ontology/omrse.md
@@ -10,9 +10,7 @@ license:
   url: https://creativecommons.org/licenses/by/4.0/
   label: CC BY 4.0
 description: This ontology covers the domain of social entities that are related to health care, such as demographic information and the roles of various individuals and organizations.
-domain: health
-tags:
- - medicine
+domain: medicine
 homepage: https://github.com/ufbmi/OMRSE/wiki/OMRSE-Overview
 tracker: https://github.com/ufbmi/OMRSE/issues
 products:

--- a/ontology/omrse.md
+++ b/ontology/omrse.md
@@ -10,7 +10,9 @@ license:
   url: https://creativecommons.org/licenses/by/4.0/
   label: CC BY 4.0
 description: This ontology covers the domain of social entities that are related to health care, such as demographic information and the roles of various individuals and organizations.
-domain: medicine
+domain: health
+tags:
+  - medicine
 homepage: https://github.com/ufbmi/OMRSE/wiki/OMRSE-Overview
 tracker: https://github.com/ufbmi/OMRSE/issues
 products:

--- a/ontology/one.md
+++ b/ontology/one.md
@@ -11,7 +11,9 @@ contact:
 description: An ontology to standardize research output of nutritional epidemiologic studies.
 domain: diet, metabolomics and nutrition
 tags:
-  - nutritional epidemiology, observational studies, dietary surveys
+  - nutritional epidemiology
+  - observational studies
+  - dietary surveys
 homepage: https://github.com/cyang0128/Nutritional-epidemiologic-ontologies
 page: https://github.com/cyang0128/Nutritional-epidemiologic-ontologies
 license:

--- a/ontology/one.md
+++ b/ontology/one.md
@@ -9,9 +9,7 @@ contact:
   github: cyang0128
   orcid: 0000-0001-9202-5309
 description: An ontology to standardize research output of nutritional epidemiologic studies.
-domain: diet, metabolomics and nutrition
-tags:
- - nutritional epidemiology, observational studies, dietary surveys
+domain: nutritional epidemiology, observational studies, dietary surveys
 homepage: https://github.com/cyang0128/Nutritional-epidemiologic-ontologies
 page: https://github.com/cyang0128/Nutritional-epidemiologic-ontologies
 license:

--- a/ontology/one.md
+++ b/ontology/one.md
@@ -9,7 +9,9 @@ contact:
   github: cyang0128
   orcid: 0000-0001-9202-5309
 description: An ontology to standardize research output of nutritional epidemiologic studies.
-domain: nutritional epidemiology, observational studies, dietary surveys
+domain: diet, metabolomics and nutrition
+tags:
+  - nutritional epidemiology, observational studies, dietary surveys
 homepage: https://github.com/cyang0128/Nutritional-epidemiologic-ontologies
 page: https://github.com/cyang0128/Nutritional-epidemiologic-ontologies
 license:

--- a/ontology/one.md
+++ b/ontology/one.md
@@ -9,7 +9,9 @@ contact:
   github: cyang0128
   orcid: 0000-0001-9202-5309
 description: An ontology to standardize research output of nutritional epidemiologic studies.
-domain: nutritional epidemiology, observational studies, dietary surveys
+domain: diet, metabolomics and nutrition
+tags:
+ - nutritional epidemiology, observational studies, dietary surveys
 homepage: https://github.com/cyang0128/Nutritional-epidemiologic-ontologies
 page: https://github.com/cyang0128/Nutritional-epidemiologic-ontologies
 license:

--- a/ontology/one.md
+++ b/ontology/one.md
@@ -9,7 +9,7 @@ contact:
   github: cyang0128
   orcid: 0000-0001-9202-5309
 description: An ontology to standardize research output of nutritional epidemiologic studies.
-domain: diet, metabolomics and nutrition
+domain: diet, metabolomics, and nutrition
 tags:
   - nutritional epidemiology
   - observational studies

--- a/ontology/ons.md
+++ b/ontology/ons.md
@@ -9,7 +9,7 @@ contact:
   github: FrancescoVit
   orcid: 0000-0001-9125-4337
 description: An ontology for description of concepts in the nutritional studies domain.
-domain: diet, metabolomics and nutrition
+domain: diet, metabolomics, and nutrition
 tags:
   - nutrition, nutritional studies, nutrition professionals
 homepage: https://github.com/enpadasi/Ontology-for-Nutritional-Studies

--- a/ontology/ons.md
+++ b/ontology/ons.md
@@ -9,9 +9,7 @@ contact:
   github: FrancescoVit
   orcid: 0000-0001-9125-4337
 description: An ontology for description of concepts in the nutritional studies domain.
-domain: diet, metabolomics and nutrition
-tags:
- - nutrition, nutritional studies, nutrition professionals
+domain: nutrition, nutritional studies, nutrition professionals
 homepage: https://github.com/enpadasi/Ontology-for-Nutritional-Studies
 page: https://github.com/enpadasi/Ontology-for-Nutritional-Studies
 license:

--- a/ontology/ons.md
+++ b/ontology/ons.md
@@ -9,7 +9,9 @@ contact:
   github: FrancescoVit
   orcid: 0000-0001-9125-4337
 description: An ontology for description of concepts in the nutritional studies domain.
-domain: nutrition, nutritional studies, nutrition professionals
+domain: diet, metabolomics and nutrition
+tags:
+  - nutrition, nutritional studies, nutrition professionals
 homepage: https://github.com/enpadasi/Ontology-for-Nutritional-Studies
 page: https://github.com/enpadasi/Ontology-for-Nutritional-Studies
 license:

--- a/ontology/ons.md
+++ b/ontology/ons.md
@@ -9,7 +9,9 @@ contact:
   github: FrancescoVit
   orcid: 0000-0001-9125-4337
 description: An ontology for description of concepts in the nutritional studies domain.
-domain: nutrition, nutritional studies, nutrition professionals
+domain: diet, metabolomics and nutrition
+tags:
+ - nutrition, nutritional studies, nutrition professionals
 homepage: https://github.com/enpadasi/Ontology-for-Nutritional-Studies
 page: https://github.com/enpadasi/Ontology-for-Nutritional-Studies
 license:

--- a/ontology/ontoavida.md
+++ b/ontology/ontoavida.md
@@ -8,7 +8,9 @@ contact:
   github: miguelfortuna
   orcid: 0000-0002-8374-1941
 description: "OntoAvida develops an integrated vocabulary for the description of the most widely-used computational approach for studying evolution using digital organisms (i.e., self-replicating computer programs that evolve within a user-defined computational environment)."
-domain: digital evolution, a branch of Artificial Life.
+domain: other
+tags:
+ - digital evolution, a branch of Artificial Life.
 homepage: https://gitlab.com/fortunalab/ontoavida
 products:
   - id: ontoavida.owl

--- a/ontology/ontoavida.md
+++ b/ontology/ontoavida.md
@@ -8,9 +8,7 @@ contact:
   github: miguelfortuna
   orcid: 0000-0002-8374-1941
 description: "OntoAvida develops an integrated vocabulary for the description of the most widely-used computational approach for studying evolution using digital organisms (i.e., self-replicating computer programs that evolve within a user-defined computational environment)."
-domain: other
-tags:
- - digital evolution, a branch of Artificial Life.
+domain: digital evolution, a branch of Artificial Life.
 homepage: https://gitlab.com/fortunalab/ontoavida
 products:
   - id: ontoavida.owl

--- a/ontology/ontoavida.md
+++ b/ontology/ontoavida.md
@@ -8,9 +8,10 @@ contact:
   github: miguelfortuna
   orcid: 0000-0002-8374-1941
 description: "OntoAvida develops an integrated vocabulary for the description of the most widely-used computational approach for studying evolution using digital organisms (i.e., self-replicating computer programs that evolve within a user-defined computational environment)."
-domain: other
+domain: simulation
 tags:
-  - digital evolution, a branch of Artificial Life.
+  - digital evolution
+  - artificial life
 homepage: https://gitlab.com/fortunalab/ontoavida
 products:
   - id: ontoavida.owl

--- a/ontology/ontoavida.md
+++ b/ontology/ontoavida.md
@@ -8,7 +8,9 @@ contact:
   github: miguelfortuna
   orcid: 0000-0002-8374-1941
 description: "OntoAvida develops an integrated vocabulary for the description of the most widely-used computational approach for studying evolution using digital organisms (i.e., self-replicating computer programs that evolve within a user-defined computational environment)."
-domain: digital evolution, a branch of Artificial Life.
+domain: other
+tags:
+  - digital evolution, a branch of Artificial Life.
 homepage: https://gitlab.com/fortunalab/ontoavida
 products:
   - id: ontoavida.owl

--- a/ontology/ontoneo.md
+++ b/ontology/ontoneo.md
@@ -11,7 +11,9 @@ description: The Obstetric and Neonatal Ontology is a structured controlled voca
 license:
   url: http://creativecommons.org/licenses/by/3.0/
   label: CC BY 3.0
-domain: biomedical, health
+domain: health
+tags:
+  - biomedical, health
 homepage: ontoneo.com
 mailing_list: http://groups.google.com/group/ontoneo-discuss
 products:

--- a/ontology/ontoneo.md
+++ b/ontology/ontoneo.md
@@ -13,7 +13,7 @@ license:
   label: CC BY 3.0
 domain: health
 tags:
-  - biomedical, health
+  - biomedical
 homepage: ontoneo.com
 mailing_list: http://groups.google.com/group/ontoneo-discuss
 products:

--- a/ontology/ontoneo.md
+++ b/ontology/ontoneo.md
@@ -11,9 +11,7 @@ description: The Obstetric and Neonatal Ontology is a structured controlled voca
 license:
   url: http://creativecommons.org/licenses/by/3.0/
   label: CC BY 3.0
-domain: health
-tags:
- - biomedical, health
+domain: biomedical, health
 homepage: ontoneo.com
 mailing_list: http://groups.google.com/group/ontoneo-discuss
 products:

--- a/ontology/ontoneo.md
+++ b/ontology/ontoneo.md
@@ -11,7 +11,9 @@ description: The Obstetric and Neonatal Ontology is a structured controlled voca
 license:
   url: http://creativecommons.org/licenses/by/3.0/
   label: CC BY 3.0
-domain: biomedical, health
+domain: health
+tags:
+ - biomedical, health
 homepage: ontoneo.com
 mailing_list: http://groups.google.com/group/ontoneo-discuss
 products:

--- a/ontology/opl.md
+++ b/ontology/opl.md
@@ -10,7 +10,9 @@ license:
   url: https://creativecommons.org/licenses/by/4.0/
   label: CC BY 4.0
 description: A reference ontology for parasite life cycle stages.
-domain: life cycle stage, parasite organism
+domain: organisms
+tags:
+  - life cycle stage, parasite organism
 homepage: https://github.com/OPL-ontology/OPL
 products:
   - id: opl.owl

--- a/ontology/opl.md
+++ b/ontology/opl.md
@@ -10,9 +10,7 @@ license:
   url: https://creativecommons.org/licenses/by/4.0/
   label: CC BY 4.0
 description: A reference ontology for parasite life cycle stages.
-domain: organisms
-tags:
- - life cycle stage, parasite organism
+domain: life cycle stage, parasite organism
 homepage: https://github.com/OPL-ontology/OPL
 products:
   - id: opl.owl

--- a/ontology/opl.md
+++ b/ontology/opl.md
@@ -12,7 +12,8 @@ license:
 description: A reference ontology for parasite life cycle stages.
 domain: organisms
 tags:
-  - life cycle stage, parasite organism
+  - life cycle stage
+  - parasite organism
 homepage: https://github.com/OPL-ontology/OPL
 products:
   - id: opl.owl

--- a/ontology/opl.md
+++ b/ontology/opl.md
@@ -10,7 +10,9 @@ license:
   url: https://creativecommons.org/licenses/by/4.0/
   label: CC BY 4.0
 description: A reference ontology for parasite life cycle stages.
-domain: life cycle stage, parasite organism
+domain: organisms
+tags:
+ - life cycle stage, parasite organism
 homepage: https://github.com/OPL-ontology/OPL
 products:
   - id: opl.owl

--- a/ontology/ornaseq.md
+++ b/ontology/ornaseq.md
@@ -8,7 +8,7 @@ contact:
   github: safisher
   orcid: 0000-0001-8034-7685
 description: An application ontology designed to annotate next-generation sequencing experiments performed on RNA.
-domain: experiments
+domain: investigations
 homepage: http://kim.bio.upenn.edu/software/ornaseq.shtml
 products:
   - id: ornaseq.owl

--- a/ontology/pco.md
+++ b/ontology/pco.md
@@ -15,9 +15,7 @@ contact:
   github: ramonawalls
   orcid: 0000-0001-8815-0078
 description: An ontology about groups of interacting organisms such as populations and communities
-domain: environment
-tags:
- - collections of organisms
+domain: collections of organisms
 homepage: https://github.com/PopulationAndCommunityOntology/pco
 products:
   - id: pco.owl

--- a/ontology/pco.md
+++ b/ontology/pco.md
@@ -15,7 +15,9 @@ contact:
   github: ramonawalls
   orcid: 0000-0001-8815-0078
 description: An ontology about groups of interacting organisms such as populations and communities
-domain: collections of organisms
+domain: environment
+tags:
+ - collections of organisms
 homepage: https://github.com/PopulationAndCommunityOntology/pco
 products:
   - id: pco.owl

--- a/ontology/pco.md
+++ b/ontology/pco.md
@@ -15,7 +15,9 @@ contact:
   github: ramonawalls
   orcid: 0000-0001-8815-0078
 description: An ontology about groups of interacting organisms such as populations and communities
-domain: collections of organisms
+domain: environment
+tags:
+  - collections of organisms
 homepage: https://github.com/PopulationAndCommunityOntology/pco
 products:
   - id: pco.owl

--- a/ontology/peco.md
+++ b/ontology/peco.md
@@ -8,7 +8,7 @@ contact:
   github: jaiswalp
   orcid: 0000-0002-1005-8383
 description: A structured, controlled vocabulary which describes the treatments, growing conditions, and/or study types used in plant biology experiments.
-domain: experiments
+domain: investigations
 tags:
   - experimental conditions
 homepage: http://planteome.org/

--- a/ontology/peco.md
+++ b/ontology/peco.md
@@ -8,7 +8,9 @@ contact:
   github: jaiswalp
   orcid: 0000-0002-1005-8383
 description: A structured, controlled vocabulary which describes the treatments, growing conditions, and/or study types used in plant biology experiments.
-domain: experimental conditions
+domain: experiments
+tags:
+ - experimental conditions
 homepage: http://planteome.org/
 page: http://browser.planteome.org/amigo/term/PECO:0007359
 products:

--- a/ontology/peco.md
+++ b/ontology/peco.md
@@ -8,9 +8,7 @@ contact:
   github: jaiswalp
   orcid: 0000-0002-1005-8383
 description: A structured, controlled vocabulary which describes the treatments, growing conditions, and/or study types used in plant biology experiments.
-domain: experiments
-tags:
- - experimental conditions
+domain: experimental conditions
 homepage: http://planteome.org/
 page: http://browser.planteome.org/amigo/term/PECO:0007359
 products:

--- a/ontology/peco.md
+++ b/ontology/peco.md
@@ -8,7 +8,9 @@ contact:
   github: jaiswalp
   orcid: 0000-0002-1005-8383
 description: A structured, controlled vocabulary which describes the treatments, growing conditions, and/or study types used in plant biology experiments.
-domain: experimental conditions
+domain: experiments
+tags:
+  - experimental conditions
 homepage: http://planteome.org/
 page: http://browser.planteome.org/amigo/term/PECO:0007359
 products:

--- a/ontology/plana.md
+++ b/ontology/plana.md
@@ -15,7 +15,7 @@ contact:
   github: srobb1
   orcid: 0000-0002-3528-5267
 description: PLANA, the planarian anatomy ontology, encompasses the anatomy and life cycle stages for both __Schmidtea mediterranea__ biotypes.
-domain: anatomy and development
+domain: anatomy
 homepage: https://github.com/obophenotype/planaria-ontology
 products:
   - id: plana.owl

--- a/ontology/plana.md
+++ b/ontology/plana.md
@@ -15,7 +15,7 @@ contact:
   github: srobb1
   orcid: 0000-0002-3528-5267
 description: PLANA, the planarian anatomy ontology, encompasses the anatomy and life cycle stages for both __Schmidtea mediterranea__ biotypes.
-domain: anatomy
+domain: anatomy and development
 homepage: https://github.com/obophenotype/planaria-ontology
 products:
   - id: plana.owl

--- a/ontology/poro.md
+++ b/ontology/poro.md
@@ -7,7 +7,7 @@ contact:
   github: bobthacker
   orcid: 0000-0002-9654-0073
 description: An ontology covering the anatomy of the taxon Porifera (sponges)
-domain: anatomy
+domain: anatomy and development
 homepage: https://github.com/obophenotype/porifera-ontology
 products:
   - id: poro.owl

--- a/ontology/poro.md
+++ b/ontology/poro.md
@@ -7,7 +7,7 @@ contact:
   github: bobthacker
   orcid: 0000-0002-9654-0073
 description: An ontology covering the anatomy of the taxon Porifera (sponges)
-domain: anatomy and development
+domain: anatomy
 homepage: https://github.com/obophenotype/porifera-ontology
 products:
   - id: poro.owl

--- a/ontology/ppo.md
+++ b/ontology/ppo.md
@@ -2,7 +2,9 @@
 layout: ontology_detail
 id: ppo
 title: Plant Phenology Ontology
-domain: plant phenotypes
+domain: phenotype
+tags:
+  - plant phenotypes
 description: An ontology for describing the phenology of individual plants and populations of plants, and for integrating plant phenological data across sources and scales.
 homepage: https://github.com/PlantPhenoOntology/PPO
 contact:

--- a/ontology/ppo.md
+++ b/ontology/ppo.md
@@ -2,7 +2,9 @@
 layout: ontology_detail
 id: ppo
 title: Plant Phenology Ontology
-domain: plant phenotypes
+domain: phenotype
+tags:
+ - plant phenotypes
 description: An ontology for describing the phenology of individual plants and populations of plants, and for integrating plant phenological data across sources and scales.
 homepage: https://github.com/PlantPhenoOntology/PPO
 contact:

--- a/ontology/ppo.md
+++ b/ontology/ppo.md
@@ -2,9 +2,7 @@
 layout: ontology_detail
 id: ppo
 title: Plant Phenology Ontology
-domain: phenotype
-tags:
- - plant phenotypes
+domain: plant phenotypes
 description: An ontology for describing the phenology of individual plants and populations of plants, and for integrating plant phenological data across sources and scales.
 homepage: https://github.com/PlantPhenoOntology/PPO
 contact:

--- a/ontology/pr.md
+++ b/ontology/pr.md
@@ -8,7 +8,9 @@ contact:
   github: nataled
   orcid: 0000-0001-5809-9523
 description: An ontological representation of protein-related entities
-domain: proteins
+domain: biochemistry
+tags:
+ - proteins
 homepage: http://proconsortium.org
 documentation: https://proconsortium.org/download/current/pro_readme.txt
 products:

--- a/ontology/pr.md
+++ b/ontology/pr.md
@@ -8,9 +8,7 @@ contact:
   github: nataled
   orcid: 0000-0001-5809-9523
 description: An ontological representation of protein-related entities
-domain: biochemistry
-tags:
- - proteins
+domain: proteins
 homepage: http://proconsortium.org
 documentation: https://proconsortium.org/download/current/pro_readme.txt
 products:

--- a/ontology/pr.md
+++ b/ontology/pr.md
@@ -8,7 +8,9 @@ contact:
   github: nataled
   orcid: 0000-0001-5809-9523
 description: An ontological representation of protein-related entities
-domain: proteins
+domain: biochemistry
+tags:
+  - proteins
 homepage: http://proconsortium.org
 documentation: https://proconsortium.org/download/current/pro_readme.txt
 products:

--- a/ontology/psdo.md
+++ b/ontology/psdo.md
@@ -12,7 +12,9 @@ contact:
   github: zachll
   orcid: 0000-0002-9117-9338
 description: Ontology to reproducibly study visualizations of clinical performance
-domain: learning systems
+domain: information
+tags:
+ - learning systems
 homepage: https://github.com/Display-Lab/psdo
 products:
   - id: psdo.owl

--- a/ontology/psdo.md
+++ b/ontology/psdo.md
@@ -12,9 +12,7 @@ contact:
   github: zachll
   orcid: 0000-0002-9117-9338
 description: Ontology to reproducibly study visualizations of clinical performance
-domain: information
-tags:
- - learning systems
+domain: learning systems
 homepage: https://github.com/Display-Lab/psdo
 products:
   - id: psdo.owl

--- a/ontology/psdo.md
+++ b/ontology/psdo.md
@@ -12,7 +12,9 @@ contact:
   github: zachll
   orcid: 0000-0002-9117-9338
 description: Ontology to reproducibly study visualizations of clinical performance
-domain: learning systems
+domain: information
+tags:
+  - learning systems
 homepage: https://github.com/Display-Lab/psdo
 products:
   - id: psdo.owl

--- a/ontology/pso.md
+++ b/ontology/pso.md
@@ -15,7 +15,9 @@ contact:
   github: cooperl09
   orcid: 0000-0002-6379-8932
 description: The Plant Stress Ontology describes...
-domain: plant disease and abiotic stress
+domain: agriculture
+tags:
+ - plant disease and abiotic stress
 homepage: https://github.com/Planteome/plant-stress-ontology
 products:
   - id: pso.owl

--- a/ontology/pso.md
+++ b/ontology/pso.md
@@ -15,7 +15,9 @@ contact:
   github: cooperl09
   orcid: 0000-0002-6379-8932
 description: The Plant Stress Ontology describes...
-domain: plant disease and abiotic stress
+domain: agriculture
+tags:
+  - plant disease and abiotic stress
 homepage: https://github.com/Planteome/plant-stress-ontology
 products:
   - id: pso.owl

--- a/ontology/pso.md
+++ b/ontology/pso.md
@@ -15,9 +15,7 @@ contact:
   github: cooperl09
   orcid: 0000-0002-6379-8932
 description: The Plant Stress Ontology describes...
-domain: agriculture
-tags:
- - plant disease and abiotic stress
+domain: plant disease and abiotic stress
 homepage: https://github.com/Planteome/plant-stress-ontology
 products:
   - id: pso.owl

--- a/ontology/pso.md
+++ b/ontology/pso.md
@@ -17,7 +17,8 @@ contact:
 description: The Plant Stress Ontology describes...
 domain: agriculture
 tags:
-  - plant disease and abiotic stress
+  - plant disease
+  - abiotic stress
 homepage: https://github.com/Planteome/plant-stress-ontology
 products:
   - id: pso.owl

--- a/ontology/pw.md
+++ b/ontology/pw.md
@@ -10,7 +10,9 @@ license:
   url: https://creativecommons.org/licenses/by/4.0/
   label: CC BY 4.0
 description: A controlled vocabulary for annotating gene products to pathways.
-domain: biological process
+domain: biological systems
+tags:
+  - biological process
 homepage: http://rgd.mcw.edu/rgdweb/ontology/search.html
 tracker: https://github.com/rat-genome-database/PW-Pathway-Ontology/issues
 page: https://download.rgd.mcw.edu/ontology/pathway/

--- a/ontology/pw.md
+++ b/ontology/pw.md
@@ -10,9 +10,7 @@ license:
   url: https://creativecommons.org/licenses/by/4.0/
   label: CC BY 4.0
 description: A controlled vocabulary for annotating gene products to pathways.
-domain: biological systems
-tags:
- - biological process
+domain: biological process
 homepage: http://rgd.mcw.edu/rgdweb/ontology/search.html
 tracker: https://github.com/rat-genome-database/PW-Pathway-Ontology/issues
 page: https://download.rgd.mcw.edu/ontology/pathway/

--- a/ontology/pw.md
+++ b/ontology/pw.md
@@ -10,7 +10,9 @@ license:
   url: https://creativecommons.org/licenses/by/4.0/
   label: CC BY 4.0
 description: A controlled vocabulary for annotating gene products to pathways.
-domain: biological process
+domain: biological systems
+tags:
+ - biological process
 homepage: http://rgd.mcw.edu/rgdweb/ontology/search.html
 tracker: https://github.com/rat-genome-database/PW-Pathway-Ontology/issues
 page: https://download.rgd.mcw.edu/ontology/pathway/

--- a/ontology/rbo.md
+++ b/ontology/rbo.md
@@ -15,7 +15,9 @@ contact:
   github: DanBerrios
   orcid: 0000-0003-4312-9552
 description: RBO is an ontology for the effects of radiation on biota in terrestrial and space environments.
-domain: radiation biology, the study of the effects of radiation on biological systems
+domain: environment
+tags:
+ - radiation biology, the study of the effects of radiation on biological systems
 homepage: https://github.com/Radiobiology-Informatics-Consortium/RBO
 products:
   - id: rbo.owl

--- a/ontology/rbo.md
+++ b/ontology/rbo.md
@@ -17,7 +17,7 @@ contact:
 description: RBO is an ontology for the effects of radiation on biota in terrestrial and space environments.
 domain: environment
 tags:
-  - radiation biology, the study of the effects of radiation on biological systems
+  - radiation biology
 homepage: https://github.com/Radiobiology-Informatics-Consortium/RBO
 products:
   - id: rbo.owl

--- a/ontology/rbo.md
+++ b/ontology/rbo.md
@@ -15,9 +15,7 @@ contact:
   github: DanBerrios
   orcid: 0000-0003-4312-9552
 description: RBO is an ontology for the effects of radiation on biota in terrestrial and space environments.
-domain: environment
-tags:
- - radiation biology, the study of the effects of radiation on biological systems
+domain: radiation biology, the study of the effects of radiation on biological systems
 homepage: https://github.com/Radiobiology-Informatics-Consortium/RBO
 products:
   - id: rbo.owl

--- a/ontology/rbo.md
+++ b/ontology/rbo.md
@@ -15,7 +15,9 @@ contact:
   github: DanBerrios
   orcid: 0000-0003-4312-9552
 description: RBO is an ontology for the effects of radiation on biota in terrestrial and space environments.
-domain: radiation biology, the study of the effects of radiation on biological systems
+domain: environment
+tags:
+  - radiation biology, the study of the effects of radiation on biological systems
 homepage: https://github.com/Radiobiology-Informatics-Consortium/RBO
 products:
   - id: rbo.owl

--- a/ontology/resid.md
+++ b/ontology/resid.md
@@ -5,9 +5,7 @@ contact:
   email: john.garavelli@ebi.ac.uk
   label: John Garavelli
 description: For the description of covalent bonds in proteins.
-domain: biochemistry
-tags:
- - proteins
+domain: proteins
 homepage: http://www.ebi.ac.uk/RESID/
 title: Protein covalent bond
 is_obsolete: true

--- a/ontology/resid.md
+++ b/ontology/resid.md
@@ -5,7 +5,9 @@ contact:
   email: john.garavelli@ebi.ac.uk
   label: John Garavelli
 description: For the description of covalent bonds in proteins.
-domain: proteins
+domain: biochemistry
+tags:
+ - proteins
 homepage: http://www.ebi.ac.uk/RESID/
 title: Protein covalent bond
 is_obsolete: true

--- a/ontology/resid.md
+++ b/ontology/resid.md
@@ -5,7 +5,9 @@ contact:
   email: john.garavelli@ebi.ac.uk
   label: John Garavelli
 description: For the description of covalent bonds in proteins.
-domain: proteins
+domain: biochemistry
+tags:
+  - proteins
 homepage: http://www.ebi.ac.uk/RESID/
 title: Protein covalent bond
 is_obsolete: true

--- a/ontology/rnao.md
+++ b/ontology/rnao.md
@@ -8,7 +8,9 @@ contact:
 license:
   url: https://creativecommons.org/publicdomain/zero/1.0/
   label: CC0 1.0
-domain: molecular structure
+domain: biochemistry
+tags:
+  - molecular structure
 homepage: https://github.com/bgsu-rna/rnao
 browsers:
   - label: RNAO

--- a/ontology/rnao.md
+++ b/ontology/rnao.md
@@ -8,9 +8,7 @@ contact:
 license:
   url: https://creativecommons.org/publicdomain/zero/1.0/
   label: CC0 1.0
-domain: biochemistry
-tags:
- - molecular structure
+domain: molecular structure
 homepage: https://github.com/bgsu-rna/rnao
 browsers:
   - label: RNAO

--- a/ontology/rnao.md
+++ b/ontology/rnao.md
@@ -8,7 +8,9 @@ contact:
 license:
   url: https://creativecommons.org/publicdomain/zero/1.0/
   label: CC0 1.0
-domain: molecular structure
+domain: biochemistry
+tags:
+ - molecular structure
 homepage: https://github.com/bgsu-rna/rnao
 browsers:
   - label: RNAO

--- a/ontology/ro.md
+++ b/ontology/ro.md
@@ -13,7 +13,9 @@ homepage: https://oborel.github.io/
 documentation: https://oborel.github.io/obo-relations/
 tracker: https://github.com/oborel/obo-relations/issues
 mailing_list: "https://groups.google.com/forum/#!forum/obo-relations"
-domain: relations
+domain: upper
+tags:
+ - relations
 contact:
   email: cjmungall@lbl.gov
   label: Chris Mungall

--- a/ontology/ro.md
+++ b/ontology/ro.md
@@ -13,9 +13,7 @@ homepage: https://oborel.github.io/
 documentation: https://oborel.github.io/obo-relations/
 tracker: https://github.com/oborel/obo-relations/issues
 mailing_list: "https://groups.google.com/forum/#!forum/obo-relations"
-domain: upper
-tags:
- - relations
+domain: relations
 contact:
   email: cjmungall@lbl.gov
   label: Chris Mungall

--- a/ontology/ro.md
+++ b/ontology/ro.md
@@ -13,7 +13,9 @@ homepage: https://oborel.github.io/
 documentation: https://oborel.github.io/obo-relations/
 tracker: https://github.com/oborel/obo-relations/issues
 mailing_list: "https://groups.google.com/forum/#!forum/obo-relations"
-domain: relations
+domain: upper
+tags:
+  - relations
 contact:
   email: cjmungall@lbl.gov
   label: Chris Mungall

--- a/ontology/scdo.md
+++ b/ontology/scdo.md
@@ -12,9 +12,7 @@ contact:
   github: JadeHotchkiss
   orcid: 0000-0002-2193-0704
 description: An ontology for the standardization of terminology and integration of knowledge about Sickle Cell Disease.
-domain: health
-tags:
- - disease
+domain: disease
 homepage: https://scdontology.h3abionet.org/
 products:
   - id: scdo.owl

--- a/ontology/scdo.md
+++ b/ontology/scdo.md
@@ -12,7 +12,9 @@ contact:
   github: JadeHotchkiss
   orcid: 0000-0002-2193-0704
 description: An ontology for the standardization of terminology and integration of knowledge about Sickle Cell Disease.
-domain: disease
+domain: health
+tags:
+  - disease
 homepage: https://scdontology.h3abionet.org/
 products:
   - id: scdo.owl

--- a/ontology/scdo.md
+++ b/ontology/scdo.md
@@ -12,7 +12,9 @@ contact:
   github: JadeHotchkiss
   orcid: 0000-0002-2193-0704
 description: An ontology for the standardization of terminology and integration of knowledge about Sickle Cell Disease.
-domain: disease
+domain: health
+tags:
+ - disease
 homepage: https://scdontology.h3abionet.org/
 products:
   - id: scdo.owl

--- a/ontology/sep.md
+++ b/ontology/sep.md
@@ -5,7 +5,9 @@ contact:
   email: psidev-gps-dev@lists.sourceforge.net
   label: SEP developers via the PSI and MSI mailing lists
 description: A structured controlled vocabulary for the annotation of sample processing and separation techniques in scientific experiments.
-domain: provenance
+domain: experiments
+tags:
+  - provenance
 homepage: http://psidev.info/index.php?q=node/312
 page: http://psidev.info/index.php?q=node/312
 products:

--- a/ontology/sep.md
+++ b/ontology/sep.md
@@ -5,7 +5,9 @@ contact:
   email: psidev-gps-dev@lists.sourceforge.net
   label: SEP developers via the PSI and MSI mailing lists
 description: A structured controlled vocabulary for the annotation of sample processing and separation techniques in scientific experiments.
-domain: provenance
+domain: experiments
+tags:
+ - provenance
 homepage: http://psidev.info/index.php?q=node/312
 page: http://psidev.info/index.php?q=node/312
 products:

--- a/ontology/sep.md
+++ b/ontology/sep.md
@@ -5,9 +5,7 @@ contact:
   email: psidev-gps-dev@lists.sourceforge.net
   label: SEP developers via the PSI and MSI mailing lists
 description: A structured controlled vocabulary for the annotation of sample processing and separation techniques in scientific experiments.
-domain: experiments
-tags:
- - provenance
+domain: provenance
 homepage: http://psidev.info/index.php?q=node/312
 page: http://psidev.info/index.php?q=node/312
 products:

--- a/ontology/sep.md
+++ b/ontology/sep.md
@@ -5,7 +5,7 @@ contact:
   email: psidev-gps-dev@lists.sourceforge.net
   label: SEP developers via the PSI and MSI mailing lists
 description: A structured controlled vocabulary for the annotation of sample processing and separation techniques in scientific experiments.
-domain: experiments
+domain: investigations
 tags:
   - provenance
 homepage: http://psidev.info/index.php?q=node/312

--- a/ontology/sepio.md
+++ b/ontology/sepio.md
@@ -3,7 +3,7 @@ layout: ontology_detail
 id: sepio
 title: Scientific Evidence and Provenance Information Ontology
 description: An ontology for representing the provenance of scientific claims and the evidence that supports them.
-domain: experiments
+domain: investigations
 tags:
   - scientific claims
   - evidence

--- a/ontology/sepio.md
+++ b/ontology/sepio.md
@@ -3,7 +3,9 @@ layout: ontology_detail
 id: sepio
 title: Scientific Evidence and Provenance Information Ontology
 description: An ontology for representing the provenance of scientific claims and the evidence that supports them.
-domain: scientific claims, evidence
+domain: experiments
+tags:
+ - scientific claims, evidence
 homepage: https://github.com/monarch-initiative/SEPIO-ontology
 tracker: https://github.com/monarch-initiative/SEPIO-ontology/issues
 contact:

--- a/ontology/sepio.md
+++ b/ontology/sepio.md
@@ -3,7 +3,9 @@ layout: ontology_detail
 id: sepio
 title: Scientific Evidence and Provenance Information Ontology
 description: An ontology for representing the provenance of scientific claims and the evidence that supports them.
-domain: scientific claims, evidence
+domain: experiments
+tags:
+  - scientific claims, evidence
 homepage: https://github.com/monarch-initiative/SEPIO-ontology
 tracker: https://github.com/monarch-initiative/SEPIO-ontology/issues
 contact:

--- a/ontology/sepio.md
+++ b/ontology/sepio.md
@@ -3,9 +3,7 @@ layout: ontology_detail
 id: sepio
 title: Scientific Evidence and Provenance Information Ontology
 description: An ontology for representing the provenance of scientific claims and the evidence that supports them.
-domain: experiments
-tags:
- - scientific claims, evidence
+domain: scientific claims, evidence
 homepage: https://github.com/monarch-initiative/SEPIO-ontology
 tracker: https://github.com/monarch-initiative/SEPIO-ontology/issues
 contact:

--- a/ontology/sepio.md
+++ b/ontology/sepio.md
@@ -5,7 +5,8 @@ title: Scientific Evidence and Provenance Information Ontology
 description: An ontology for representing the provenance of scientific claims and the evidence that supports them.
 domain: experiments
 tags:
-  - scientific claims, evidence
+  - scientific claims
+  - evidence
 homepage: https://github.com/monarch-initiative/SEPIO-ontology
 tracker: https://github.com/monarch-initiative/SEPIO-ontology/issues
 contact:

--- a/ontology/sibo.md
+++ b/ontology/sibo.md
@@ -6,7 +6,9 @@ contact:
   email: cjmungall@lbl.gov
   label: Chris Mungall
 description: Social Behavior in insects
-domain: behavior
+domain: biological systems
+tags:
+  - behavior
 homepage: https://github.com/obophenotype/sibo
 tracker: https://github.com/obophenotype/sibo/issues
 products:

--- a/ontology/sibo.md
+++ b/ontology/sibo.md
@@ -6,9 +6,7 @@ contact:
   email: cjmungall@lbl.gov
   label: Chris Mungall
 description: Social Behavior in insects
-domain: biological systems
-tags:
- - behavior
+domain: behavior
 homepage: https://github.com/obophenotype/sibo
 tracker: https://github.com/obophenotype/sibo/issues
 products:

--- a/ontology/sibo.md
+++ b/ontology/sibo.md
@@ -6,7 +6,9 @@ contact:
   email: cjmungall@lbl.gov
   label: Chris Mungall
 description: Social Behavior in insects
-domain: behavior
+domain: biological systems
+tags:
+ - behavior
 homepage: https://github.com/obophenotype/sibo
 tracker: https://github.com/obophenotype/sibo/issues
 products:

--- a/ontology/so.md
+++ b/ontology/so.md
@@ -10,7 +10,9 @@ license:
   url: https://creativecommons.org/licenses/by/4.0/
   label: CC BY 4.0
 description: A structured controlled vocabulary for sequence annotation, for the exchange of annotation data and for the description of sequence objects in databases.
-domain: biological sequence
+domain: biochemistry
+tags:
+ - biological sequence
 homepage: https://github.com/The-Sequence-Ontology/SO-Ontologies
 mailing_list: https://sourceforge.net/p/song/mailman/song-devel/
 page: https://en.wikipedia.org/wiki/Sequence_Ontology

--- a/ontology/so.md
+++ b/ontology/so.md
@@ -10,7 +10,9 @@ license:
   url: https://creativecommons.org/licenses/by/4.0/
   label: CC BY 4.0
 description: A structured controlled vocabulary for sequence annotation, for the exchange of annotation data and for the description of sequence objects in databases.
-domain: biological sequence
+domain: biochemistry
+tags:
+  - biological sequence
 homepage: https://github.com/The-Sequence-Ontology/SO-Ontologies
 mailing_list: https://sourceforge.net/p/song/mailman/song-devel/
 page: https://en.wikipedia.org/wiki/Sequence_Ontology

--- a/ontology/so.md
+++ b/ontology/so.md
@@ -10,9 +10,7 @@ license:
   url: https://creativecommons.org/licenses/by/4.0/
   label: CC BY 4.0
 description: A structured controlled vocabulary for sequence annotation, for the exchange of annotation data and for the description of sequence objects in databases.
-domain: biochemistry
-tags:
- - biological sequence
+domain: biological sequence
 homepage: https://github.com/The-Sequence-Ontology/SO-Ontologies
 mailing_list: https://sourceforge.net/p/song/mailman/song-devel/
 page: https://en.wikipedia.org/wiki/Sequence_Ontology

--- a/ontology/spd.md
+++ b/ontology/spd.md
@@ -10,7 +10,7 @@ license:
   url: https://creativecommons.org/licenses/by/3.0/
   label: CC BY 3.0
 description: An ontology for spider comparative biology including anatomical parts (e.g. leg, claw), behavior (e.g. courtship, combing) and products (i.g. silk, web, borrow).
-domain: anatomy
+domain: anatomy and development
 homepage: http://research.amnh.org/atol/files/
 products:
   - id: spd.owl

--- a/ontology/spd.md
+++ b/ontology/spd.md
@@ -10,7 +10,7 @@ license:
   url: https://creativecommons.org/licenses/by/3.0/
   label: CC BY 3.0
 description: An ontology for spider comparative biology including anatomical parts (e.g. leg, claw), behavior (e.g. courtship, combing) and products (i.g. silk, web, borrow).
-domain: anatomy and development
+domain: anatomy
 homepage: http://research.amnh.org/atol/files/
 products:
   - id: spd.owl

--- a/ontology/stato.md
+++ b/ontology/stato.md
@@ -9,7 +9,9 @@ contact:
   label: Alejandra Gonzalez-Beltran
   github: agbeltran
   orcid: 0000-0003-3499-8262
-domain: statistics
+domain: information technology
+tags:
+  - statistics
 homepage: http://stato-ontology.org/
 products:
   - id: stato.owl

--- a/ontology/stato.md
+++ b/ontology/stato.md
@@ -9,7 +9,9 @@ contact:
   label: Alejandra Gonzalez-Beltran
   github: agbeltran
   orcid: 0000-0003-3499-8262
-domain: statistics
+domain: information technology
+tags:
+ - statistics
 homepage: http://stato-ontology.org/
 products:
   - id: stato.owl

--- a/ontology/stato.md
+++ b/ontology/stato.md
@@ -9,9 +9,7 @@ contact:
   label: Alejandra Gonzalez-Beltran
   github: agbeltran
   orcid: 0000-0003-3499-8262
-domain: information technology
-tags:
- - statistics
+domain: statistics
 homepage: http://stato-ontology.org/
 products:
   - id: stato.owl

--- a/ontology/swo.md
+++ b/ontology/swo.md
@@ -15,7 +15,9 @@ products:
   - id: swo.owl
 title: Software ontology
 description: The Software Ontology (SWO) is a resource for describing software tools, their types, tasks, versions, provenance and associated data. It contains detailed information on licensing and formats as well as software applications themselves, mainly (but not limited) to the bioinformatics community.
-domain: software
+domain: information technology
+tags:
+  - software
 build:
   source_url: https://raw.githubusercontent.com/allysonlister/swo/master/release/swo_inferred.owl
   method: owl2obo

--- a/ontology/swo.md
+++ b/ontology/swo.md
@@ -15,9 +15,7 @@ products:
   - id: swo.owl
 title: Software ontology
 description: The Software Ontology (SWO) is a resource for describing software tools, their types, tasks, versions, provenance and associated data. It contains detailed information on licensing and formats as well as software applications themselves, mainly (but not limited) to the bioinformatics community.
-domain: information technology
-tags:
- - software
+domain: software
 build:
   source_url: https://raw.githubusercontent.com/allysonlister/swo/master/release/swo_inferred.owl
   method: owl2obo

--- a/ontology/swo.md
+++ b/ontology/swo.md
@@ -15,7 +15,9 @@ products:
   - id: swo.owl
 title: Software ontology
 description: The Software Ontology (SWO) is a resource for describing software tools, their types, tasks, versions, provenance and associated data. It contains detailed information on licensing and formats as well as software applications themselves, mainly (but not limited) to the bioinformatics community.
-domain: software
+domain: information technology
+tags:
+ - software
 build:
   source_url: https://raw.githubusercontent.com/allysonlister/swo/master/release/swo_inferred.owl
   method: owl2obo

--- a/ontology/symp.md
+++ b/ontology/symp.md
@@ -7,9 +7,7 @@ contact:
   github: lschriml
   orcid: 0000-0001-8910-9851
 description: An ontology of disease symptoms, with symptoms encompasing perceived changes in function, sensations or appearance reported by a patient indicative of a disease.
-domain: health
-tags:
- - disease
+domain: disease
 homepage: http://symptomontologywiki.igs.umaryland.edu/mediawiki/index.php/Main_Page
 products:
   - id: symp.owl

--- a/ontology/symp.md
+++ b/ontology/symp.md
@@ -7,7 +7,9 @@ contact:
   github: lschriml
   orcid: 0000-0001-8910-9851
 description: An ontology of disease symptoms, with symptoms encompasing perceived changes in function, sensations or appearance reported by a patient indicative of a disease.
-domain: disease
+domain: health
+tags:
+ - disease
 homepage: http://symptomontologywiki.igs.umaryland.edu/mediawiki/index.php/Main_Page
 products:
   - id: symp.owl

--- a/ontology/symp.md
+++ b/ontology/symp.md
@@ -7,7 +7,9 @@ contact:
   github: lschriml
   orcid: 0000-0001-8910-9851
 description: An ontology of disease symptoms, with symptoms encompasing perceived changes in function, sensations or appearance reported by a patient indicative of a disease.
-domain: disease
+domain: health
+tags:
+  - disease
 homepage: http://symptomontologywiki.igs.umaryland.edu/mediawiki/index.php/Main_Page
 products:
   - id: symp.owl

--- a/ontology/tads.md
+++ b/ontology/tads.md
@@ -8,7 +8,7 @@ license:
   url: https://creativecommons.org/licenses/by/4.0/
   label: CC BY 4.0
 description: "The anatomy of the Tick, <i>Families: Ixodidae, Argassidae</i>"
-domain: anatomy
+domain: anatomy and development
 homepage: https://www.vectorbase.org/ontology-browser
 products:
   - id: tads.owl

--- a/ontology/tads.md
+++ b/ontology/tads.md
@@ -8,7 +8,7 @@ license:
   url: https://creativecommons.org/licenses/by/4.0/
   label: CC BY 4.0
 description: "The anatomy of the Tick, <i>Families: Ixodidae, Argassidae</i>"
-domain: anatomy and development
+domain: anatomy
 homepage: https://www.vectorbase.org/ontology-browser
 products:
   - id: tads.owl

--- a/ontology/tao.md
+++ b/ontology/tao.md
@@ -6,7 +6,7 @@ contact:
   email: wasila.dahdul@usd.edu
   label: Wasila Dahdul
 description: Multispecies fish anatomy ontology. Originally seeded from ZFA, but intended to cover terms relevant to other taxa
-domain: anatomy
+domain: anatomy and development
 homepage: http://wiki.phenoscape.org/wiki/Teleost_Anatomy_Ontology
 products:
   - id: tao.owl

--- a/ontology/tao.md
+++ b/ontology/tao.md
@@ -6,7 +6,7 @@ contact:
   email: wasila.dahdul@usd.edu
   label: Wasila Dahdul
 description: Multispecies fish anatomy ontology. Originally seeded from ZFA, but intended to cover terms relevant to other taxa
-domain: anatomy and development
+domain: anatomy
 homepage: http://wiki.phenoscape.org/wiki/Teleost_Anatomy_Ontology
 products:
   - id: tao.owl

--- a/ontology/taxrank.md
+++ b/ontology/taxrank.md
@@ -7,7 +7,9 @@ contact:
   github: balhoff
   orcid: 0000-0002-8688-6599
 description: A vocabulary of taxonomic ranks (species, family, phylum, etc)
-domain: taxonomy
+domain: organisms
+tags:
+ - taxonomy
 homepage: https://github.com/phenoscape/taxrank
 products:
   - id: taxrank.owl

--- a/ontology/taxrank.md
+++ b/ontology/taxrank.md
@@ -7,7 +7,9 @@ contact:
   github: balhoff
   orcid: 0000-0002-8688-6599
 description: A vocabulary of taxonomic ranks (species, family, phylum, etc)
-domain: taxonomy
+domain: organisms
+tags:
+  - taxonomy
 homepage: https://github.com/phenoscape/taxrank
 products:
   - id: taxrank.owl

--- a/ontology/taxrank.md
+++ b/ontology/taxrank.md
@@ -7,9 +7,7 @@ contact:
   github: balhoff
   orcid: 0000-0002-8688-6599
 description: A vocabulary of taxonomic ranks (species, family, phylum, etc)
-domain: organisms
-tags:
- - taxonomy
+domain: taxonomy
 homepage: https://github.com/phenoscape/taxrank
 products:
   - id: taxrank.owl

--- a/ontology/tgma.md
+++ b/ontology/tgma.md
@@ -8,7 +8,7 @@ license:
   url: https://creativecommons.org/publicdomain/zero/1.0/
   label: CC0 1.0
 description: A structured controlled vocabulary of the anatomy of mosquitoes.
-domain: anatomy and development
+domain: anatomy
 homepage: https://www.vectorbase.org/ontology-browser
 products:
   - id: tgma.owl

--- a/ontology/tgma.md
+++ b/ontology/tgma.md
@@ -8,7 +8,7 @@ license:
   url: https://creativecommons.org/publicdomain/zero/1.0/
   label: CC0 1.0
 description: A structured controlled vocabulary of the anatomy of mosquitoes.
-domain: anatomy
+domain: anatomy and development
 homepage: https://www.vectorbase.org/ontology-browser
 products:
   - id: tgma.owl

--- a/ontology/trans.md
+++ b/ontology/trans.md
@@ -7,7 +7,9 @@ contact:
   github: lschriml
   orcid: 0000-0001-8910-9851
 description: "An ontology representing the disease transmission process during which the pathogen is transmitted directly or indirectly from its natural reservoir, a susceptible host or source to a new host."
-domain: disease
+domain: health
+tags:
+ - disease
 homepage: https://github.com/DiseaseOntology/PathogenTransmissionOntology
 products:
   - id: trans.owl

--- a/ontology/trans.md
+++ b/ontology/trans.md
@@ -7,9 +7,7 @@ contact:
   github: lschriml
   orcid: 0000-0001-8910-9851
 description: "An ontology representing the disease transmission process during which the pathogen is transmitted directly or indirectly from its natural reservoir, a susceptible host or source to a new host."
-domain: health
-tags:
- - disease
+domain: disease
 homepage: https://github.com/DiseaseOntology/PathogenTransmissionOntology
 products:
   - id: trans.owl

--- a/ontology/trans.md
+++ b/ontology/trans.md
@@ -7,7 +7,9 @@ contact:
   github: lschriml
   orcid: 0000-0001-8910-9851
 description: "An ontology representing the disease transmission process during which the pathogen is transmitted directly or indirectly from its natural reservoir, a susceptible host or source to a new host."
-domain: disease
+domain: health
+tags:
+  - disease
 homepage: https://github.com/DiseaseOntology/PathogenTransmissionOntology
 products:
   - id: trans.owl

--- a/ontology/tto.md
+++ b/ontology/tto.md
@@ -7,9 +7,7 @@ contact:
   github: balhoff
   orcid: 0000-0002-8688-6599
 description: An ontology covering the taxonomy of teleosts (bony fish)
-domain: organisms
-tags:
- - taxonomy
+domain: taxonomy
 homepage: https://github.com/phenoscape/teleost-taxonomy-ontology
 products:
   - id: tto.obo

--- a/ontology/tto.md
+++ b/ontology/tto.md
@@ -7,7 +7,9 @@ contact:
   github: balhoff
   orcid: 0000-0002-8688-6599
 description: An ontology covering the taxonomy of teleosts (bony fish)
-domain: taxonomy
+domain: organisms
+tags:
+  - taxonomy
 homepage: https://github.com/phenoscape/teleost-taxonomy-ontology
 products:
   - id: tto.obo

--- a/ontology/tto.md
+++ b/ontology/tto.md
@@ -7,7 +7,9 @@ contact:
   github: balhoff
   orcid: 0000-0002-8688-6599
 description: An ontology covering the taxonomy of teleosts (bony fish)
-domain: taxonomy
+domain: organisms
+tags:
+ - taxonomy
 homepage: https://github.com/phenoscape/teleost-taxonomy-ontology
 products:
   - id: tto.obo

--- a/ontology/txpo.md
+++ b/ontology/txpo.md
@@ -7,7 +7,9 @@ contact:
   github: yuki-yamagata
   orcid: 0000-0002-9673-1283
 description: TOXic Process Ontology (TXPO) systematizes a wide variety of terms involving toxicity courses and processes. The first version of TXPO focuses on liver toxicity.
-domain: toxicity
+domain: biochemistry
+tags:
+  - toxicity
 homepage: https://toxpilot.nibiohn.go.jp/
 tracker: https://github.com/txpo-ontology/TXPO/issues
 products:

--- a/ontology/txpo.md
+++ b/ontology/txpo.md
@@ -7,9 +7,7 @@ contact:
   github: yuki-yamagata
   orcid: 0000-0002-9673-1283
 description: TOXic Process Ontology (TXPO) systematizes a wide variety of terms involving toxicity courses and processes. The first version of TXPO focuses on liver toxicity.
-domain: biochemistry
-tags:
- - toxicity
+domain: toxicity
 homepage: https://toxpilot.nibiohn.go.jp/
 tracker: https://github.com/txpo-ontology/TXPO/issues
 products:

--- a/ontology/txpo.md
+++ b/ontology/txpo.md
@@ -7,7 +7,9 @@ contact:
   github: yuki-yamagata
   orcid: 0000-0002-9673-1283
 description: TOXic Process Ontology (TXPO) systematizes a wide variety of terms involving toxicity courses and processes. The first version of TXPO focuses on liver toxicity.
-domain: toxicity
+domain: biochemistry
+tags:
+ - toxicity
 homepage: https://toxpilot.nibiohn.go.jp/
 tracker: https://github.com/txpo-ontology/TXPO/issues
 products:

--- a/ontology/uberon.md
+++ b/ontology/uberon.md
@@ -78,7 +78,7 @@ license:
 taxon:
   id: NCBITaxon:33208
   label: Metazoa
-domain: anatomy and development
+domain: anatomy
 repository: https://github.com/obophenotype/uberon
 tracker: https://github.com/obophenotype/uberon/issues
 releases: http://purl.obolibrary.org/obo/uberon/releases/

--- a/ontology/uberon.md
+++ b/ontology/uberon.md
@@ -78,7 +78,7 @@ license:
 taxon:
   id: NCBITaxon:33208
   label: Metazoa
-domain: anatomy
+domain: anatomy and development
 repository: https://github.com/obophenotype/uberon
 tracker: https://github.com/obophenotype/uberon/issues
 releases: http://purl.obolibrary.org/obo/uberon/releases/

--- a/ontology/upa.md
+++ b/ontology/upa.md
@@ -18,7 +18,9 @@ contact:
   github: amorgat
   orcid: 0000-0002-1216-2969
 description: "A manually curated resource for the representation and annotation of metabolic pathways"
-domain: pathways
+domain: biological systems
+tags:
+ - pathways
 homepage: https://github.com/geneontology/unipathway
 products:
   - id: upa.owl

--- a/ontology/upa.md
+++ b/ontology/upa.md
@@ -18,9 +18,7 @@ contact:
   github: amorgat
   orcid: 0000-0002-1216-2969
 description: "A manually curated resource for the representation and annotation of metabolic pathways"
-domain: biological systems
-tags:
- - pathways
+domain: pathways
 homepage: https://github.com/geneontology/unipathway
 products:
   - id: upa.owl

--- a/ontology/upa.md
+++ b/ontology/upa.md
@@ -18,7 +18,9 @@ contact:
   github: amorgat
   orcid: 0000-0002-1216-2969
 description: "A manually curated resource for the representation and annotation of metabolic pathways"
-domain: pathways
+domain: biological systems
+tags:
+  - pathways
 homepage: https://github.com/geneontology/unipathway
 products:
   - id: upa.owl

--- a/ontology/vsao.md
+++ b/ontology/vsao.md
@@ -6,7 +6,7 @@ contact:
   email: wasila.dahdul@usd.edu
   label: Wasila Dahdul
 description: Vertebrate skeletal anatomy ontology.
-domain: anatomy and development
+domain: anatomy
 homepage: https://www.nescent.org/phenoscape/Main_Page
 page: https://www.phenoscape.org/wiki/Skeletal_Anatomy_Jamboree
 products:

--- a/ontology/vsao.md
+++ b/ontology/vsao.md
@@ -6,7 +6,7 @@ contact:
   email: wasila.dahdul@usd.edu
   label: Wasila Dahdul
 description: Vertebrate skeletal anatomy ontology.
-domain: anatomy
+domain: anatomy and development
 homepage: https://www.nescent.org/phenoscape/Main_Page
 page: https://www.phenoscape.org/wiki/Skeletal_Anatomy_Jamboree
 products:

--- a/ontology/wbbt.md
+++ b/ontology/wbbt.md
@@ -11,7 +11,7 @@ license:
   url: https://creativecommons.org/licenses/by/4.0/
   label: CC BY 4.0
 description: A structured controlled vocabulary of the anatomy of <i>Caenorhabditis elegans</i>.
-domain: anatomy
+domain: anatomy and development
 homepage: https://github.com/obophenotype/c-elegans-gross-anatomy-ontology
 tracker: https://github.com/obophenotype/c-elegans-gross-anatomy-ontology/issues
 products:

--- a/ontology/wbbt.md
+++ b/ontology/wbbt.md
@@ -11,7 +11,7 @@ license:
   url: https://creativecommons.org/licenses/by/4.0/
   label: CC BY 4.0
 description: A structured controlled vocabulary of the anatomy of <i>Caenorhabditis elegans</i>.
-domain: anatomy and development
+domain: anatomy
 homepage: https://github.com/obophenotype/c-elegans-gross-anatomy-ontology
 tracker: https://github.com/obophenotype/c-elegans-gross-anatomy-ontology/issues
 products:

--- a/ontology/wbls.md
+++ b/ontology/wbls.md
@@ -11,7 +11,9 @@ license:
   url: https://creativecommons.org/licenses/by/4.0/
   label: CC BY 4.0
 description: A structured controlled vocabulary of the development of <i>Caenorhabditis elegans</i>.
-domain: developemental life stage
+domain: anatomy and development
+tags:
+  - developemental life stage
 homepage: https://github.com/obophenotype/c-elegans-development-ontology
 tracker: https://github.com/obophenotype/c-elegans-development-ontology/issues
 products:

--- a/ontology/wbls.md
+++ b/ontology/wbls.md
@@ -11,9 +11,7 @@ license:
   url: https://creativecommons.org/licenses/by/4.0/
   label: CC BY 4.0
 description: A structured controlled vocabulary of the development of <i>Caenorhabditis elegans</i>.
-domain: anatomy and development
-tags:
- - developemental life stage
+domain: developemental life stage
 homepage: https://github.com/obophenotype/c-elegans-development-ontology
 tracker: https://github.com/obophenotype/c-elegans-development-ontology/issues
 products:

--- a/ontology/wbls.md
+++ b/ontology/wbls.md
@@ -11,7 +11,9 @@ license:
   url: https://creativecommons.org/licenses/by/4.0/
   label: CC BY 4.0
 description: A structured controlled vocabulary of the development of <i>Caenorhabditis elegans</i>.
-domain: developemental life stage
+domain: anatomy and development
+tags:
+ - developemental life stage
 homepage: https://github.com/obophenotype/c-elegans-development-ontology
 tracker: https://github.com/obophenotype/c-elegans-development-ontology/issues
 products:

--- a/ontology/xao.md
+++ b/ontology/xao.md
@@ -2,7 +2,7 @@
 layout: ontology_detail
 id: xao
 description: XAO represents the anatomy and development of the African frogs Xenopus laevis and tropicalis.
-domain: anatomy and development
+domain: anatomy
 homepage: http://www.xenbase.org/anatomy/xao.do?method=display
 contact:
   label: Erik Segerdell

--- a/ontology/xao.md
+++ b/ontology/xao.md
@@ -2,7 +2,7 @@
 layout: ontology_detail
 id: xao
 description: XAO represents the anatomy and development of the African frogs Xenopus laevis and tropicalis.
-domain: anatomy
+domain: anatomy and development
 homepage: http://www.xenbase.org/anatomy/xao.do?method=display
 contact:
   label: Erik Segerdell

--- a/ontology/xco.md
+++ b/ontology/xco.md
@@ -9,7 +9,9 @@ license:
   url: https://creativecommons.org/publicdomain/zero/1.0/
   label: CC0 1.0
 description: Conditions under which physiological and morphological measurements are made both in the clinic and in studies involving humans or model organisms.
-domain: clinical
+domain: health
+tags:
+ - clinical
 homepage: https://rgd.mcw.edu/rgdweb/ontology/view.html?acc_id=XCO:0000000
 tracker: https://github.com/rat-genome-database/XCO-experimental-condition-ontology/issues
 page: https://download.rgd.mcw.edu/ontology/experimental_condition/

--- a/ontology/xco.md
+++ b/ontology/xco.md
@@ -9,9 +9,7 @@ license:
   url: https://creativecommons.org/publicdomain/zero/1.0/
   label: CC0 1.0
 description: Conditions under which physiological and morphological measurements are made both in the clinic and in studies involving humans or model organisms.
-domain: health
-tags:
- - clinical
+domain: clinical
 homepage: https://rgd.mcw.edu/rgdweb/ontology/view.html?acc_id=XCO:0000000
 tracker: https://github.com/rat-genome-database/XCO-experimental-condition-ontology/issues
 page: https://download.rgd.mcw.edu/ontology/experimental_condition/

--- a/ontology/xco.md
+++ b/ontology/xco.md
@@ -9,7 +9,9 @@ license:
   url: https://creativecommons.org/publicdomain/zero/1.0/
   label: CC0 1.0
 description: Conditions under which physiological and morphological measurements are made both in the clinic and in studies involving humans or model organisms.
-domain: clinical
+domain: health
+tags:
+  - clinical
 homepage: https://rgd.mcw.edu/rgdweb/ontology/view.html?acc_id=XCO:0000000
 tracker: https://github.com/rat-genome-database/XCO-experimental-condition-ontology/issues
 page: https://download.rgd.mcw.edu/ontology/experimental_condition/

--- a/ontology/xlmod.md
+++ b/ontology/xlmod.md
@@ -9,7 +9,9 @@ contact:
   label: Lutz Fischer
   github: lutzfischer
   orcid: 0000-0003-4978-0864
-domain: MS cross-linker reagents
+domain: biochemistry
+tags:
+  - MS cross-linker reagents
 mailing_list: psidev-ms-vocab@lists.sourceforge.net
 homepage: http://www.psidev.info/groups/controlled-vocabularies
 page: http://www.psidev.info/groups/controlled-vocabularies

--- a/ontology/xlmod.md
+++ b/ontology/xlmod.md
@@ -9,7 +9,9 @@ contact:
   label: Lutz Fischer
   github: lutzfischer
   orcid: 0000-0003-4978-0864
-domain: MS cross-linker reagents
+domain: biochemistry
+tags:
+ - MS cross-linker reagents
 mailing_list: psidev-ms-vocab@lists.sourceforge.net
 homepage: http://www.psidev.info/groups/controlled-vocabularies
 page: http://www.psidev.info/groups/controlled-vocabularies

--- a/ontology/xlmod.md
+++ b/ontology/xlmod.md
@@ -9,9 +9,7 @@ contact:
   label: Lutz Fischer
   github: lutzfischer
   orcid: 0000-0003-4978-0864
-domain: biochemistry
-tags:
- - MS cross-linker reagents
+domain: MS cross-linker reagents
 mailing_list: psidev-ms-vocab@lists.sourceforge.net
 homepage: http://www.psidev.info/groups/controlled-vocabularies
 page: http://www.psidev.info/groups/controlled-vocabularies

--- a/ontology/zfa.md
+++ b/ontology/zfa.md
@@ -8,7 +8,7 @@ contact:
   github: cerivs
   orcid: 0000-0002-2244-7917
 description: A structured controlled vocabulary of the anatomy and development of the Zebrafish
-domain: anatomy and development
+domain: anatomy
 homepage: https://wiki.zfin.org/display/general/Anatomy+Atlases+and+Resources
 products:
   - id: zfa.owl

--- a/ontology/zfa.md
+++ b/ontology/zfa.md
@@ -8,7 +8,7 @@ contact:
   github: cerivs
   orcid: 0000-0002-2244-7917
 description: A structured controlled vocabulary of the anatomy and development of the Zebrafish
-domain: anatomy
+domain: anatomy and development
 homepage: https://wiki.zfin.org/display/general/Anatomy+Atlases+and+Resources
 products:
   - id: zfa.owl

--- a/ontology/zfs.md
+++ b/ontology/zfs.md
@@ -8,7 +8,7 @@ contact:
   github: cerivs
   orcid: 0000-0002-2244-7917
 description: Developmental stages of the Zebrafish
-domain: anatomy
+domain: anatomy and development
 homepage: https://wiki.zfin.org/display/general/Anatomy+Atlases+and+Resources
 page: https://github.com/obophenotype/developmental-stage-ontologies/wiki/ZFS
 tracker: https://github.com/cerivs/zebrafish-anatomical-ontology/issues

--- a/ontology/zfs.md
+++ b/ontology/zfs.md
@@ -8,7 +8,7 @@ contact:
   github: cerivs
   orcid: 0000-0002-2244-7917
 description: Developmental stages of the Zebrafish
-domain: anatomy and development
+domain: anatomy
 homepage: https://wiki.zfin.org/display/general/Anatomy+Atlases+and+Resources
 page: https://github.com/obophenotype/developmental-stage-ontologies/wiki/ZFS
 tracker: https://github.com/cerivs/zebrafish-anatomical-ontology/issues

--- a/util/schema/registry_schema.json
+++ b/util/schema/registry_schema.json
@@ -99,6 +99,22 @@
       "level": "error",
       "description": "'domain' is a mandatory field. The value is the scientific topic area addressed by the ontology.",
       "type": "string"
+      "enum": [
+        "upper",
+        "anatomy and development",
+        "health",
+        "phenotype",
+        "experiments",
+        "environment",
+        "biochemistry",
+        "microbiology",
+        "agriculture",
+        "diet, metabolomics and nutrition",
+        "biological systems",
+        "information technology",
+        "organisms",
+        "information"
+      ]
     },
     "tags": {
       "description": "'tags' is an optional field. The value is a list of strings, meant to extend 'domain' by providing more details.",

--- a/util/schema/registry_schema.json
+++ b/util/schema/registry_schema.json
@@ -96,9 +96,16 @@
       "suggest": false
     },
     "domain": {
-      "level": "warning",
-      "description": "'domain' is a recommended field. The value is the scientific topic area addressed by the ontology.",
+      "level": "error",
+      "description": "'domain' is a mandatory field. The value is the scientific topic area addressed by the ontology.",
       "type": "string"
+    },
+    "tags": {
+      "description": "'tags' is an optional field. The value is a list of strings, meant to extend 'domain' by providing more details.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
     },
     "funded_by": {
       "suggest": false

--- a/util/schema/registry_schema.json
+++ b/util/schema/registry_schema.json
@@ -113,7 +113,8 @@
         "biological systems",
         "information technology",
         "organisms",
-        "information"
+        "information",
+        "other"
       ]
     },
     "tags": {

--- a/util/schema/registry_schema.json
+++ b/util/schema/registry_schema.json
@@ -98,7 +98,7 @@
     "domain": {
       "level": "error",
       "description": "'domain' is a mandatory field. The value is the scientific topic area addressed by the ontology.",
-      "type": "string"
+      "type": "string",
       "enum": [
         "upper",
         "anatomy and development",

--- a/util/schema/registry_schema.json
+++ b/util/schema/registry_schema.json
@@ -114,7 +114,7 @@
         "information technology",
         "organisms",
         "information",
-        "other"
+        "simulation"
       ]
     },
     "tags": {

--- a/util/schema/registry_schema.json
+++ b/util/schema/registry_schema.json
@@ -104,7 +104,7 @@
         "anatomy and development",
         "health",
         "phenotype",
-        "experiments",
+        "investigations",
         "environment",
         "biochemistry",
         "microbiology",

--- a/util/schema/registry_schema.json
+++ b/util/schema/registry_schema.json
@@ -109,7 +109,7 @@
         "biochemistry",
         "microbiology",
         "agriculture",
-        "diet, metabolomics and nutrition",
+        "diet, metabolomics, and nutrition",
         "biological systems",
         "information technology",
         "organisms",


### PR DESCRIPTION
Fixes #1225 

As we are finally starting to figure out the front page display, here the harmonised domain metadata for all ontologies according to https://github.com/OBOFoundry/OBOFoundry.github.io/issues/1225.

This PR

- Harmonises all ontologies to one of 15 domains, see #1225
- Moves all the previous domains into a different metadata element (tags)
- Constraints both the `tags` and the `domain` elements in the metadata schema, making `domain` a required enum.
- This manual "rough" categorisation is only for display purposes - once we have complete alignment with COB, we may be able to do something a bit cooler for finding ontologies, but this will likely by orthogonal.