### PR TITLE
merged in missing tools & info from OntologyTools.md

### DIFF
--- a/resources.md
+++ b/resources.md
@@ -5,41 +5,43 @@ title: Ontology Tools and Resources
 ## Ontology Browsers
 
 - [OBO Foundry](http://www.obofoundry.org/)
-- [BioPortal](http://bioportal.bioontology.org/)
-- [Ontology Lookup Service](https://www.ebi.ac.uk/ols/index)
-- [Ontobee](http://www.ontobee.org/)
+- [BioPortal](http://bioportal.bioontology.org/): has over 700 biomedical ontologies, including the OBO Foundry ontologies. Users can search for terms or browse individual ontologies. BioPortal also provides tools to aid in increasing ontology interoperability.
+- [Ontology Lookup Service (OLS)](https://www.ebi.ac.uk/ols/index): lets users search for terms across all ontologies, or individual ontologies, as well as view term hierarchies. OLS also has an API so that ontologies can be browsed programmatically.
+- [Ontobee](http://www.ontobee.org/): Part of the Onto-Animal tool collection. Users can search all available ontologies and browse detailed descriptions of individiual terms. OntoBee is the default server for most OBO Foundry ontology IRIs.
+- [AberOWL](http://aber-owl.net/): A repository of biological ontologies and access to reasoned versions of those ontologies. Ontolgies can be browsed by term labels or queried by Manchester OWL syntax statements.
 - [QuickGO](https://www.ebi.ac.uk/QuickGO/)
 - [AmiGO](http://amigo.geneontology.org/amigo)
 - [Linked Open Vocabularies](https://lov.linkeddata.es/dataset/lov/)
 
 ## Tutorials
 
-- [**OBO Ontology Training**](https://oboacademy.github.io/obook/): lessons and tutorials aimed at database curators, ontology curators, ontology engineers/developers, and (semantic) software engineers. Includes the [OBOOK](https://oboacademy.github.io/obook/): open documentation for biomedical ontology engineering.
+- [**OBO Ontology Training**](https://oboacademy.github.io/obook/): lessons and tutorials aimed at database curators, ontology curators, ontology engineers/developers, and (semantic) software engineers. Includes the [OBOOK](https://oboacademy.github.io/obook/), a collection of open documentation for biomedical ontology engineering.
 - [Introduction to Ontologies](https://github.com/prog4biol/pfb2018/blob/master/workshops/Ontologies/IntroToOntologies_CSH_2018-10-28g.pdf): slides from Cold Spring Harbor workshop, October 2018, by Nicole Vasilevsky.
 - [Ontology 101 Tutorial](http://icbo2018.cgrb.oregonstate.edu/node/19): from International Conference on Biological Ontology (ICBO) 2018
 - [Ontology 101 Open Educational Resource](https://github.com/OHSUBD2K/BDK14-Ontologies-101): Funded by NIH BD2K Initiative.
 - [Cell Ontology Tutorial](https://github.com/obophenotype/cell-ontology-training/blob/master/README.md): Led by David Osumi-Sutherland, Alex Diehl, Nico Matentzoglu and Nicole Vasilevsky
 - [ROBOT tutorial](https://ontodev.github.io/robot-tutorial/#/title-slide) by James Overton
-- [OBO Academy](https://www.youtube.com/channel/UCKAkmAIIfPZc5kjdait-MdQ) - A YouTube channel containing presentations and tutorials relevant to the OBO Foundry
+- [OBO Academy](https://www.youtube.com/channel/UCKAkmAIIfPZc5kjdait-MdQ): A YouTube channel with presentations and tutorials relevant to the OBO Foundry
 - [Pizza Tutorial for Protégé 5](https://drive.google.com/file/d/1UqI19JiGnJwzKx_JQ7qRAz7bmCzyqZpj/view) by Michael DeBellis. [More info](https://www.michaeldebellis.com/post/new-protege-pizza-tutorial).
 - [Introduction to Biomedical Ontologies](http://ontology.buffalo.edu/smith/BioOntology_Course.html): A training course in eight lectures by [Barry Smith](http://ontology.buffalo.edu/smith/)
 - [Building Ontologies with Basic Formal Ontology](http://ontology.buffalo.edu/BOBFO/detailed-table-of-contents.html): By Robert Arp, Barry Smith, and Andrew Spear
 
 ## Ontology Tools
 
-- [Protégé](https://protege.stanford.edu/): An ontology development software application
-- [Ontology Development Kit](https://github.com/INCATools/ontology-development-kit): A toolkit to initialize an OBO library repository and associated files.
-- [ROBOT](http://robot.obolibrary.org/): ROBOT is a tool for working with Open Biomedical Ontologies.
-- [VOCOL](https://vocol.iais.fraunhofer.de/): An Integrated Environment for Collaborative Vocabulary Development.
-- [Karma Data Integration](http://usc-isi-i2.github.io/karma/): A data integration tool.
-- [Ontofox](http://ontofox.hegroup.org/): An ontology term and relation extraction and reuse tool.
+- [Ontology Development Kit (ODK)](https://github.com/INCATools/ontology-development-kit): A toolkit for initializing a new ontology repository. The template includes a structured directory, a Makefile with automated release workflows, continuous integration testing, and full documentation.
+- [ROBOT](http://robot.obolibrary.org/): A command line tool to automate ontology workflows. It includes commands that can be used manually or integrated in automated processes to develop and release ontologies.
+- [Protégé](https://protege.stanford.edu/): An ontology editing environment for OWL ontologies. It allows developers to visualize the ontology hierarchy, add and edit ontology terms, reason over the ontology, and more.
+- [Onto-Animals](http://www.hegroup.org/ontozoo/): Tools to extract external ontology terms, compare ontologies, edit ontology terms, query and visualize ontologies, and more.
+- [VOCOL](https://vocol.iais.fraunhofer.de/): An integrated environment for collaborative vocabulary development
+- [Karma Data Integration](http://usc-isi-i2.github.io/karma/): A data integration tool
+- [Ontofox](http://ontofox.hegroup.org/): An ontology term and relation extraction and reuse tool
 - [Ubergraph](https://github.com/INCATools/ubergraph): A sparql endpoint with many OBO ontologies loaded and pre-reasoned with simple triples materialized
 
 ## Ontology Analysis
 
 - [OBO Dashboard](https://dashboard.obofoundry.org): An assesment of OBO Foundry ontologies' conformance to OBO Foundry principles 
 - [OBO Community Health Report](https://cthoyt.com/obo-community-health): A self-updating assessment of the quality of metadata, responsiveness of the maintainers, and the overall community engagement for each OBO Foundry ontology.
-- [Ontology Quality Assessment](https://cthoyt.com/oquat): A self-updating assesment of the semantic quality of OBO Foundry ontologies and beyond (i.e., using known prefixes, using standard identifiers, etc.) 
+- [Ontology Quality Assessment](https://cthoyt.com/oquat): A self-updating assesment of the semantic quality of OBO Foundry ontologies and beyond (using known prefixes, using standard identifiers, etc.) 
 
 ## Relevant Publications/blogs
 


### PR DESCRIPTION
Added two tools that were on the unliked and soon-to-be-removed docs/OntologyTools.md. Added descriptions to some browsers (which had no descriptions). A few other minor updates for conciseness and consistency.