### PR TITLE
Centralize info on participation

### DIFF
--- a/docs/participate.md
+++ b/docs/participate.md
@@ -1,0 +1,16 @@
+---
+layout: doc
+id: Participate
+title: How to participate in the OBO Foundry
+---
+
+The OBO Foundry is currently a volunteer-run organization. There are many ways to get involved:  
+ <ul>
+            <li>Submit a bug report, question, or feature request to the<a href="https://github.com/OBOFoundry/OBOFoundry.github.io/issues">OBO Foundry issue tracker</a></li>
+            <li>Join the <a href="https://groups.google.com/forum/#!forum/obo-discuss">OBO-Discuss mailing list</a></li>
+            <li>Join the <a href="https://groups.google.com/forum/#!members/obo-tools">OBO-Tools mailing list</a></li>
+            <li>Participate in the <a href="https://obo-communitygroup.slack.com/archives/C01DP18L5GW">OBO Community Slack channel</a></li>
+             <li><a href="/faq/how-do-i-register-my-ontology.html">Submit your ontology</a></li>
+	     <li><a href="/faq//how-do-i-modify-website.html">Create a pull request to improve this website</a></li>
+	      <li>Nominate yourself to <a href="/docs/NewOBOFC.md">join the OBO Foundry Operations Committee</a></li>
+</ul>   

--- a/docs/participate.md
+++ b/docs/participate.md
@@ -5,12 +5,10 @@ title: How to participate in the OBO Foundry
 ---
 
 The OBO Foundry is currently a volunteer-run organization. There are many ways to get involved:  
- <ul>
-            <li>Submit a bug report, question, or feature request to the<a href="https://github.com/OBOFoundry/OBOFoundry.github.io/issues">OBO Foundry issue tracker</a></li>
-            <li>Join the <a href="https://groups.google.com/forum/#!forum/obo-discuss">OBO-Discuss mailing list</a></li>
-            <li>Join the <a href="https://groups.google.com/forum/#!members/obo-tools">OBO-Tools mailing list</a></li>
-            <li>Participate in the <a href="https://obo-communitygroup.slack.com/archives/C01DP18L5GW">OBO Community Slack channel</a></li>
-             <li><a href="/faq/how-do-i-register-my-ontology.html">Submit your ontology</a></li>
-	     <li><a href="/faq//how-do-i-modify-website.html">Create a pull request to improve this website</a></li>
-	      <li>Nominate yourself to <a href="/docs/NewOBOFC.md">join the OBO Foundry Operations Committee</a></li>
-</ul>   
+- Submit a bug report, question, or feature request to the [OBO Foundry issue tracker](https://github.com/OBOFoundry/OBOFoundry.github.io/issues)
+- Join the [OBO-Discuss mailing list](https://groups.google.com/forum/#!forum/obo-discuss)
+- Join the [OBO-Tools mailing list](https://groups.google.com/forum/#!members/obo-tools)
+- Participate in the [OBO Community Slack channel](https://obo-communitygroup.slack.com/archives/C01DP18L5GW)
+- [Submit your ontology](/faq/how-do-i-register-my-ontology.html) to be considered for inclusion in the OBO Foundry
+- [Create a pull request to improve this website](/faq//how-do-i-modify-website.html)
+- Nominate yourself to [join the OBO Foundry Operations Committee](/docs/NewOBOFC.md)


### PR DESCRIPTION
Currently distributed among menus or linked from other pages.

Not sure whether < li > will work in the web page, and I can't check that in the preview, so I'll have to wait for someone to merge this PR and then fix the formatting if needed.