### PR TITLE
Rename "biochemistry" domain to "chemistry and biochemistry"

### DIFF
--- a/ontology/chebi.md
+++ b/ontology/chebi.md
@@ -19,7 +19,7 @@ contact:
 license:
   url: https://creativecommons.org/licenses/by/4.0/
   label: CC BY 4.0
-domain: biochemistry
+domain: chemistry and biochemistry
 homepage: http://www.ebi.ac.uk/chebi
 page: http://www.ebi.ac.uk/chebi/init.do?toolBarForward=userManual
 depicted_by: https://www.ebi.ac.uk/chebi/images/ChEBI_logo.png

--- a/ontology/cheminf.md
+++ b/ontology/cheminf.md
@@ -14,7 +14,7 @@ license:
   url: http://creativecommons.org/licenses/by/4.0/
   label: CC BY 4.0
 description: Includes terms for the descriptors commonly used in cheminformatics software applications and the algorithms which generate them.
-domain: biochemistry
+domain: chemistry and biochemistry
 homepage: https://github.com/semanticchemistry/semanticchemistry
 mailing_list: https://groups.google.com/forum/#!forum/cheminf-ontology
 products:

--- a/ontology/chiro.md
+++ b/ontology/chiro.md
@@ -15,7 +15,7 @@ contact:
   github: nicolevasilevsky
   orcid: 0000-0001-5208-3432
 description: CHEBI provides a distinct role hierarchy. Chemicals in the structural hierarchy are connected via a 'has role' relation. CHIRO provides links from these roles to useful other classes in other ontologies. This will allow direct connection between chemical structures (small molecules, drugs) and what they do. This could be formalized using 'capable of', in the same way Uberon and the Cell Ontology link structures to processes.
-domain: biochemistry
+domain: chemistry and biochemistry
 homepage: https://github.com/obophenotype/chiro
 products:
   - id: chiro.owl

--- a/ontology/gno.md
+++ b/ontology/gno.md
@@ -7,7 +7,7 @@ contact:
   github: edwardsnj
   orcid: 0000-0001-5168-3196
 description: GlyTouCan provides stable accessions for glycans described at varyious degrees of characterization, including compositions (no linkage) and topologies (no carbon bond positions or anomeric configurations). GNOme organizes these stable accessions for interative browsing, for text-based searching, and for automated reasoning with well-defined characterization levels.
-domain: biochemistry
+domain: chemistry and biochemistry
 tags:
   - glycan structure
 homepage: https://gnome.glyomics.org/

--- a/ontology/lipro.md
+++ b/ontology/lipro.md
@@ -6,7 +6,7 @@ contact:
   email: bakerc@unb.ca
   label: Christipher Baker
 description: An ontology representation of the LIPIDMAPS nomenclature classification.
-domain: biochemistry
+domain: chemistry and biochemistry
 tags:
   - lipids
 title: Lipid Ontology

--- a/ontology/mod.md
+++ b/ontology/mod.md
@@ -13,7 +13,7 @@ publications:
   - id: https://www.ncbi.nlm.nih.gov/pubmed/18688235
     title: "The PSI-MOD community standard for representation of protein modification data"
 description: PSI-MOD is an ontology consisting of terms that describe protein chemical modifications
-domain: biochemistry
+domain: chemistry and biochemistry
 tags:
   - proteins
 homepage: http://www.psidev.info/MOD

--- a/ontology/mro.md
+++ b/ontology/mro.md
@@ -5,7 +5,7 @@ title: MHC Restriction Ontology
 description: An ontology for Major Histocompatibility Complex (MHC) restriction in experiments
 tracker: https://github.com/IEDB/MRO/issues
 homepage: https://github.com/IEDB/MRO
-domain: biochemistry
+domain: chemistry and biochemistry
 tags:
   - Major Histocompatibility Complex
 contact:

--- a/ontology/pr.md
+++ b/ontology/pr.md
@@ -8,7 +8,7 @@ contact:
   github: nataled
   orcid: 0000-0001-5809-9523
 description: An ontological representation of protein-related entities
-domain: biochemistry
+domain: chemistry and biochemistry
 tags:
   - proteins
 homepage: http://proconsortium.org

--- a/ontology/resid.md
+++ b/ontology/resid.md
@@ -5,7 +5,7 @@ contact:
   email: john.garavelli@ebi.ac.uk
   label: John Garavelli
 description: For the description of covalent bonds in proteins.
-domain: biochemistry
+domain: chemistry and biochemistry
 tags:
   - proteins
 homepage: http://www.ebi.ac.uk/RESID/

--- a/ontology/rnao.md
+++ b/ontology/rnao.md
@@ -8,7 +8,7 @@ contact:
 license:
   url: https://creativecommons.org/publicdomain/zero/1.0/
   label: CC0 1.0
-domain: biochemistry
+domain: chemistry and biochemistry
 tags:
   - molecular structure
 homepage: https://github.com/bgsu-rna/rnao

--- a/ontology/sbo.md
+++ b/ontology/sbo.md
@@ -7,7 +7,7 @@ contact:
   github: rsmsheriff
   orcid: 0000-0003-0705-9809
 description: Terms commonly used in Systems Biology, and in particular in computational modeling.
-domain: biochemistry
+domain: chemistry and biochemistry
 homepage: http://www.ebi.ac.uk/sbo/
 products:
   - id: sbo.owl

--- a/ontology/so.md
+++ b/ontology/so.md
@@ -10,7 +10,7 @@ license:
   url: https://creativecommons.org/licenses/by/4.0/
   label: CC BY 4.0
 description: A structured controlled vocabulary for sequence annotation, for the exchange of annotation data and for the description of sequence objects in databases.
-domain: biochemistry
+domain: chemistry and biochemistry
 tags:
   - biological sequence
 homepage: http://www.sequenceontology.org/

--- a/ontology/txpo.md
+++ b/ontology/txpo.md
@@ -7,7 +7,7 @@ contact:
   github: yuki-yamagata
   orcid: 0000-0002-9673-1283
 description: TOXic Process Ontology (TXPO) systematizes a wide variety of terms involving toxicity courses and processes. The first version of TXPO focuses on liver toxicity.
-domain: biochemistry
+domain: chemistry and biochemistry
 tags:
   - toxicity
 homepage: https://toxpilot.nibiohn.go.jp/

--- a/ontology/xlmod.md
+++ b/ontology/xlmod.md
@@ -9,7 +9,7 @@ contact:
   label: Lutz Fischer
   github: lutzfischer
   orcid: 0000-0003-4978-0864
-domain: biochemistry
+domain: chemistry and biochemistry
 tags:
   - MS cross-linker reagents
 mailing_list: psidev-ms-vocab@lists.sourceforge.net

--- a/util/bulk_domain_rename.py
+++ b/util/bulk_domain_rename.py
@@ -1,0 +1,37 @@
+"""This script bulk renames a given domain.
+
+Run with: ``python bulk_domain_rename.py <old> <new>``.
+
+Author: `Charles Tapley Hoyt <https://cthoyt.com>`_.
+"""
+
+import pathlib
+
+import click
+
+HERE = pathlib.Path(__file__).parent.resolve()
+ONTOLOGY_DIRECTORY = HERE.parent.joinpath("ontology").resolve()
+
+
+@click.command()
+@click.argument("old_label")
+@click.argument("new_label")
+def main(old_label: str, new_label: str):
+    """Rename domains across all ontologies."""
+    old_line = f"domain: {old_label}"
+    new_line = f"domain: {new_label}"
+
+    for path in ONTOLOGY_DIRECTORY.glob("*.md"):
+        with path.open() as file:
+            lines = [line.rstrip("\n") for line in file]
+
+        with path.open("w") as file:
+            for line in lines:
+                if line == old_line:
+                    print(new_line, file=file)
+                else:
+                    print(line, file=file)
+
+
+if __name__ == '__main__':
+    main()

--- a/util/bulk_domain_rename.py
+++ b/util/bulk_domain_rename.py
@@ -33,5 +33,5 @@ def main(old_label: str, new_label: str):
                     print(line, file=file)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/util/schema/registry_schema.json
+++ b/util/schema/registry_schema.json
@@ -107,7 +107,7 @@
         "phenotype",
         "investigations",
         "environment",
-        "biochemistry",
+        "chemistry and biochemistry",
         "microbiology",
         "agriculture",
         "diet, metabolomics, and nutrition",


### PR DESCRIPTION
Closes #1908

While adding domains to the remaining OBO Foundry ontologies in #1884, it became clear that some ontologies are only about chemistry and not biochemistry. It was suggested to generalize the "biochemistry" domain annotation to "chemistry and biochemistry" to make this a bit more inclusive.

This PR demonstrates doing the following:

1. Renames the domain in the schema file
2. Adds a script for bulk renaming of domains, in case this ever needs to be done again
3. Applies the renaming described above