### PR TITLE
Standardize logo usage

### DIFF
--- a/_layouts/ontology_detail.html
+++ b/_layouts/ontology_detail.html
@@ -9,10 +9,9 @@ layout: default
     <div class="page-header">
       <h1>
         {% if page.depicted_by %}
-        <img alt="logo" src="{{page.depicted_by}}"/>
+        <img alt="logo" src="{{page.depicted_by}}" style="max-height: 50px;" />
         {% endif %}
         {{ page.title }}
-        <small>{{ page.tagline }}</small>
       </h1>
       <p>
         {{page.description}}
@@ -48,7 +47,7 @@ layout: default
     {% endfor %}
   </div>
   {% endif %}
-  
+
   {% if page.activity_status == "inactive" %}{% unless page.is_obsolete %}
   <div>
     <div class="alert alert-warning" role="alert">
@@ -56,7 +55,7 @@ layout: default
     </div>
   </div>
   {% endunless %}{% endif %}
-  
+
   {% if page.activity_status == "orphaned" %}{% unless page.is_obsolete %}
   <div>
     <div class="alert alert-warning" role="alert">
@@ -172,13 +171,13 @@ layout: default
 
 
       <div class="col-md-4">
-        <dl class="dl-horizontal" style="dd { margin-left: 0 }">
+        <dl class="dl-horizontal" style="margin-left: 0">
 
           <dt>
             ID Space
             <span data-toggle="tooltip"
                   title="ID prefix"
-                  html="true">
+                  data-html="true">
             </span>
           </dt>
           <dd>
@@ -326,7 +325,7 @@ layout: default
             <button type="button"
                     data-toggle="tooltip"
                     title="See FAQ entry: How is metadata stored?"
-                    html="true"
+                    data-html="true"
                     class="btn btn-default">
               View
             </button>
@@ -336,7 +335,7 @@ layout: default
             <button type="button"
                     data-toggle="tooltip"
                     title="See FAQ entry: How I do edit my metadata?"
-                    html="true"
+                    data-html="true"
                     class="btn btn-default">
               Edit</button>
           </a>
@@ -345,7 +344,7 @@ layout: default
             <button type="button"
                     data-toggle="tooltip"
                     title="See FAQ entry: How I do edit my PURL?"
-                    html="true"
+                    data-html="true"
                     class="btn btn-default">
               PURL</button>
           </a>

--- a/_layouts/ontology_detail.html
+++ b/_layouts/ontology_detail.html
@@ -9,7 +9,7 @@ layout: default
     <div class="page-header">
       <h1>
         {% if page.depicted_by %}
-        <img alt="logo" src="{{page.depicted_by}}" style="max-height: 50px;" />
+        <img alt="logo" src="{{page.depicted_by}}" style="max-height: 1em;" />
         {% endif %}
         {{ page.title }}
       </h1>

--- a/ontology/cmo.md
+++ b/ontology/cmo.md
@@ -35,8 +35,7 @@ browsers:
 activity_status: active
 repository: https://github.com/rat-genome-database/CMO-Clinical-Measurement-Ontology
 preferredPrefix: CMO
+logo: http://rgd.mcw.edu/common/images/rgd_LOGO_blue_rgd.gif
 ---
-
-<img src="http://rgd.mcw.edu/common/images/rgd_LOGO_blue_rgd.gif"/>
 
 The Clinical Measurement Ontology is designed to be used to standardize morphological and physiological measurement records generated from clinical and model organism research and health programs.

--- a/ontology/cmo.md
+++ b/ontology/cmo.md
@@ -35,7 +35,7 @@ browsers:
 activity_status: active
 repository: https://github.com/rat-genome-database/CMO-Clinical-Measurement-Ontology
 preferredPrefix: CMO
-logo: http://rgd.mcw.edu/common/images/rgd_LOGO_blue_rgd.gif
+depicted_by: http://rgd.mcw.edu/common/images/rgd_LOGO_blue_rgd.gif
 ---
 
 The Clinical Measurement Ontology is designed to be used to standardize morphological and physiological measurement records generated from clinical and model organism research and health programs.

--- a/ontology/doid.md
+++ b/ontology/doid.md
@@ -65,7 +65,7 @@ usages:
 activity_status: active
 repository: https://github.com/DiseaseOntology/HumanDiseaseOntology
 preferredPrefix: DOID
-logo: http://www.disease-ontology.org/media/images/DO_logo.jpg
+depicted_by: http://www.disease-ontology.org/media/images/DO_logo.jpg
 ---
 
 Creating a comprehensive classification of human diseases organized by etiology.

--- a/ontology/doid.md
+++ b/ontology/doid.md
@@ -65,6 +65,7 @@ usages:
 activity_status: active
 repository: https://github.com/DiseaseOntology/HumanDiseaseOntology
 preferredPrefix: DOID
+logo: http://www.disease-ontology.org/media/images/DO_logo.jpg
 ---
 
 Creating a comprehensive classification of human diseases organized by etiology.
@@ -75,5 +76,3 @@ This file is equivalent to doid-non-classified.obo.
 
 - DO provides an additional OBO file, [doid-merged.obo](https://raw.githubusercontent.com/DiseaseOntology/HumanDiseaseOntology/master/src/ontology/doid-merged.obo). 
  for the [AGR](http://www.alliancegenome.org) that includes [OMIM](http://omim.org) to DO associations as xrefs plus defined  relationships between OMIM susceptibility IDs and DO terms.  
-
-<img src="http://www.disease-ontology.org/media/images/DO_logo.jpg"/>

--- a/ontology/eco.md
+++ b/ontology/eco.md
@@ -51,9 +51,8 @@ usages:
 activity_status: active
 repository: https://github.com/evidenceontology/evidenceontology
 preferredPrefix: ECO
+logo: https://avatars1.githubusercontent.com/u/12802432
 ---
-
-<img src="https://avatars1.githubusercontent.com/u/12802432" alt="ECO logo"/>
 
 The Evidence & Conclusion Ontology (ECO) describes types of scientific evidence within the realm of biological research that can arise from laboratory experiments, computational methods, manual literature curation, and other means. Researchers can use these types of evidence to support assertions about things (such as scientific conclusions, gene annotations, or other statements of fact) that result from scientific research.
 

--- a/ontology/eco.md
+++ b/ontology/eco.md
@@ -51,7 +51,7 @@ usages:
 activity_status: active
 repository: https://github.com/evidenceontology/evidenceontology
 preferredPrefix: ECO
-logo: https://avatars1.githubusercontent.com/u/12802432
+depicted_by: https://avatars1.githubusercontent.com/u/12802432
 ---
 
 The Evidence & Conclusion Ontology (ECO) describes types of scientific evidence within the realm of biological research that can arise from laboratory experiments, computational methods, manual literature curation, and other means. Researchers can use these types of evidence to support assertions about things (such as scientific conclusions, gene annotations, or other statements of fact) that result from scientific research.

--- a/ontology/ecto.md
+++ b/ontology/ecto.md
@@ -51,5 +51,5 @@ license:
 activity_status: active
 repository: https://github.com/EnvironmentOntology/environmental-exposure-ontology
 preferredPrefix: ECTO
-logo: https://raw.githubusercontent.com/jmcmurry/closed-illustrations/master/logos/ecto-logos/ecto-logo_black-banner.png
+depicted_by: https://raw.githubusercontent.com/jmcmurry/closed-illustrations/master/logos/ecto-logos/ecto-logo_black-banner.png
 ---

--- a/ontology/ecto.md
+++ b/ontology/ecto.md
@@ -44,7 +44,6 @@ dependencies:
   - id: ro
   - id: uberon
   - id: xco
-
 tracker: https://github.com/EnvironmentOntology/environmental-exposure-ontology/issues
 license:
   url: https://creativecommons.org/publicdomain/zero/1.0/
@@ -52,5 +51,5 @@ license:
 activity_status: active
 repository: https://github.com/EnvironmentOntology/environmental-exposure-ontology
 preferredPrefix: ECTO
+logo: https://raw.githubusercontent.com/jmcmurry/closed-illustrations/master/logos/ecto-logos/ecto-logo_black-banner.png
 ---
-<img src="https://raw.githubusercontent.com/jmcmurry/closed-illustrations/master/logos/ecto-logos/ecto-logo_black-banner.png"/>

--- a/ontology/envo.md
+++ b/ontology/envo.md
@@ -85,11 +85,10 @@ tracker: https://github.com/EnvironmentOntology/envo/issues/
 activity_status: active
 repository: https://github.com/EnvironmentOntology/envo
 preferredPrefix: ENVO
+logo: /logos/envo.png
 ---
 
 EnvO is a community ontology for the concise, controlled description of environments.
-
-<img src="/logos/envo.png"/>
 
 Envo can be cited as:
 

--- a/ontology/envo.md
+++ b/ontology/envo.md
@@ -85,7 +85,7 @@ tracker: https://github.com/EnvironmentOntology/envo/issues/
 activity_status: active
 repository: https://github.com/EnvironmentOntology/envo
 preferredPrefix: ENVO
-logo: /logos/envo.png
+depicted_by: /logos/envo.png
 ---
 
 EnvO is a community ontology for the concise, controlled description of environments.

--- a/ontology/eo.md
+++ b/ontology/eo.md
@@ -39,7 +39,7 @@ usages:
         description: Gramene annotations to cold temperature regiment
 activity_status: inactive
 repository: https://github.com/Planteome/plant-environment-ontology
-logo: http://planteome.org/sites/default/files/garland_logo.PNG
+depicted_by: http://planteome.org/sites/default/files/garland_logo.PNG
 ---
 
 A structured, controlled vocabulary for the representation of plant environmental conditions.

--- a/ontology/eo.md
+++ b/ontology/eo.md
@@ -39,13 +39,10 @@ usages:
         description: Gramene annotations to cold temperature regiment
 activity_status: inactive
 repository: https://github.com/Planteome/plant-environment-ontology
+logo: http://planteome.org/sites/default/files/garland_logo.PNG
 ---
 
 A structured, controlled vocabulary for the representation of plant environmental conditions.
-
-<img alt="Planteome logo" src="http://planteome.org/sites/default/files/garland_logo.PNG"/>
-
-Note this ontology is  replaced by [PECO](peco.html).
 
 ## Migration Guide from EO to PECO
 

--- a/ontology/hp.md
+++ b/ontology/hp.md
@@ -56,7 +56,7 @@ usages:
 activity_status: active
 repository: https://github.com/obophenotype/human-phenotype-ontology
 preferredPrefix: HP
-logo: https://raw.githubusercontent.com/obophenotype/human-phenotype-ontology/master/logo/HPO-logo-black_small.png
+depicted_by: https://raw.githubusercontent.com/obophenotype/human-phenotype-ontology/master/logo/HPO-logo-black_small.png
 ---
 
 An ontology is a computational representation of a domain of knowledge based upon a controlled, standardized vocabulary for describing entities and the semantic relationships between them.

--- a/ontology/hp.md
+++ b/ontology/hp.md
@@ -56,9 +56,8 @@ usages:
 activity_status: active
 repository: https://github.com/obophenotype/human-phenotype-ontology
 preferredPrefix: HP
+logo: https://raw.githubusercontent.com/obophenotype/human-phenotype-ontology/master/logo/HPO-logo-black_small.png
 ---
-
-<img src="https://raw.githubusercontent.com/obophenotype/human-phenotype-ontology/master/logo/HPO-logo-black_small.png"/>
 
 An ontology is a computational representation of a domain of knowledge based upon a controlled, standardized vocabulary for describing entities and the semantic relationships between them.
 

--- a/ontology/maxo.md
+++ b/ontology/maxo.md
@@ -47,8 +47,7 @@ license:
 activity_status: active
 repository: https://github.com/monarch-initiative/MAxO
 preferredPrefix: MAXO
+logo: https://raw.githubusercontent.com/jmcmurry/closed-illustrations/master/logos/maxo-logos/maxo_logo_black-banner.png
 ---
 
 The Medical Action Ontology (MAxO) provides a structured vocabulary for medical procedures, interventions, therapies, and treatments for disease with an emphasis on rare disease (RD). It is often difficult to find relevant clinical literature about strategies to manage RD patients. Responding to this need, MAxO provides a vocabulary to annotate diseases and phenotypes with recommended treatments and interventions.
-
-<img src="https://raw.githubusercontent.com/jmcmurry/closed-illustrations/master/logos/maxo-logos/maxo_logo_black-banner.png"/>

--- a/ontology/maxo.md
+++ b/ontology/maxo.md
@@ -47,7 +47,7 @@ license:
 activity_status: active
 repository: https://github.com/monarch-initiative/MAxO
 preferredPrefix: MAXO
-logo: https://raw.githubusercontent.com/jmcmurry/closed-illustrations/master/logos/maxo-logos/maxo_logo_black-banner.png
+depicted_by: https://raw.githubusercontent.com/jmcmurry/closed-illustrations/master/logos/maxo-logos/maxo_logo_black-banner.png
 ---
 
 The Medical Action Ontology (MAxO) provides a structured vocabulary for medical procedures, interventions, therapies, and treatments for disease with an emphasis on rare disease (RD). It is often difficult to find relevant clinical literature about strategies to manage RD patients. Responding to this need, MAxO provides a vocabulary to annotate diseases and phenotypes with recommended treatments and interventions.

--- a/ontology/ncro.md
+++ b/ontology/ncro.md
@@ -15,7 +15,6 @@ contact:
 license:
   url: https://creativecommons.org/licenses/by/4.0/
   label: CC BY 4.0
-# depicted_by:
 # build:
 #  source_url: http://purl.obofoundry.org/obo/obi/repository/trunk/src/ontology/branches/
 # integration_server: http://build.berkeleybop.org/job/build-obi/

--- a/ontology/peco.md
+++ b/ontology/peco.md
@@ -26,8 +26,7 @@ publications:
 activity_status: active
 repository: https://github.com/Planteome/plant-experimental-conditions-ontology
 preferredPrefix: PECO
+logo: http://planteome.org/sites/default/files/garland_logo.PNG
 ---
 
 A structured, controlled vocabulary for the representation of plant experimental conditions.
-
-<img alt="Planteome logo" src="http://planteome.org/sites/default/files/garland_logo.PNG"/>

--- a/ontology/peco.md
+++ b/ontology/peco.md
@@ -26,7 +26,7 @@ publications:
 activity_status: active
 repository: https://github.com/Planteome/plant-experimental-conditions-ontology
 preferredPrefix: PECO
-logo: http://planteome.org/sites/default/files/garland_logo.PNG
+depicted_by: http://planteome.org/sites/default/files/garland_logo.PNG
 ---
 
 A structured, controlled vocabulary for the representation of plant experimental conditions.

--- a/ontology/po.md
+++ b/ontology/po.md
@@ -69,8 +69,7 @@ usages:
 activity_status: active
 repository: https://github.com/Planteome/plant-ontology
 preferredPrefix: PO
+logo: http://planteome.org/sites/default/files/garland_logo.PNG
 ---
 
 The Plant Ontology is a structured vocabulary and database resource that links plant anatomy, morphology and growth and development to plant genomics data. The PO is under active development to expand to encompass terms and annotations from all plants.
-
-<img alt="Planteome logo" src="http://planteome.org/sites/default/files/garland_logo.PNG"/>

--- a/ontology/po.md
+++ b/ontology/po.md
@@ -69,7 +69,7 @@ usages:
 activity_status: active
 repository: https://github.com/Planteome/plant-ontology
 preferredPrefix: PO
-logo: http://planteome.org/sites/default/files/garland_logo.PNG
+depicted_by: http://planteome.org/sites/default/files/garland_logo.PNG
 ---
 
 The Plant Ontology is a structured vocabulary and database resource that links plant anatomy, morphology and growth and development to plant genomics data. The PO is under active development to expand to encompass terms and annotations from all plants.

--- a/ontology/pw.md
+++ b/ontology/pw.md
@@ -35,7 +35,7 @@ browsers:
 activity_status: active
 repository: https://github.com/rat-genome-database/PW-Pathway-Ontology
 preferredPrefix: PW
-logo: http://rgd.mcw.edu/common/images/rgd_LOGO_blue_rgd.gif
+depicted_by: http://rgd.mcw.edu/common/images/rgd_LOGO_blue_rgd.gif
 ---
 
 The Pathway Ontology is a controlled vocabulary for pathways that provides standard terms for the annotation of gene products. The Pathway Ontology is under development at <a href="http://rgd.mcw.edu">Rat Genome Database</a>.

--- a/ontology/pw.md
+++ b/ontology/pw.md
@@ -35,8 +35,7 @@ browsers:
 activity_status: active
 repository: https://github.com/rat-genome-database/PW-Pathway-Ontology
 preferredPrefix: PW
+logo: http://rgd.mcw.edu/common/images/rgd_LOGO_blue_rgd.gif
 ---
-
-<img src="http://rgd.mcw.edu/common/images/rgd_LOGO_blue_rgd.gif"/>
 
 The Pathway Ontology is a controlled vocabulary for pathways that provides standard terms for the annotation of gene products. The Pathway Ontology is under development at <a href="http://rgd.mcw.edu">Rat Genome Database</a>.

--- a/ontology/rs.md
+++ b/ontology/rs.md
@@ -33,8 +33,7 @@ taxon:
 activity_status: active
 repository: https://github.com/rat-genome-database/RS-Rat-Strain-Ontology
 preferredPrefix: RS
+logo: http://rgd.mcw.edu/common/images/rgd_LOGO_blue_rgd.gif
 ---
-
-<img src="http://rgd.mcw.edu/common/images/rgd_LOGO_blue_rgd.gif"/>
 
 Ontology of rat strains

--- a/ontology/rs.md
+++ b/ontology/rs.md
@@ -33,7 +33,7 @@ taxon:
 activity_status: active
 repository: https://github.com/rat-genome-database/RS-Rat-Strain-Ontology
 preferredPrefix: RS
-logo: http://rgd.mcw.edu/common/images/rgd_LOGO_blue_rgd.gif
+depicted_by: http://rgd.mcw.edu/common/images/rgd_LOGO_blue_rgd.gif
 ---
 
 Ontology of rat strains

--- a/ontology/sepio.md
+++ b/ontology/sepio.md
@@ -27,8 +27,7 @@ products:
 activity_status: active
 repository: https://github.com/monarch-initiative/SEPIO-ontology
 preferredPrefix: SEPIO
+logo: https://raw.githubusercontent.com/jmcmurry/closed-illustrations/master/logos/SEPIO-LOGOS/sepio_logo_black-banner.png
 ---
 
 The Scientific Evidence and Provenance Information Ontology (SEPIO) was developed to support description of evidence and provenance information for scientific claims. The core model represents the relationships between claims, their evidence lines, the information items that comprise these lines of evidence, and the methods, tools, and agents involved in the creation of these entities.  Use cases driving SEPIO development include integration of scientific claims and their associated evidence/provenance metadata, and support for the discovery, analysis, and evaluation of claims based on this metadata.
-
-<img src="https://raw.githubusercontent.com/jmcmurry/closed-illustrations/master/logos/SEPIO-LOGOS/sepio_logo_black-banner.png"/>

--- a/ontology/sepio.md
+++ b/ontology/sepio.md
@@ -27,7 +27,7 @@ products:
 activity_status: active
 repository: https://github.com/monarch-initiative/SEPIO-ontology
 preferredPrefix: SEPIO
-logo: https://raw.githubusercontent.com/jmcmurry/closed-illustrations/master/logos/SEPIO-LOGOS/sepio_logo_black-banner.png
+depicted_by: https://raw.githubusercontent.com/jmcmurry/closed-illustrations/master/logos/SEPIO-LOGOS/sepio_logo_black-banner.png
 ---
 
 The Scientific Evidence and Provenance Information Ontology (SEPIO) was developed to support description of evidence and provenance information for scientific claims. The core model represents the relationships between claims, their evidence lines, the information items that comprise these lines of evidence, and the methods, tools, and agents involved in the creation of these entities.  Use cases driving SEPIO development include integration of scientific claims and their associated evidence/provenance metadata, and support for the discovery, analysis, and evaluation of claims based on this metadata.

--- a/ontology/to.md
+++ b/ontology/to.md
@@ -51,8 +51,7 @@ usages:
 activity_status: active
 repository: https://github.com/Planteome/plant-trait-ontology
 preferredPrefix: TO
+logo: http://planteome.org/sites/default/files/garland_logo.PNG
 ---
 
 A controlled vocabulary of describe phenotypic traits in plants. Each trait is a distinguishable feature, characteristic, quality or phenotypic feature of a developing or mature plant.
-
-<img alt="Planteome logo" src="http://planteome.org/sites/default/files/garland_logo.PNG"/>

--- a/ontology/to.md
+++ b/ontology/to.md
@@ -51,7 +51,7 @@ usages:
 activity_status: active
 repository: https://github.com/Planteome/plant-trait-ontology
 preferredPrefix: TO
-logo: http://planteome.org/sites/default/files/garland_logo.PNG
+depicted_by: http://planteome.org/sites/default/files/garland_logo.PNG
 ---
 
 A controlled vocabulary of describe phenotypic traits in plants. Each trait is a distinguishable feature, characteristic, quality or phenotypic feature of a developing or mature plant.

--- a/ontology/uberon.md
+++ b/ontology/uberon.md
@@ -176,9 +176,8 @@ products:
       - ehdaa2
 activity_status: active
 preferredPrefix: UBERON
+logo: https://raw.githubusercontent.com/jmcmurry/closed-illustrations/master/logos/uberon-logos/uberon_logo_black-banner.png
 ---
 
 Uberon is an integrated cross-species ontology covering anatomical structures in animals. See the <a href="http://uberon.org">Uberon website</a> for more info, or read the <a
  href="http://genomebiology.com/2012/13/1/R5">Uberon paper in Genome Biology</a>.
-
-<img src="https://raw.githubusercontent.com/jmcmurry/closed-illustrations/master/logos/uberon-logos/uberon_logo_black-banner.png"/>

--- a/ontology/uberon.md
+++ b/ontology/uberon.md
@@ -92,7 +92,7 @@ publications:
     title: "Uberon, an integrative multi-species anatomy ontology"
   - id: http://www.ncbi.nlm.nih.gov/pubmed/25009735
     title: "Unification of multi-species vertebrate anatomy ontologies for comparative biology in Uberon"
-depicted_by: http://uberon.github.io/images/u-logo.jpg
+depicted_by: https://raw.githubusercontent.com/jmcmurry/closed-illustrations/master/logos/uberon-logos/uberon_logo_black-banner.png
 dependencies:
   - id: go
     subset: uberon/go_import.owl
@@ -176,7 +176,6 @@ products:
       - ehdaa2
 activity_status: active
 preferredPrefix: UBERON
-logo: https://raw.githubusercontent.com/jmcmurry/closed-illustrations/master/logos/uberon-logos/uberon_logo_black-banner.png
 ---
 
 Uberon is an integrated cross-species ontology covering anatomical structures in animals. See the <a href="http://uberon.org">Uberon website</a> for more info, or read the <a

--- a/ontology/vhog.md
+++ b/ontology/vhog.md
@@ -7,7 +7,7 @@ products:
 is_obsolete: true
 replaced_by: uberon
 activity_status: inactive
-logo: http://bgee.org/img/logo/bgee13_logo.png
+depicted_by: http://bgee.org/img/logo/bgee13_logo.png
 ---
 
 vHOG has been rolled into Uberon, with homology assertions available on a [separate project on github](https://github.com/BgeeDB/anatomical-similarity-annotations)

--- a/ontology/vhog.md
+++ b/ontology/vhog.md
@@ -7,8 +7,7 @@ products:
 is_obsolete: true
 replaced_by: uberon
 activity_status: inactive
+logo: http://bgee.org/img/logo/bgee13_logo.png
 ---
 
 vHOG has been rolled into Uberon, with homology assertions available on a [separate project on github](https://github.com/BgeeDB/anatomical-similarity-annotations)
-
-<img src="http://bgee.org/img/logo/bgee13_logo.png"/>

--- a/ontology/xco.md
+++ b/ontology/xco.md
@@ -35,9 +35,8 @@ browsers:
 activity_status: active
 repository: https://github.com/rat-genome-database/XCO-experimental-condition-ontology
 preferredPrefix: XCO
+logo: http://rgd.mcw.edu/common/images/rgd_LOGO_blue_rgd.gif
 ---
-
-<img src="http://rgd.mcw.edu/common/images/rgd_LOGO_blue_rgd.gif"/>
 
 Conditions under which physiological and morphological measurements are made both in the clinic and in studies involving humans or model organisms.
 

--- a/ontology/xco.md
+++ b/ontology/xco.md
@@ -35,7 +35,7 @@ browsers:
 activity_status: active
 repository: https://github.com/rat-genome-database/XCO-experimental-condition-ontology
 preferredPrefix: XCO
-logo: http://rgd.mcw.edu/common/images/rgd_LOGO_blue_rgd.gif
+depicted_by: http://rgd.mcw.edu/common/images/rgd_LOGO_blue_rgd.gif
 ---
 
 Conditions under which physiological and morphological measurements are made both in the clinic and in studies involving humans or model organisms.

--- a/util/schema/registry_schema.json
+++ b/util/schema/registry_schema.json
@@ -293,6 +293,11 @@
         "label"
       ]
     },
+    "logo": {
+      "description": "The URL to a logo for the resource",
+      "type": "string",
+      "format": "uri"
+    },
     "mailing_list": {
       "level": "info",
       "description": "'mailing_list' is an informative field. The value is a mailing list on which ontology discussions take place.",

--- a/util/schema/registry_schema.json
+++ b/util/schema/registry_schema.json
@@ -293,11 +293,6 @@
         "label"
       ]
     },
-    "logo": {
-      "description": "The URL to a logo for the resource",
-      "type": "string",
-      "format": "uri"
-    },
     "mailing_list": {
       "level": "info",
       "description": "'mailing_list' is an informative field. The value is a mailing list on which ontology discussions take place.",


### PR DESCRIPTION
There were a lot of images floating around in the free text of ontologies' metadata. For example, this causes the Uberon image to be massive and look quite bad (see https://obofoundry.org/ontology/uberon)

This PR standardizes all of those logos using the pre-existing `depicted_by` tag as well as imposes a maximum height constraint on the current format so the larger images don't make the layout look bad. It also does a few minor fixes to the ontology detail.