### PR TITLE
Truncate long short descriptions

### DIFF
--- a/_includes/ontology_table.html
+++ b/_includes/ontology_table.html
@@ -36,15 +36,15 @@ Download table as: [ <a href="/registry/ontologies.yml">YAML</a> | <a href="/reg
       </td>
       <td>
         {% if ont.is_obsolete %}
-        <s>
-          {{ ont.description }}
-        </s>
-        <mark>obsolete</mark>
+            <s>
+              {{ ont.description | truncate: 140 }}
+            </s>
+            <mark>obsolete</mark>
         {% elsif ont.activity_status == "inactive" %}
-        {{ ont.description }}
-        <mark>inactive</mark>
+            {{ ont.description | truncate: 140 }}
+            <mark>inactive</mark>
         {% else %}
-        {{ ont.description }}
+            {{ ont.description | truncate: 140 }}
         {% endif %}
         <small>
           <a href="ontology/{{ ont.id }}.html" > Detail </a>


### PR DESCRIPTION
Related to #1966, #1965, and #1968, this PR adds some code to truncate the ontology short descriptions to 140 characters. Just like tweets, this is a pretty reasonable length and makes the homepage much easier to read. E.g., from the top ontologies, only PO's description is truncated (and the details link is already there to expand to the full ontology page):

<img width="1130" alt="Screen Shot 2022-06-20 at 15 26 57" src="https://user-images.githubusercontent.com/5069736/174613262-664e2edc-00a7-484b-9e3f-77a001cee374.png">

