### PR TITLE
Replace dropdown FAQ menu with redirect to new FAQ page

### DIFF
--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -87,53 +87,9 @@
           </ul>
         </li>
 
-
-        <li class="dropdown">
-          <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">FAQ <span class="caret"></span></a>
-          <ul class="dropdown-menu">
-            <!-- in theory we could auto-generate this part of the navbar -->
-            <!-- <li><a href="/faq/who-is-the-foundry.html">Who is the OBO Foundry?</a></li> -->
-            <!-- <li role="separator" class="divider"></li> -->
-            <li class="dropdown-header"><i>Policy</i></li>
-            <!-- these just direct to the relevant pages: I think someone should make dedicated FAQ entries -->
-            <li><a href="/principles/fp-000-summary.html">What are the OBO Foundry Principles?</a></li>
-            <li><a href="/id-policy.html">What is the OBO ID Policy?</a></li>
-            <li><a href="/docs/ReservePrefix.html">My ontology is not ready for OBO Foundry, can I reserve a prefix anyway?</a></li>
-            <li><a href="/faq/foundry-vs-format.html">What's the difference between an OBO Foundry ontology and an OBO format ontology?</a></li>
-            <li role="separator" class="divider"></li>
-            <li class="dropdown-header"><i>Citation</i></li>
-            <li><a href="/registry/publications.html">How do I cite the OBO Foundry?</a></li>
-            <li><a href="/docs/Citation.html">How do I cite a specific ontology?</a></li>
-            <li role="separator" class="divider"></li>
-            <li class="dropdown-header"><i>Terms</i></li>
-            <li><a href="/faq/how-do-i-request-a-term.html">How do I request a new ontology term?</a></li>
-            <li role="separator" class="divider"></li>
-            <li class="dropdown-header"><i>Ontology display</i></li>
-            <li><a href="/faq/how-do-i-add-browser.html">How do I add a custom browser for my ontology?</a></li>
-            <li><a href="/faq/where-is-the-obo-file.html">Why is there no OBO-Format file listed for my ontology?</a></li>
-            <li role="separator" class="divider"></li>
-            <li class="dropdown-header"><i>Ontology metadata</i></li>
-            <li><a href="/faq/how-do-i-edit-metadata.html">How do I edit the metadata for my ontology?</a></li>
-            <li><a href="/faq/permissible-metadata-content.html">What are permissible values in the metadata file, e.g. for 'publications'?</a></li>
-            <li><a href="/faq/what-is-the-build-field.html">What is the <code>build</code> object in the ontology metadata?</a></li>
-            <li><a href="/docs/OntologyStatus.html">What does it mean for an ontology to be flagged as 'inactive', 'orphaned' or 'obsolete'?</a></li>
-            <li role="separator" class="divider"></li>
-            <li class="dropdown-header"><i>OBO Dashboard</i></li>
-            <li><a href="/faq/dashboard.html">What is the OBO Dashboard?</a></li>
-            <li><a href="/faq/dashboard.html">How can I assess my ontology using the OBO Dashboard?</a></li>
-            <li role="separator" class="divider"></li>
-            <li class="dropdown-header"><i>Guides</i></li>
-            <li><a href="/resources">What tools are there for creating, editing and working with OBO ontologies?</a></li>
-            <li><a href="https://douroucouli.wordpress.com/2014/01/08/creating-an-ontology-project/">How should I manage my ontology using version control?</a></li>
-            <li><a href="http://robot.obolibrary.org/convert">How do I convert between formats (e.g. OBO to OWL format)?</a></li>
-            <li><a href="faq/managing-ontology.html">How should I manage and curate my ontology throughout its lifecycle?</a></li>
-            <li role="separator" class="divider"></li>
-            <li class="dropdown-header"><i>Participate</i></li>
-            <li><a href="/faq/how-do-i-register-my-ontology.html">How do I submit my ontology?</a></li>
-            <li><a href="/docs/participate.html">How can I get involved in the OBO Foundry?</a></li>
-          </ul>
+        <li>
+          <a href="/faq">Frequently Asked Questions (FAQ)<span class="caret"></span></a>
         </li>
-
 
       </ul>
       <form class="navbar-form navbar-left" role="search" action="http://www.ontobee.org/search" method="get">

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -88,7 +88,7 @@
         </li>
 
         <li>
-          <a href="/faq">Frequently Asked Questions (FAQ)<span class="caret"></span></a>
+          <a href="/faq/index.html">Frequently Asked Questions (FAQ)<span class="caret"></span></a>
         </li>
 
       </ul>


### PR DESCRIPTION
completing request by @cthoyt in #2019, "Shouldn't this PR also remove the entire drop-down list from the navbar?"