### PR TITLE
Standardize publication references to PubMed

### DIFF
--- a/ontology/bspo.md
+++ b/ontology/bspo.md
@@ -24,7 +24,7 @@ build:
   infallible: 1
 tracker: https://github.com/obophenotype/biological-spatial-ontology/issues
 publications:
-  - id: http://www.ncbi.nlm.nih.gov/pubmed/25140222
+  - id: https://www.ncbi.nlm.nih.gov/pubmed/25140222
     title: "Nose to tail, roots to shoots: spatial descriptors for phenotypic diversity in the Biological Spatial Ontology."
 activity_status: active
 repository: https://github.com/obophenotype/biological-spatial-ontology

--- a/ontology/chebi.md
+++ b/ontology/chebi.md
@@ -24,7 +24,7 @@ homepage: http://www.ebi.ac.uk/chebi
 page: http://www.ebi.ac.uk/chebi/init.do?toolBarForward=userManual
 depicted_by: https://www.ebi.ac.uk/chebi/images/ChEBI_logo.png
 publications:
-  - id: http://europepmc.org/article/MED/26467479
+  - id: https://www.ncbi.nlm.nih.gov/pubmed/26467479
     title: "ChEBI in 2016: Improved services and an expanding collection of metabolites."
 browsers:
   - label: CHEBI

--- a/ontology/cl.md
+++ b/ontology/cl.md
@@ -66,7 +66,7 @@ usages:
     type: annotation
     description: The National Human Genome Research Institute (NHGRI) launched a public research consortium named ENCODE, the Encyclopedia Of DNA Elements, in September 2003, to carry out a project to identify all functional elements in the human genome sequence. The ENCODE DCC users Uberon to annotate samples
     publications:
-      - id: https://doi.org/10.1093/database/bav010
+      - id: https://www.ncbi.nlm.nih.gov/pubmed/25776021
         title: "Ontology application and use at the ENCODE DCC"
   - user: http://fantom5-collaboration.gsc.riken.jp/
     type: annotation

--- a/ontology/cmo.md
+++ b/ontology/cmo.md
@@ -24,9 +24,9 @@ build:
   source_url: https://download.rgd.mcw.edu/ontology/clinical_measurement/clinical_measurement.obo
   method: obo2owl
 publications:
-  - id: http://www.ncbi.nlm.nih.gov/pubmed/22654893
+  - id: https://www.ncbi.nlm.nih.gov/pubmed/22654893
     title: "Three ontologies to define phenotype measurement data."
-  - id: http://www.ncbi.nlm.nih.gov/pubmed/24103152
+  - id: https://www.ncbi.nlm.nih.gov/pubmed/24103152
     title: "The clinical measurement, measurement method and experimental condition ontologies: expansion, improvements and new applications."
 browsers:
   - label: RGD

--- a/ontology/dinto.md
+++ b/ontology/dinto.md
@@ -15,7 +15,7 @@ license:
   url: https://creativecommons.org/licenses/by/3.0/
   label: CC BY 3.0
 publications:
-  - id: http://pubs.acs.org/doi/10.1021/acs.jcim.5b00119
+  - id: https://www.ncbi.nlm.nih.gov/pubmed/26147071
     title: "DINTO: Using OWL Ontologies and SWRL Rules to Infer Drug–Drug Interactions and Their Mechanisms."
 activity_status: inactive
 is_obsolete: true

--- a/ontology/doid.md
+++ b/ontology/doid.md
@@ -38,7 +38,7 @@ build:
   infallible: 1
 tracker: https://github.com/DiseaseOntology/HumanDiseaseOntology/issues
 publications:
-  - id: http://www.ncbi.nlm.nih.gov/pubmed/?term=25348409
+  - id: https://www.ncbi.nlm.nih.gov/pubmed/25348409
     title: "Disease Ontology 2015 update: an expanded and updated database of human diseases for linking biomedical knowledge through disease data"
 license:
   url: https://creativecommons.org/publicdomain/zero/1.0/

--- a/ontology/dpo.md
+++ b/ontology/dpo.md
@@ -31,7 +31,7 @@ browsers:
     title: FlyBase Browser
     url: http://flybase.org/.bin/cvreport.html?cvterm=FBcv:0000347
 publications:
-  - id: https://doi.org/10.1186/2041-1480-4-30
+  - id: https://www.ncbi.nlm.nih.gov/pubmed/24138933
     title: "The Drosophila phenotype ontology."
 usages:
   - user: http://flybase.org

--- a/ontology/eco.md
+++ b/ontology/eco.md
@@ -23,9 +23,9 @@ contact:
   github: mgiglio99
   orcid: 0000-0001-7628-5565
 publications:
-  - id: http://www.ncbi.nlm.nih.gov/pubmed/30407590
+  - id: https://www.ncbi.nlm.nih.gov/pubmed/30407590
     title: "ECO, the Evidence & Conclusion Ontology: community standard for evidence information."
-  - id: http://www.ncbi.nlm.nih.gov/pubmed/25052702
+  - id: https://www.ncbi.nlm.nih.gov/pubmed/25052702
     title: "Standardized description of scientific evidence using the Evidence Ontology (ECO)"
 license:
   url: https://creativecommons.org/publicdomain/zero/1.0/

--- a/ontology/eco.md
+++ b/ontology/eco.md
@@ -46,7 +46,7 @@ usages:
       - url: https://monarchinitiative.org/phenotype/HP%3A0001300#disease
         description: "Parkinsonism: Characteristic neurologic anomaly resulting form degeneration of dopamine-generating cells in the substantia nigra, a region of the midbrain, characterized clinically by shaking, rigidity, slowness of movement and difficulty with walking and gait."
     publications:
-      - id: https://academic.oup.com/nar/article/45/D1/D712/2605791
+      - id: https://www.ncbi.nlm.nih.gov/pubmed/27899636
         title: "The Monarch Initiative: an integrative data and analytic platform connecting phenotypes to genotypes across species"
 activity_status: active
 repository: https://github.com/evidenceontology/evidenceontology

--- a/ontology/ehdaa2.md
+++ b/ontology/ehdaa2.md
@@ -24,7 +24,7 @@ build:
   path: src/ontology
   method: vcs
 publications:
-  - id: http://www.ncbi.nlm.nih.gov/pubmed/22973865
+  - id: https://www.ncbi.nlm.nih.gov/pubmed/22973865
     title: "A new ontology (structured hierarchy) of human developmental anatomy for the first 7 weeks (Carnegie stages 1-20)."
 dependencies:
   - id: aeo

--- a/ontology/envo.md
+++ b/ontology/envo.md
@@ -14,9 +14,9 @@ license:
   url: http://creativecommons.org/licenses/by/3.0/
   label: CC BY 3.0
 publications:
-  - id: http://www.dx.doi.org/10.1186/2041-1480-4-43
+  - id: https://www.ncbi.nlm.nih.gov/pubmed/24330602
     title: "The environment ontology: contextualising biological and biomedical entities"
-  - id: https://doi.org/10.1186/s13326-016-0097-6
+  - id: https://www.ncbi.nlm.nih.gov/pubmed/27664130
     title: "The environment ontology in 2016: bridging domains with increased scope, semantic density, and interoperation"
 products:
   - id: envo.owl

--- a/ontology/eo.md
+++ b/ontology/eo.md
@@ -24,7 +24,7 @@ license:
 is_obsolete: true
 replaced_by: peco
 publications:
-  - id: http://www.ncbi.nlm.nih.gov/pubmed/22847540
+  - id: https://www.ncbi.nlm.nih.gov/pubmed/22847540
     title: "Ontologies as integrative tools for plant science."
 usages:
   - user: http://planteome.org/

--- a/ontology/fbbt.md
+++ b/ontology/fbbt.md
@@ -42,13 +42,13 @@ browsers:
     title: BioPortal Browser
     url: http://bioportal.bioontology.org/ontologies/FB-BT?p=classes
 publications:
-  - id: https://doi.org/10.1186/2041-1480-4-32
+  - id: https://www.ncbi.nlm.nih.gov/pubmed/24138933
     title: "The Drosophila anatomy ontology. [Journal of Biomedical Semantics"
-  - id: https://doi.org/10.1093/bioinformatics/bts113
+  - id: https://www.ncbi.nlm.nih.gov/pubmed/22402613
     title: "A strategy for building neuroanatomy ontologies"
-  - id: https://doi.org/10.1093/bioinformatics/btr677
+  - id: https://www.ncbi.nlm.nih.gov/pubmed/22180411
     title: "The Virtual Fly Brain Browser and Query Interface"
-  - id: https://doi.org/10.1093/nar/gkj068
+  - id: https://www.ncbi.nlm.nih.gov/pubmed/16381917
     title: "FlyBase: anatomical data, images and queries"
 usages:
   - user: http://www.virtualflybrain.org/

--- a/ontology/fma.md
+++ b/ontology/fma.md
@@ -12,11 +12,11 @@ domain: anatomy and development
 homepage: http://si.washington.edu/projects/fma
 page: http://en.wikipedia.org/wiki/Foundational_Model_of_Anatomy
 publications:
-  - id: http://www.ncbi.nlm.nih.gov/pubmed/18688289
+  - id: https://www.ncbi.nlm.nih.gov/pubmed/18688289
     title: Translating the Foundational Model of Anatomy into OWL
-  - id: http://www.ncbi.nlm.nih.gov/pubmed/18360535
+  - id: https://www.ncbi.nlm.nih.gov/pubmed/18360535
     title: "The foundational model of anatomy in OWL: Experience and perspectives"
-  - id: http://www.ncbi.nlm.nih.gov/pubmed/16779026
+  - id: https://www.ncbi.nlm.nih.gov/pubmed/16779026
     title: "Challenges in converting frame-based ontology into OWL: the Foundational Model of Anatomy case-study"
 products:
   - id: fma.owl

--- a/ontology/fypo.md
+++ b/ontology/fypo.md
@@ -22,7 +22,7 @@ taxon:
   label: S. pombe
 tracker: https://github.com/pombase/fypo/issues
 publications:
-  - id: http://www.ncbi.nlm.nih.gov/pubmed/23658422
+  - id: https://www.ncbi.nlm.nih.gov/pubmed/23658422
     title: "FYPO: The Fission Yeast Phenotype Ontology."
 license:
   url: http://creativecommons.org/licenses/by/4.0/

--- a/ontology/hp.md
+++ b/ontology/hp.md
@@ -38,13 +38,13 @@ browsers:
     title: Monarch Phenotype Page
     url: http://monarchinitiative.org/phenotype/HP:0000118
 publications:
-  - id: http://www.ncbi.nlm.nih.gov/pubmed/18950739
+  - id: https://www.ncbi.nlm.nih.gov/pubmed/18950739
     title: "The Human Phenotype Ontology: a tool for annotating and analyzing human hereditary disease."
-  - id: http://www.ncbi.nlm.nih.gov/pubmed/26119816
+  - id: https://www.ncbi.nlm.nih.gov/pubmed/26119816
     title: "The Human Phenotype Ontology: Semantic Unification of Common and Rare Disease."
-  - id: http://www.ncbi.nlm.nih.gov/pubmed/24217912
+  - id: https://www.ncbi.nlm.nih.gov/pubmed/24217912
     title: "The Human Phenotype Ontology project: linking molecular biology and disease through phenotype data."
-  - id: http://www.ncbi.nlm.nih.gov/pubmed/30476213
+  - id: https://www.ncbi.nlm.nih.gov/pubmed/30476213
     title: "Expansion of the Human Phenotype Ontology (HPO) knowledge base and resources."
 usages:
   - user: https://monarchinitiative.org/

--- a/ontology/mmo.md
+++ b/ontology/mmo.md
@@ -24,9 +24,9 @@ build:
   source_url: https://download.rgd.mcw.edu/ontology/measurement_method/measurement_method.obo
   method: obo2owl
 publications:
-  - id: http://www.ncbi.nlm.nih.gov/pubmed/22654893
+  - id: https://www.ncbi.nlm.nih.gov/pubmed/22654893
     title: "Three ontologies to define phenotype measurement data."
-  - id: http://www.ncbi.nlm.nih.gov/pubmed/24103152
+  - id: https://www.ncbi.nlm.nih.gov/pubmed/24103152
     title: "The clinical measurement, measurement method and experimental condition ontologies: expansion, improvements and new applications."
 browsers:
   - label: RGD

--- a/ontology/mod.md
+++ b/ontology/mod.md
@@ -10,7 +10,7 @@ license:
   url: https://creativecommons.org/licenses/by/4.0/
   label: CC BY 4.0
 publications:
-  - id: https://pubmed.ncbi.nlm.nih.gov/18688235/
+  - id: https://www.ncbi.nlm.nih.gov/pubmed/18688235
     title: "The PSI-MOD community standard for representation of protein modification data"
 description: PSI-MOD is an ontology consisting of terms that describe protein chemical modifications
 domain: biochemistry

--- a/ontology/mondo.md
+++ b/ontology/mondo.md
@@ -51,7 +51,7 @@ usages:
       - url: https://monarchinitiative.org/phenotype/HP:0001300#disease
         description: "Parkinsonism: Characteristic neurologic anomaly resulting form degeneration of dopamine-generating cells in the substantia nigra, a region of the midbrain, characterized clinically by shaking, rigidity, slowness of movement and difficulty with walking and gait."
     publications:
-      - id: https://academic.oup.com/nar/article/45/D1/D712/2605791
+      - id: https://www.ncbi.nlm.nih.gov/pubmed/27899636
         title: "The Monarch Initiative: an integrative data and analytic platform connecting phenotypes to genotypes across species "
   - user: https://www.clinicalgenome.org/
     type: annotation

--- a/ontology/mro.md
+++ b/ontology/mro.md
@@ -26,7 +26,7 @@ usages:
       - url: https://www.iedb.org/assay/1357035
         description: "Epitope ID: 59611 based on reference 1003499"
     publications:
-      - id: https://doi.org/10.1093/nar/gky1006
+      - id: https://www.ncbi.nlm.nih.gov/pubmed/30357391
         title: "The Immune Epitope Database (IEDB): 2018 update"
 activity_status: active
 repository: https://github.com/IEDB/MRO

--- a/ontology/ms.md
+++ b/ontology/ms.md
@@ -21,7 +21,7 @@ dependencies:
   - id: pato
   - id: uo
 publications:
-  - id: http://www.ncbi.nlm.nih.gov/pubmed/23482073
+  - id: https://www.ncbi.nlm.nih.gov/pubmed/23482073
     title: "The HUPO proteomics standards initiative- mass spectrometry controlled vocabulary."
 products:
   - id: ms.obo

--- a/ontology/pato.md
+++ b/ontology/pato.md
@@ -43,7 +43,7 @@ usages:
       - url: https://www.ebi.ac.uk/ols/ontologies/hp/terms?iri=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FHP_0011017&viewMode=All&siblings=false
         description: An abnormality in a cellular process.
     publications:
-      - id: https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6324074/
+      - id: https://www.ncbi.nlm.nih.gov/pubmed/30476213
         title: "Expansion of the Human Phenotype Ontology (HPO) knowledge base and resources"
 activity_status: active
 preferredPrefix: PATO

--- a/ontology/peco.md
+++ b/ontology/peco.md
@@ -21,7 +21,7 @@ license:
   url: https://creativecommons.org/licenses/by/4.0/
   label: CC BY 4.0
 publications:
-  - id: https://doi.org/10.1093/nar/gkx1152
+  - id: https://www.ncbi.nlm.nih.gov/pubmed/29186578
     title: "The Planteome database: an integrated resource for reference ontologies, plant genomics and phenomics."
 activity_status: active
 repository: https://github.com/Planteome/plant-experimental-conditions-ontology

--- a/ontology/po.md
+++ b/ontology/po.md
@@ -28,9 +28,9 @@ page: https://github.com/Planteome/plant-ontology
 twitter: planteome
 tracker: https://github.com/Planteome/plant-ontology/issues
 publications:
-  - id: http://www.ncbi.nlm.nih.gov/pubmed/23220694
+  - id: https://www.ncbi.nlm.nih.gov/pubmed/23220694
     title: "The plant ontology as a tool for comparative plant anatomy and genomic analyses."
-  - id: https://doi.org/10.1093/nar/gkx1152
+  - id: https://www.ncbi.nlm.nih.gov/pubmed/29186578
     title: "The Planteome database: an integrated resource for reference ontologies, plant genomics and phenomics."
 products:
   - id: po.owl

--- a/ontology/poro.md
+++ b/ontology/poro.md
@@ -20,7 +20,7 @@ license:
   label: CC BY 3.0
 title: Porifera Ontology
 publications:
-  - id: https://doi.org/10.1186/2041-1480-5-39
+  - id: https://www.ncbi.nlm.nih.gov/pubmed/25276334
     title: "The Porifera Ontology (PORO): enhancing sponge systematics with an anatomy ontology"
 dependencies:
   - id: uberon

--- a/ontology/pr.md
+++ b/ontology/pr.md
@@ -42,8 +42,8 @@ build:
   infallible: 0
 tracker: https://github.com/PROconsortium/PRoteinOntology/issues
 publications:
-  - id: https://proconsortium.org/pro_dsmnt.shtml#publication
-    title: "Publications & Dissemination"
+  - id: https://www.ncbi.nlm.nih.gov/pubmed/27899649
+    title: "Protein Ontology (PRO): enhancing and scaling up the representation of protein entities"
 usages:
   - user: https://github.com/UCDenver-ccp/CRAFT
     description: Colorado Richly Annotated Full-Text (CRAFT) Corpus; PRO is used for entity tagging and annotation

--- a/ontology/pw.md
+++ b/ontology/pw.md
@@ -24,9 +24,9 @@ build:
   source_url: https://download.rgd.mcw.edu/ontology/pathway/pathway.obo
   method: obo2owl
 publications:
-  - id: http://www.ncbi.nlm.nih.gov/pubmed/21478484
+  - id: https://www.ncbi.nlm.nih.gov/pubmed/21478484
     title: "The Rat Genome Database pathway portal."
-  - id: http://www.ncbi.nlm.nih.gov/pubmed/24499703
+  - id: https://www.ncbi.nlm.nih.gov/pubmed/24499703
     title: "The pathway ontology - updates and applications."
 browsers:
   - label: RGD

--- a/ontology/ro.md
+++ b/ontology/ro.md
@@ -58,7 +58,7 @@ usages:
     type: annotation
     description: RO is used for annotation extensions in the GO and GO Causal Activity Models.
     publications:
-      - id: https://doi.org/10.1186/1471-2105-15-155
+      - id: https://www.ncbi.nlm.nih.gov/pubmed/24885854
         title: "A method for increasing expressivity of Gene Ontology annotations using a compositional approach"
     examples:
       - url: http://model.geneontology.org/56d1143000003402

--- a/ontology/rs.md
+++ b/ontology/rs.md
@@ -14,7 +14,7 @@ homepage: http://rgd.mcw.edu/rgdweb/search/strains.html
 tracker: https://github.com/rat-genome-database/RS-Rat-Strain-Ontology/issues
 page: https://download.rgd.mcw.edu/ontology/rat_strain/
 publications:
-  - id: http://www.ncbi.nlm.nih.gov/pubmed/24267899
+  - id: https://www.ncbi.nlm.nih.gov/pubmed/24267899
     title: "Rat Strain Ontology: structured controlled vocabulary designed to facilitate access to strain data at RGD."
 browsers:
   - label: RGD

--- a/ontology/so.md
+++ b/ontology/so.md
@@ -34,9 +34,9 @@ build:
   method: obo2owl
 tracker: https://github.com/The-Sequence-Ontology/SO-Ontologies/issues
 publications:
-  - id: http://www.ncbi.nlm.nih.gov/pubmed/15892872
+  - id: https://www.ncbi.nlm.nih.gov/pubmed/15892872
     title: "The Sequence Ontology: a tool for the unification of genome annotations."
-  - id: http://www.ncbi.nlm.nih.gov/pubmed/20226267
+  - id: https://www.ncbi.nlm.nih.gov/pubmed/20226267
     title: Evolution of the Sequence Ontology terms and relationships.
 depicted_by: http://sequenceontology.org/img/so_icon.png
 activity_status: active

--- a/ontology/to.md
+++ b/ontology/to.md
@@ -35,7 +35,7 @@ build:
   infallible: 1
 tracker: https://github.com/Planteome/plant-trait-ontology/issues
 publications:
-  - id: https://doi.org/10.1093/nar/gkx1152
+  - id: https://www.ncbi.nlm.nih.gov/pubmed/29186578
     title: "The Planteome database: an integrated resource for reference ontologies, plant genomics and phenomics."
 usages:
   - user: http://planteome.org/

--- a/ontology/uberon.md
+++ b/ontology/uberon.md
@@ -88,9 +88,9 @@ contact:
   github: cmungall
   orcid: 0000-0002-6601-2165
 publications:
-  - id: http://www.ncbi.nlm.nih.gov/pubmed/22293552
+  - id: https://www.ncbi.nlm.nih.gov/pubmed/22293552
     title: "Uberon, an integrative multi-species anatomy ontology"
-  - id: http://www.ncbi.nlm.nih.gov/pubmed/25009735
+  - id: https://www.ncbi.nlm.nih.gov/pubmed/25009735
     title: "Unification of multi-species vertebrate anatomy ontologies for comparative biology in Uberon"
 depicted_by: http://uberon.github.io/images/u-logo.jpg
 dependencies:

--- a/ontology/uberon.md
+++ b/ontology/uberon.md
@@ -29,7 +29,7 @@ usages:
     type: annotation
     description: The National Human Genome Research Institute (NHGRI) launched a public research consortium named ENCODE, the Encyclopedia Of DNA Elements, in September 2003, to carry out a project to identify all functional elements in the human genome sequence. The ENCODE DCC users Uberon to annotate samples
     publications:
-      - id: https://doi.org/10.1093/database/bav010
+      - id: https://www.ncbi.nlm.nih.gov/pubmed/25776021
         title: "Ontology application and use at the ENCODE DCC"
   - user: http://fantom5-collaboration.gsc.riken.jp/
     type: annotation
@@ -57,14 +57,14 @@ usages:
   - user: http://single-cell.clst.riken.jp/
     description: SCPortalen
     publications:
-      - id: https://doi.org/10.1093/nar/gkx949
+      - id: https://www.ncbi.nlm.nih.gov/pubmed/29045713
         title: "SCPortalen: human and mouse single-cell centric database"
     type: Database
   - user: https://www.ebi.ac.uk/chembl/
     description: "ChEMBL uses Uberon to describe organ/tissue information in assays"
     type: Database
     publications:
-      - id: https://doi.org/10.1093/nar/gky1075
+      - id: https://www.ncbi.nlm.nih.gov/pubmed/30398643
         title: "ChEMBL: towards direct deposition of bioassay data"
 funded_by:
   - "NIH R24OD011883"

--- a/ontology/upa.md
+++ b/ontology/upa.md
@@ -10,7 +10,7 @@ build:
   system: git
   path: "."
 publications:
-  - id: http://www.ncbi.nlm.nih.gov/pubmed/22102589
+  - id: https://www.ncbi.nlm.nih.gov/pubmed/22102589
     title: "UniPathway: a resource for the exploration and annotation of metabolic pathways"
 contact:
   email: "Anne.Morgat@sib.swiss"

--- a/ontology/upheno.md
+++ b/ontology/upheno.md
@@ -35,7 +35,7 @@ usages:
       - url: https://monarchinitiative.org/phenotype/HP:0001300#disease
         description: "Characteristic neurologic anomaly resulting form degeneration of dopamine-generating cells in the substantia nigra, a region of the midbrain, characterized clinically by shaking, rigidity, slowness of movement and difficulty with walking and gait."
     publications:
-      - id: https://academic.oup.com/nar/article/45/D1/D712/2605791
+      - id: https://www.ncbi.nlm.nih.gov/pubmed/27899636
         title: "The Monarch Initiative: an integrative data and analytic platform connecting phenotypes to genotypes across species "
 build:
   source_url: http://build.berkeleybop.org/job/build-pheno-ontologies/lastSuccessfulBuild/artifact/*zip*/archive.zip

--- a/ontology/wbbt.md
+++ b/ontology/wbbt.md
@@ -36,7 +36,7 @@ usages:
       - url: http://www.wormbase.org/db/get?name=WBGene00000912;class=Gene;widget=expression
         description: "Expression for gene daf-16 with WormBase ID WBGene00000912"
     publications:
-      - id: https://academic.oup.com/nar/article/48/D1/D762/5603222
+      - id: https://www.ncbi.nlm.nih.gov/pubmed/31642470
         title: "WormBase: a modern Model Organism Information Resource"
 activity_status: active
 repository: https://github.com/obophenotype/c-elegans-gross-anatomy-ontology

--- a/ontology/wbbt.md
+++ b/ontology/wbbt.md
@@ -26,7 +26,7 @@ build:
   system: git
   path: "."
 publications:
-  - id: https://pubmed.ncbi.nlm.nih.gov/18629098/
+  - id: https://www.ncbi.nlm.nih.gov/pubmed/18629098
     title: "Building a cell and anatomy ontology of Caenorhabditis elegans"
 usages:
   - user: https://www.wormbase.org/

--- a/ontology/wbls.md
+++ b/ontology/wbls.md
@@ -38,7 +38,7 @@ usages:
       - url: http://www.wormbase.org/db/get?name=WBGene00000912;class=Gene;widget=expression
         description: Expression for daf-16 gene with WormBase ID WBGene00000912.
     publications:
-      - id: https://academic.oup.com/nar/article/48/D1/D762/5603222
+      - id: https://www.ncbi.nlm.nih.gov/pubmed/31642470
         title: "WormBase: a modern Model Organism Information Resource"
 activity_status: active
 repository: https://github.com/obophenotype/c-elegans-development-ontology

--- a/ontology/wbls.md
+++ b/ontology/wbls.md
@@ -28,7 +28,7 @@ build:
   system: git
   path: "."
 publications:
-  - id: https://academic.oup.com/nar/article/48/D1/D762/5603222
+  - id: https://www.ncbi.nlm.nih.gov/pubmed/31642470
     title: "WormBase: a modern Model Organism Information Resource"
 usages:
   - user: https://www.wormbase.org/

--- a/ontology/wbphenotype.md
+++ b/ontology/wbphenotype.md
@@ -37,7 +37,7 @@ usages:
       - url: http://www.wormbase.org/db/get?name=WBGene00000912;class=Gene;widget=expression
         description: Expression for daf-16 gene with WormBase ID WBGene00000912.
     publications:
-      - id: https://academic.oup.com/nar/article/48/D1/D762/5603222
+      - id: https://www.ncbi.nlm.nih.gov/pubmed/31642470
         title: "WormBase: a modern Model Organism Information Resource"
   - user: https://monarchinitiative.org/
     type: annotation
@@ -46,7 +46,7 @@ usages:
       - url: https://monarchinitiative.org/phenotype/WBPhenotype%3A0000370
         description: "Egg long: The fertilized oocytes have a greater than standard length measured end to end compared to control."
     publications:
-      - id: https://academic.oup.com/nar/article/45/D1/D712/2605791
+      - id: https://www.ncbi.nlm.nih.gov/pubmed/27899636
         title: "The Monarch Initiative: an integrative data and analytic platform connecting phenotypes to genotypes across species "
 activity_status: active
 repository: https://github.com/obophenotype/c-elegans-phenotype-ontology

--- a/ontology/wbphenotype.md
+++ b/ontology/wbphenotype.md
@@ -27,7 +27,7 @@ build:
   system: git
   path: "."
 publications:
-  - id: http://www.ncbi.nlm.nih.gov/pubmed/?term=21261995
+  - id: https://www.ncbi.nlm.nih.gov/pubmed/21261995
     title: "Worm Phenotype Ontology: integrating phenotype data within and beyond the C. elegans community."
 usages:
   - user: https://www.wormbase.org/

--- a/ontology/xao.md
+++ b/ontology/xao.md
@@ -25,9 +25,9 @@ build:
   infallible: 0
 tracker: https://github.com/xenopus-anatomy/xao/issues
 publications:
-  - id: http://www.ncbi.nlm.nih.gov/pubmed/18817563
+  - id: https://www.ncbi.nlm.nih.gov/pubmed/18817563
     title: "An ontology for Xenopus anatomy and development."
-  - id: http://www.ncbi.nlm.nih.gov/pubmed/24139024
+  - id: https://www.ncbi.nlm.nih.gov/pubmed/24139024
     title: "Enhanced XAO: the ontology of Xenopus anatomy and development underpins more accurate annotation of gene expression and queries on Xenbase."
 usages:
   - user: http://www.xenbase.org

--- a/ontology/xco.md
+++ b/ontology/xco.md
@@ -24,9 +24,9 @@ build:
   source_url: https://download.rgd.mcw.edu/ontology/experimental_condition/experimental_condition.obo
   method: obo2owl
 publications:
-  - id: http://www.ncbi.nlm.nih.gov/pubmed/22654893
+  - id: https://www.ncbi.nlm.nih.gov/pubmed/22654893
     title: "Three ontologies to define phenotype measurement data."
-  - id: http://www.ncbi.nlm.nih.gov/pubmed/24103152
+  - id: https://www.ncbi.nlm.nih.gov/pubmed/24103152
     title: "The clinical measurement, measurement method and experimental condition ontologies: expansion, improvements and new applications."
 browsers:
   - label: RGD

--- a/ontology/zfa.md
+++ b/ontology/zfa.md
@@ -29,7 +29,7 @@ build:
   infallible: 1
 tracker: https://github.com/cerivs/zebrafish-anatomical-ontology/issues
 publications:
-  - id: http://www.ncbi.nlm.nih.gov/pubmed/24568621
+  - id: https://www.ncbi.nlm.nih.gov/pubmed/24568621
     title: "The zebrafish anatomy and stage ontologies: representing the anatomy and development of Danio rerio."
 usages:
   - user: http://zfin.org

--- a/ontology/zp.md
+++ b/ontology/zp.md
@@ -40,7 +40,7 @@ usages:
       - url: https://monarchinitiative.org/phenotype/ZP:0005692
         description: "adaxial cell absent, abnormal: Abnormal(ly) absent (of) adaxial cell."
     publications:
-      - id: https://academic.oup.com/nar/article/45/D1/D712/2605791
+      - id: https://www.ncbi.nlm.nih.gov/pubmed/27899636
         title: "The Monarch Initiative: an integrative data and analytic platform connecting phenotypes to genotypes across species"
 activity_status: active
 repository: https://github.com/obophenotype/zebrafish-phenotype-ontology

--- a/tests/test_integrity.py
+++ b/tests/test_integrity.py
@@ -57,10 +57,6 @@ class TestIntegrity(unittest.TestCase):
 
     def test_publications(self):
         """Test publications information."""
-        valid_prefixes = [
-            "https://www.ncbi.nlm.nih.gov/pubmed/",
-            "https://doi.org/",
-        ]
         for ontology, data in sorted(self.ontologies.items()):
             for i, publication in enumerate(data.get("publications", [])):
                 identifier = publication["id"]
@@ -75,10 +71,7 @@ class TestIntegrity(unittest.TestCase):
                     self.assertIsInstance(identifier, str)
                     self.assertFalse(identifier.endswith("/"))
                     self.assertTrue(
-                        any(
-                            identifier.startswith(valid_prefix)
-                            for valid_prefix in valid_prefixes
-                        ),
+                        identifier.startswith("https://www.ncbi.nlm.nih.gov/pubmed/"),
                         msg=f"{ontology} publication {i} has unexpected identifier: {identifier}",
                     )
 

--- a/tests/test_integrity.py
+++ b/tests/test_integrity.py
@@ -9,6 +9,8 @@ HERE = Path(__file__).parent.resolve()
 ROOT = HERE.parent
 ONTOLOGY_DIRECTORY = ROOT.joinpath("ontology").resolve()
 
+uri_prefix = "https://www.ncbi.nlm.nih.gov/pubmed/"
+
 
 def get_data():
     """Get ontology data."""
@@ -56,7 +58,6 @@ class TestIntegrity(unittest.TestCase):
 
     def test_publications(self):
         """Test publications information."""
-        uri_prefix = "https://www.ncbi.nlm.nih.gov/pubmed/"
         for ontology, data in sorted(self.ontologies.items()):
             for i, publication in enumerate(data.get("publications", [])):
                 identifier = publication["id"]
@@ -67,11 +68,26 @@ class TestIntegrity(unittest.TestCase):
                     continue
 
                 with self.subTest(ontology=ontology, id=identifier):
-                    self.assertIn("title", publication)
-                    self.assertIsInstance(identifier, str)
-                    self.assertFalse(identifier.endswith("/"))
-                    self.assertTrue(
-                        identifier.startswith(uri_prefix),
+                    self.assert_valid_publication_id(
+                        publication,
                         msg=f"{ontology} publication {i} has unexpected identifier: {identifier}",
                     )
-                    self.assertTrue(identifier[len(uri_prefix):].isnumeric())
+
+            for i, usage in enumerate(data.get("usages", [])):
+                for j, publication in enumerate(usage.get("publications", [])):
+                    self.assertIn("user", usage, msg=f"Malformed usage missing a user in {ontology}")
+                    with self.subTest(ontology=ontology, user=usage["user"], id=publication["id"]):
+                        self.assert_valid_publication_id(
+                            publication,
+                            msg=f"{ontology} usage {i} publication {j} has unexpected identifier: {publication['id']}",
+                        )
+
+    def assert_valid_publication_id(self, publication, msg=None):
+        """Assert that the publication is annotated properly."""
+        self.assertIn("title", publication)
+        self.assertIn("id", publication)
+        identifier = publication["id"]
+        self.assertIsInstance(identifier, str)
+        self.assertFalse(identifier.endswith("/"))
+        self.assertTrue(identifier.startswith(uri_prefix), msg=msg)
+        self.assertTrue(identifier[len(uri_prefix):].isnumeric())

--- a/tests/test_integrity.py
+++ b/tests/test_integrity.py
@@ -3,7 +3,6 @@
 import unittest
 from pathlib import Path
 
-import citation_url
 import yaml
 
 HERE = Path(__file__).parent.resolve()
@@ -57,6 +56,7 @@ class TestIntegrity(unittest.TestCase):
 
     def test_publications(self):
         """Test publications information."""
+        uri_prefix = "https://www.ncbi.nlm.nih.gov/pubmed/"
         for ontology, data in sorted(self.ontologies.items()):
             for i, publication in enumerate(data.get("publications", [])):
                 identifier = publication["id"]
@@ -71,9 +71,7 @@ class TestIntegrity(unittest.TestCase):
                     self.assertIsInstance(identifier, str)
                     self.assertFalse(identifier.endswith("/"))
                     self.assertTrue(
-                        identifier.startswith("https://www.ncbi.nlm.nih.gov/pubmed/"),
+                        identifier.startswith(uri_prefix),
                         msg=f"{ontology} publication {i} has unexpected identifier: {identifier}",
                     )
-
-                    result = citation_url.parse(identifier)
-                    self.assertEqual(citation_url.Status.success, result.status)
+                    self.assertTrue(identifier[len(uri_prefix):].isnumeric())


### PR DESCRIPTION
This pull request standardizes all references to use a PubMed URL in the `publications` and `usages` entries for each ontology. This process resolved a few publisher-specific URLs, found associated PubMed identifiers for DOIs, added https when http was used, and cleaned up various other bits of garbage in URLs.

This PR adds a corresponding unit test to make sure all future publications use this standardized format.

A single exception is made for AGRO, whose reference is to an old BioCreative proceedings which was never assigned a DOI.

Looking forward, it might be a good idea to more carefully annotate these fields using `pubmed` then to have an additional script to bring in full metadata for the publications for display on the OBO site.