### PR TITLE
Added example usages

### DIFF
--- a/ontology/cheminf.md
+++ b/ontology/cheminf.md
@@ -33,7 +33,7 @@ usages:
   user: https://www.ebi.ac.uk/chembl/
 - description: ENM uses CHEMINF for chemical information terms
   user: https://github.com/enanomapper/ontologies
-- descriptoin: PubChem uses CHEMINF in their RDF representation
+- description: PubChem uses CHEMINF in their RDF representation
   examples:
   - description: Physicochemical properties are represented as classes that are typed with CHEMINF classes
     url: https://pubchem.ncbi.nlm.nih.gov/rest/rdf/descriptor/CID161282_Canonical_SMILES

--- a/ontology/cheminf.md
+++ b/ontology/cheminf.md
@@ -25,5 +25,18 @@ publications:
   title: 'The chemical information ontology: provenance and disambiguation for chemical data on the biological semantic web'
 repository: https://github.com/semanticchemistry/semanticchemistry
 tracker: https://github.com/semanticchemistry/semanticchemistry/issues
+usages:
+- description: ChEMBL uses CHEMINF in the RDF download
+  examples:
+  - description: Physicochemical properties are represented as classes that are typed with CHEMINF classes
+    url: http://rdf.ebi.ac.uk/resource/chembl/molecule/CHEMBL6939#mw_freebase
+  user: https://www.ebi.ac.uk/chembl/
+- description: ENM uses CHEMINF for chemical information terms
+  user: https://github.com/enanomapper/ontologies
+- descriptoin: PubChem uses CHEMINF in their RDF representation
+  examples:
+  - description: Physicochemical properties are represented as classes that are typed with CHEMINF classes
+    url: https://pubchem.ncbi.nlm.nih.gov/rest/rdf/descriptor/CID161282_Canonical_SMILES
+  user: https://pubchem.ncbi.nlm.nih.gov/
 activity_status: active
 ---

--- a/ontology/cheminf.md
+++ b/ontology/cheminf.md
@@ -28,11 +28,9 @@ tracker: https://github.com/semanticchemistry/semanticchemistry/issues
 usages:
 - description: ChEMBL uses CHEMINF in the RDF download
   examples:
-  - description: Physicochemical properties are represented as classes that are typed with CHEMINF classes
-    url: http://rdf.ebi.ac.uk/resource/chembl/molecule/CHEMBL6939#mw_freebase
+  - description: The RDF is provided as SPARQL endpoint by Maastricht University.
+    url: https://chemblmirror.rdf.bigcat-bioinformatics.org/
   user: https://www.ebi.ac.uk/chembl/
-- description: ENM uses CHEMINF for chemical information terms
-  user: https://github.com/enanomapper/ontologies
 - description: PubChem uses CHEMINF in their RDF representation
   examples:
   - description: Physicochemical properties are represented as classes that are typed with CHEMINF classes


### PR DESCRIPTION
Added three: the ENM ontology, ChEMBL, and PubChem

I propose to wait until https://github.com/OBOFoundry/OBOFoundry.github.io/pull/2023 is applied/merged/finalized after which I will rebase this patch to resolve the merge conflict.