### PR TITLE
Deactivate sort by foundry status

### DIFF
--- a/util/validate-metadata.py
+++ b/util/validate-metadata.py
@@ -121,7 +121,7 @@ def validate_metadata(item, schema):
     results = {}
 
     # determine how to sort this item in the grid:
-    results["foundry"] = True if item.get("in_foundry_order") == 1 else False
+    results["foundry"] = False #True if item.get("in_foundry_order") == 1 else False
     results["obsolete"] = True if item.get("is_obsolete") is True else False
     # if there is no status, put them at the bottom with inactive:
     results["ontology_status"] = (

--- a/util/validate-metadata.py
+++ b/util/validate-metadata.py
@@ -121,7 +121,7 @@ def validate_metadata(item, schema):
     results = {}
 
     # determine how to sort this item in the grid:
-    results["foundry"] = False # True if item.get("in_foundry_order") == 1 else False
+    results["foundry"] = False  # True if item.get("in_foundry_order") == 1 else False
     results["obsolete"] = True if item.get("is_obsolete") is True else False
     # if there is no status, put them at the bottom with inactive:
     results["ontology_status"] = (

--- a/util/validate-metadata.py
+++ b/util/validate-metadata.py
@@ -121,7 +121,7 @@ def validate_metadata(item, schema):
     results = {}
 
     # determine how to sort this item in the grid:
-    results["foundry"] = False #True if item.get("in_foundry_order") == 1 else False
+    results["foundry"] = False # True if item.get("in_foundry_order") == 1 else False
     results["obsolete"] = True if item.get("is_obsolete") is True else False
     # if there is no status, put them at the bottom with inactive:
     results["ontology_status"] = (


### PR DESCRIPTION
Now we have a front page which breaks up the site by domains by default:

<img width="770" alt="image" src="https://user-images.githubusercontent.com/7070631/185761216-4816f682-42c0-4fb3-b2a4-e306204b2784.png">

This PR will deactivate sort by foundry status so we don't get these odd sorts in the default view (this is foundry status first, then alphabetical):

<img width="339" alt="image" src="https://user-images.githubusercontent.com/7070631/185761884-4e03ce15-929d-46d7-9a2b-a815ae4bec8c.png">

I will leave this open until Wednesday 26th September. 