### PR TITLE
Fix dividers in FAQ dropdown

### DIFF
--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -93,7 +93,7 @@
           <ul class="dropdown-menu">
             <!-- in theory we could auto-generate this part of the navbar -->
             <!-- <li><a href="/faq/who-is-the-foundry.html">Who is the OBO Foundry?</a></li> -->
-            <li role="separator" class="divider"></li>
+            <!-- <li role="separator" class="divider"></li> -->
             <li class="dropdown-header"><i>Policy</i></li>
             <!-- these just direct to the relevant pages: I think someone should make dedicated FAQ entries -->
             <li><a href="/principles/fp-000-summary.html">What are the OBO Foundry Principles?</a></li>

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -94,37 +94,37 @@
             <!-- in theory we could auto-generate this part of the navbar -->
             <!-- <li><a href="/faq/who-is-the-foundry.html">Who is the OBO Foundry?</a></li> -->
             <li role="separator" class="divider"></li>
-            <li><i>Policy</i></li>
+            <li class="dropdown-header"><i>Policy</i></li>
             <!-- these just direct to the relevant pages: I think someone should make dedicated FAQ entries -->
             <li><a href="/principles/fp-000-summary.html">What are the OBO Foundry Principles?</a></li>
             <li><a href="/id-policy.html">What is the OBO ID Policy?</a></li>
             <li><a href="/docs/ReservePrefix.html">My ontology is not ready for OBO Foundry, can I reserve a prefix anyway?</a></li>
             <li><a href="/faq/foundry-vs-format.html">What's the difference between an OBO Foundry ontology and an OBO format ontology?</a></li>
             <li role="separator" class="divider"></li>
-            <li><i>Citation</i></li>
+            <li class="dropdown-header"><i>Citation</i></li>
             <li><a href="/registry/publications.html">How do I cite the OBO Foundry?</a></li>
             <li><a href="/docs/Citation.html">How do I cite a specific ontology?</a></li>
             <li role="separator" class="divider"></li>
-            <li><i>Terms</i></li>
+            <li class="dropdown-header"><i>Terms</i></li>
             <li><a href="/faq/how-do-i-request-a-term.html">How do I request a new ontology term?</a></li>
             <li role="separator" class="divider"></li>
-            <li><i>Ontology display</i></li>
+            <li class="dropdown-header"><i>Ontology display</i></li>
             <li><a href="/faq/how-do-i-add-browser.html">How do I add a custom browser for my ontology?</a></li>
             <li><a href="/faq/where-is-the-obo-file.html">Why is there no OBO-Format file listed for my ontology?</a></li>
             <li role="separator" class="divider"></li>
-            <li><i>Ontology metadata</i></li>
+            <li class="dropdown-header"><i>Ontology metadata</i></li>
             <li><a href="/faq/how-do-i-edit-metadata.html">How do I edit the metadata for my ontology?</a></li>
             <li><a href="/faq/permissible-metadata-content.html">What are permissible values in the metadata file, e.g. for 'publications'?</a></li>
             <li><a href="/faq/what-is-the-build-field.html">What is the <code>build</code> object in the ontology metadata?</a></li>
             <li><a href="/docs/OntologyStatus.html">What does it mean for an ontology to be flagged as 'inactive', 'orphaned' or 'obsolete'?</a></li>
             <li role="separator" class="divider"></li>
-            <li><i>Guides</i></li>
+            <li class="dropdown-header"><i>Guides</i></li>
             <li><a href="/resources">What tools are there for creating, editing and working with OBO ontologies?</a></li>
             <li><a href="https://douroucouli.wordpress.com/2014/01/08/creating-an-ontology-project/">How should I manage my ontology using version control?</a></li>
             <li><a href="http://robot.obolibrary.org/convert">How do I convert between formats (e.g. OBO to OWL format)?</a></li>
             <li><a href="faq/managing-ontology.html">How should I manage and curate my ontology throughout its lifecycle?</a></li>
             <li role="separator" class="divider"></li>
-            <li><i>Participate</i></li>
+            <li class="dropdown-header"><i>Participate</i></li>
             <li><a href="/faq/how-do-i-register-my-ontology.html">How do I submit my ontology?</a></li>
             <li><a href="/docs/participate.html">How can I get involved in the OBO Foundry?</a></li>
           </ul>


### PR DESCRIPTION
Now looks like this:
<img width="543" alt="Screen Shot 2022-08-05 at 12 03 45" src="https://user-images.githubusercontent.com/5069736/183054553-19ceaa99-87e8-4825-9135-c2f729078c75.png">
