### PR TITLE
Remove stray debug command

### DIFF
--- a/_includes/js/custom.js
+++ b/_includes/js/custom.js
@@ -441,7 +441,6 @@ jQuery(document).ready(function() {
             let event = new Event('change');
             element.dispatchEvent(event);
             $('#table-main').css('display', 'block');
-            debugger;
             $( 'a' ).tooltip({
                 tooltipClass: "mytooltipstyle",
                 show: {


### PR DESCRIPTION
Hi! If you visit the [homepage](https://obofoundry.org/) in Chrome with dev tools open, the loading will stop on this stray debug command. The `debugger` word in JavaScript is equivalent to a breakpoint, but they only work if a browser's dev tools equivalent is active at the time the `debugger` line is reached.

Most people will not likely be affected by this bug except for developers who may have dev tools open while looking at the source or messing around in the js console. Anyway, removing this line fixes the problem, let me know if you have any questions!