### PR TITLE
updated OBO ontology training description

### DIFF
--- a/resources.md
+++ b/resources.md
@@ -14,20 +14,20 @@ title: Ontology Tools and Resources
 
 ## Tutorials
 
-- [OBO Semantic Engineering Training](https://oboacademy.github.io/obook/)
+- [**OBO Ontology Training**](https://oboacademy.github.io/obook/): lessons and tutorials aimed at database curators, ontology curators, ontology engineers/developers, and (semantic) software engineers. Includes the [OBOOK](https://oboacademy.github.io/obook/): open documentation for biomedical ontology engineering.
 - [Introduction to Ontologies](https://github.com/prog4biol/pfb2018/blob/master/workshops/Ontologies/IntroToOntologies_CSH_2018-10-28g.pdf): slides from Cold Spring Harbor workshop, October 2018, by Nicole Vasilevsky.
 - [Ontology 101 Tutorial](http://icbo2018.cgrb.oregonstate.edu/node/19): from International Conference on Biological Ontology (ICBO) 2018
 - [Ontology 101 Open Educational Resource](https://github.com/OHSUBD2K/BDK14-Ontologies-101): Funded by NIH BD2K Initiative.
 - [Cell Ontology Tutorial](https://github.com/obophenotype/cell-ontology-training/blob/master/README.md): Led by David Osumi-Sutherland, Alex Diehl, Nico Matentzoglu and Nicole Vasilevsky
 - [ROBOT tutorial](https://ontodev.github.io/robot-tutorial/#/title-slide) by James Overton
 - [OBO Academy](https://www.youtube.com/channel/UCKAkmAIIfPZc5kjdait-MdQ) - A YouTube channel containing presentations and tutorials relevant to the OBO Foundry
-- [Pizza Tutorial for Protégé 5](https://drive.google.com/file/d/1UqI19JiGnJwzKx_JQ7qRAz7bmCzyqZpj/view) by Michael DeBellis. More [info.](https://www.michaeldebellis.com/post/new-protege-pizza-tutorial).
+- [Pizza Tutorial for Protégé 5](https://drive.google.com/file/d/1UqI19JiGnJwzKx_JQ7qRAz7bmCzyqZpj/view) by Michael DeBellis. [More info](https://www.michaeldebellis.com/post/new-protege-pizza-tutorial).
 - [Introduction to Biomedical Ontologies](http://ontology.buffalo.edu/smith/BioOntology_Course.html): A training course in eight lectures by [Barry Smith](http://ontology.buffalo.edu/smith/)
 - [Building Ontologies with Basic Formal Ontology](http://ontology.buffalo.edu/BOBFO/detailed-table-of-contents.html): By Robert Arp, Barry Smith, and Andrew Spear
 
 ## Ontology Tools
 
-- [Protege](https://protege.stanford.edu/): An ontology development software application
+- [Protégé](https://protege.stanford.edu/): An ontology development software application
 - [Ontology Development Kit](https://github.com/INCATools/ontology-development-kit): A toolkit to initialize an OBO library repository and associated files.
 - [ROBOT](http://robot.obolibrary.org/): ROBOT is a tool for working with Open Biomedical Ontologies.
 - [VOCOL](https://vocol.iais.fraunhofer.de/): An Integrated Environment for Collaborative Vocabulary Development.
@@ -43,6 +43,7 @@ title: Ontology Tools and Resources
 
 ## Relevant Publications/blogs
 
+- [**OBO Foundry in 2021: operationalizing open data principles to evaluate ontologies**](https://academic.oup.com/database/article/doi/10.1093/database/baab069/6410158) **(2021)**. Rebecca Jackson, Nicolas Matentzoglu, James A Overton, Randi Vita, James P Balhoff, Pier Luigi Buttigieg, Seth Carbon, Melanie Courtot, Alexander D Diehl, Damion M Dooley, William D Duncan, Nomi L Harris, Melissa A Haendel, Suzanna E Lewis, Darren A Natale, David Osumi-Sutherland, Alan Ruttenberg, Lynn M Schriml, Barry Smith, Christian J Stoeckert Jr., Nicole A Vasilevsky, Ramona L Walls, Jie Zheng, Christopher J Mungall, Bjoern Peters. *Database*, Volume 2021, baab069, https://doi.org/10.1093/database/baab069
 - [The OBO Foundry: coordinated evolution of ontologies to support biomedical data integration](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC2814061/) (Smith et al., 2007). Nat Biotechnol 2007 Nov;25(11):1251–1255. http://dx.doi.org/10.1038/nbt1346
 - [MIRO: guidelines for minimum information for the reporting of an ontology](https://jbiomedsem.biomedcentral.com/articles/10.1186/s13326-017-0172-7) (2018). Nicolas Matentzoglu, James Malone, Chris Mungall and Robert Stevens, Journal of Biomedical Semantics 2018 9:6, https://doi.org/10.1186/s13326-017-0172-7
 - [Monkeying around with OWL](https://douroucouli.wordpress.com/): a technical blog on ontologies and ontology engineering by Chris Mungall.


### PR DESCRIPTION
and added 2021 OBO Foundry paper (might as well; already had older paper listed here).

Addresses #1929 (at least, in terms of making the OBO Ontology Training easier to find).

It's possible there are other things in this page that need updating or are obsolete and should be removed.