### PR TITLE
remove "id" line to avoid having Edit button that goes to the wrong URL

### DIFF
--- a/resources.md
+++ b/resources.md
@@ -1,6 +1,5 @@
 ---
 layout: doc
-id: resources
 title: Ontology Tools and Resources
 ---
 ## Ontology Browsers


### PR DESCRIPTION
to fix this issue I noted in #1939:
> The edit button on https://obofoundry.org/resources points to https://github.com/OBOFoundry/OBOFoundry.github.io/edit/master/docs/resources.md which is wrong -- it should point to https://github.com/OBOFoundry/OBOFoundry.github.io/edit/master/resources.md

Darren noted:
> Unless I'm mistaken, there's naught to do except move the file to where it is expected.

I responded:
> I don't want to do that; then everything else that points to that page will be pointing to the wrong place. Instead, I think the "fix" here is to take out the id so that it doesn't have an Edit button. Is that ok?