### PR TITLE
Permit any kind of publication in publication field

### DIFF
--- a/tests/test_integrity.py
+++ b/tests/test_integrity.py
@@ -89,5 +89,3 @@ class TestIntegrity(unittest.TestCase):
         identifier = publication["id"]
         self.assertIsInstance(identifier, str)
         self.assertFalse(identifier.endswith("/"))
-        self.assertTrue(identifier.startswith(uri_prefix), msg=msg)
-        self.assertTrue(identifier[len(uri_prefix):].isnumeric())


### PR DESCRIPTION
According to our OBO operations call on the 19th of April, we (the OBO operations committee) mostly unanimously decided to open the publication field to mean: "This is what we want you to cite when you cite this ontology" as opposed to "this is the peer-reviewed publication we have produced describing the ontology".