### PR TITLE
Ensure shacl prefix map does not exclude obsolete ontologies from the prefix map

### DIFF
--- a/util/make-shacl-prefixes.py
+++ b/util/make-shacl-prefixes.py
@@ -43,8 +43,9 @@ def main(args):
     print(" sh:declare")
     sep = ""
     for ont in data["ontologies"]:
-        if ont.get("is_obsolete", False):
-            continue
+        #if ont.get("is_obsolete", False):
+        #    continue
+        # See https://github.com/OBOFoundry/OBOFoundry.github.io/issues/1976
         prefix = ont.get("preferredPrefix", ont["id"].upper())
         print(
             f'{sep}[ sh:prefix "{prefix}" ; sh:namespace "http://purl.obolibrary.org/obo/{prefix}_"]'

--- a/util/make-shacl-prefixes.py
+++ b/util/make-shacl-prefixes.py
@@ -43,7 +43,7 @@ def main(args):
     print(" sh:declare")
     sep = ""
     for ont in data["ontologies"]:
-        #if ont.get("is_obsolete", False):
+        # if ont.get("is_obsolete", False):
         #    continue
         # See https://github.com/OBOFoundry/OBOFoundry.github.io/issues/1976
         prefix = ont.get("preferredPrefix", ont["id"].upper())


### PR DESCRIPTION
fixes #1976

@jamesaoverton in the end this was only the shacl map, the obo_context was correct.