### PR TITLE
new answer to a FAQ

### DIFF
--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -120,7 +120,7 @@
             <li role="separator" class="divider"></li>
             <li><i>Guides</i></li>
             <li><a href="/resources">What tools are there for creating, editing and working with OBO ontologies?</a></li>
-            <li><a href="https://douroucouli.wordpress.com/2014/01/08/creating-an-ontology-project/">How should I manage my ontology using version control?</a></li>
+            <li><a href="/faq/managing-ontology.html">How should I manage and curate my ontology?</a></li>
             <li><a href="http://robot.obolibrary.org/convert">How do I convert between formats (e.g. OBO to OWL format)?</a></li>
             <li role="separator" class="divider"></li>
             <li><i>Participate</i></li>


### PR DESCRIPTION
addresses this point in #1930:
>  The link for "How should I manage my ontology using version control?" points to https://douroucouli.wordpress.com/2014/01/08/creating-an-ontology-project/
Is that 2014 blog post really the best and most up-to-date reference?

Note that this change is paired with #2011 and should not be merged until that PR is merged.