### PR TITLE
Fix typo in OMIT's preferred prefix and add test to guard future typos

### DIFF
--- a/ontology/omit.md
+++ b/ontology/omit.md
@@ -19,7 +19,7 @@ products:
 title: Ontology for MIRNA Target
 activity_status: active
 repository: https://github.com/OmniSearch/omit
-preferredPrefix: chemistry and biochemistry
+preferredPrefix: OMIT
 domain: chemistry and biochemistry
 ---
 

--- a/tests/test_integrity.py
+++ b/tests/test_integrity.py
@@ -146,3 +146,14 @@ class TestIntegrity(unittest.TestCase):
             if configuration.get("level") in {"warning", "error"}
         }
         self.assertEqual(required - skip_keys, high_level - skip_keys)
+
+    def test_preferred_prefix(self):
+        """Test all preferred prefixes."""
+        for prefix, record in self.ontologies.items():
+            with self.subTest(prefix=prefix):
+                if record.get("activity_status") != "active":
+                    continue
+                preferred_prefix = record.get("preferredPrefix")
+                self.assertIsNotNone(preferred_prefix)
+                self.assertLessEqual(2, len(preferred_prefix))
+                self.assertNotIn(" ", preferred_prefix)


### PR DESCRIPTION
Somehow this preferred prefix was updated in a previous PR. This PR fixes it and adds some minimal tests for preferred prefixes (i.e., no spaces allowed)