### PR TITLE
Lint HTML and markdown with prettier

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-or-question.md
+++ b/.github/ISSUE_TEMPLATE/bug-or-question.md
@@ -1,7 +1,6 @@
 ---
 name: Bug report or question
 about: Report a problem on obofoundry.org or ask a question
-
 ---
 
 If you are reporting an issue with our website, please specify the URL you were looking at, which browser and OS you are using, and if possible,

--- a/.github/ISSUE_TEMPLATE/obo-foundry-principles.md
+++ b/.github/ISSUE_TEMPLATE/obo-foundry-principles.md
@@ -2,9 +2,6 @@
 name: OBO Foundry Principles
 about: Suggestions regarding wording of (or additions to) principles
 title: 'Principle #<ENTER NUMBER HERE> "<ENTER NAME HERE>"'
-labels: 'attn: Editorial WG'
+labels: "attn: Editorial WG"
 assignees: nataled
-
 ---
-
-

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ share/python-wheels/
 .installed.cfg
 *.egg
 MANIFEST
+node_modules/

--- a/.prettierignore
+++ b/.prettierignore
@@ -6,3 +6,7 @@ _site
 _includes/themes/
 ontology/
 legacy/
+README-sitedev.md
+README.md
+LICENSE-code.md
+LICENSE.md

--- a/.prettierignore
+++ b/.prettierignore
@@ -4,3 +4,5 @@ _site
 *.js
 *.json
 _includes/themes/
+ontology/
+legacy/

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,6 @@
+_site
+*.yml
+*.css
+*.js
+*.json
+_includes/themes/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,14 +4,14 @@ Thank you for taking the time to contribute. We appreciate it!
 
 There are two ways to contribute to this effort. The first way is to use this project's [Issues Page](https://github.com/OBOFoundry/OBOFoundry.github.io/issues), which we use as a forum to discuss both major and minor issues related to developing the OBO repository, procedures and associated web interface. Examples of the type of issues that can be submitted are:
 
- * Issues to do with the website and other technical issues
- * Issues relating to metadata about individual ontologies
- * Issues regarding OBO as a whole
+- Issues to do with the website and other technical issues
+- Issues relating to metadata about individual ontologies
+- Issues regarding OBO as a whole
 
 Please refer to the FAQ section [faq/how-do-i-edit-metadata.md](faq/how-do-i-edit-metadata.md) on making Pull Requests.
 
-
 <a name="issue_resolution"></a>
+
 ## Issue Resolution
 
 Once a pull request or issue have been submitted, anyone can comment or vote on an issue to express their opinion following the Apache voting system. Quick summary:

--- a/README-sitedev.md
+++ b/README-sitedev.md
@@ -150,5 +150,5 @@ We use bootstrap 3, so far no themes.
 HTML code is kept nice looking with [`prettier`](https://prettier.io):
 
 ```shell
-npx prettier --write _includes/ _layouts/
+npx prettier --write .
 ```

--- a/README-sitedev.md
+++ b/README-sitedev.md
@@ -147,8 +147,6 @@ We use bootstrap 3, so far no themes.
 
 ### Code quality
 
-HTML code is kept nice looking with [`prettier`](https://prettier.io):
-
-```shell
-npx prettier --write .
-```
+1. Install the Node Package Manager (NPM) following [these instructions](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm)
+2. Install [`prettier`](https://prettier.io) with NPM using `npm install --save-dev --save-exact prettier`
+3. Run `prettier` from the root of the repository using the [node package executor (NPX)](https://www.npmjs.com/package/npx) with `npx prettier --write .`

--- a/README-sitedev.md
+++ b/README-sitedev.md
@@ -145,3 +145,10 @@ current wiki, but other opinions welcome.
 
 We use bootstrap 3, so far no themes.
 
+### Code quality
+
+HTML code is kept nice looking with [`prettier`](https://prettier.io):
+
+```shell
+npx prettier --write _includes/ _layouts/
+```

--- a/README-sitedev.md
+++ b/README-sitedev.md
@@ -148,5 +148,6 @@ We use bootstrap 3, so far no themes.
 ### Code quality
 
 1. Install the Node Package Manager (NPM) following [these instructions](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm)
-2. Install [`prettier`](https://prettier.io) with NPM using `npm install --save-dev --save-exact prettier`
-3. Run `prettier` from the root of the repository using the [node package executor (NPX)](https://www.npmjs.com/package/npx) with `npx prettier --write .`
+2. Install the [node package exector (`npx`)](https://www.npmjs.com/package/npx) with NPM using `npm install npx`
+2. Install [`prettier`](https://prettier.io) with NPM using `npm install prettier`
+3. Run `prettier` from the root of the repository with `npx prettier --write .`

--- a/_includes/aboutme.html
+++ b/_includes/aboutme.html
@@ -14,7 +14,7 @@
               <span class="icon search"></span>
               {% include ontobee_search.html %}
 </p>
-<p>
+<div>
     <h6>github.com/obophenotype/OBO</h6>
     <iframe 
        class="github-btn"
@@ -27,7 +27,7 @@
             allowtransparency="true" frameborder="0" scrolling="0"
             width="98px" height="20px">
     </iframe>
-</p>
+</div>
 <p>
   <a href="https://twitter.com/{{ site.project.twitter }}" class="twitter-follow-button" data-link-color="#0069D6" data-show-count="true">Follow @{{ site.project.twitter }}</a>
 </p>
@@ -35,10 +35,10 @@
 
   <a href="https://plus.google.com/+OBOOrg" rel="publisher">Google+</a>
 </p>
-<p>
+<div>
     <ul class="buttons unstyled">
       <li><a href="https://github.com/{{ site.project.github.org }}" rel="me" class="social github" title="Go to github.com/{{ site.project.github.org }}" target="_blank"></a></li>
       <li><a href="http://www.twitter.com/{{ site.project.twitter }}" rel="me" class="social twitter" title="Go to twitter.com/{{ site.project.twitter }}" target="_blank"></a></li>
       <li><a href="https://github.com/{{ site.project.github.org }}/OBO/Feedback/issues/new" rel="me" class="social mail" title="Leave feedback for {{ site.project.name  }}"  target="_blank"></a></li>				
     </ul>
-</p>
+</div>

--- a/_includes/aboutme.html
+++ b/_includes/aboutme.html
@@ -1,44 +1,83 @@
 <p>
-  <img 
-       src="{{ site.imgurl}}/u-logo.jpg" alt="logo" 
-       title="Follow us on Twitter @{{ site.author.twitter }}" 
-       class="img-rounded floatLeft" 
-       />
+  <img
+    src="{{ site.imgurl}}/u-logo.jpg"
+    alt="logo"
+    title="Follow us on Twitter @{{ site.author.twitter }}"
+    class="img-rounded floatLeft"
+  />
 
-    OBO is an integrated cross-species ontology covering anatomical
-    structures in animals. See the <a href="{{ site.baseurl}}about.html">about</a> page
-    for more info.
-
-</p>					
+  OBO is an integrated cross-species ontology covering anatomical structures in
+  animals. See the <a href="{{ site.baseurl}}about.html">about</a> page for more
+  info.
+</p>
 <p>
-              <span class="icon search"></span>
-              {% include ontobee_search.html %}
+  <span class="icon search"></span>
+  {% include ontobee_search.html %}
 </p>
 <div>
-    <h6>github.com/obophenotype/OBO</h6>
-    <iframe 
-       class="github-btn"
-       src="http://ghbtns.com/github-btn.html?user={{site.project.github.org }}&repo={{ site.project.github.repo }}&type=watch&count=true" 
-       allowtransparency="true" 
-       frameborder="0" scrolling="0" width="80px" height="20px">
-    </iframe>&nbsp;
-    <iframe class="github-btn"
-            src="http://ghbtns.com/github-btn.html?user={{ site.project.github.org }}&repo={{ site.project.github.repo}}&type=fork&count=true"
-            allowtransparency="true" frameborder="0" scrolling="0"
-            width="98px" height="20px">
-    </iframe>
+  <h6>github.com/obophenotype/OBO</h6>
+  <iframe
+    class="github-btn"
+    src="http://ghbtns.com/github-btn.html?user={{site.project.github.org }}&repo={{ site.project.github.repo }}&type=watch&count=true"
+    allowtransparency="true"
+    frameborder="0"
+    scrolling="0"
+    width="80px"
+    height="20px"
+  >
+  </iframe
+  >&nbsp;
+  <iframe
+    class="github-btn"
+    src="http://ghbtns.com/github-btn.html?user={{ site.project.github.org }}&repo={{ site.project.github.repo}}&type=fork&count=true"
+    allowtransparency="true"
+    frameborder="0"
+    scrolling="0"
+    width="98px"
+    height="20px"
+  >
+  </iframe>
 </div>
 <p>
-  <a href="https://twitter.com/{{ site.project.twitter }}" class="twitter-follow-button" data-link-color="#0069D6" data-show-count="true">Follow @{{ site.project.twitter }}</a>
+  <a
+    href="https://twitter.com/{{ site.project.twitter }}"
+    class="twitter-follow-button"
+    data-link-color="#0069D6"
+    data-show-count="true"
+    >Follow @{{ site.project.twitter }}</a
+  >
 </p>
 <p>
-
   <a href="https://plus.google.com/+OBOOrg" rel="publisher">Google+</a>
 </p>
 <div>
-    <ul class="buttons unstyled">
-      <li><a href="https://github.com/{{ site.project.github.org }}" rel="me" class="social github" title="Go to github.com/{{ site.project.github.org }}" target="_blank"></a></li>
-      <li><a href="http://www.twitter.com/{{ site.project.twitter }}" rel="me" class="social twitter" title="Go to twitter.com/{{ site.project.twitter }}" target="_blank"></a></li>
-      <li><a href="https://github.com/{{ site.project.github.org }}/OBO/Feedback/issues/new" rel="me" class="social mail" title="Leave feedback for {{ site.project.name  }}"  target="_blank"></a></li>				
-    </ul>
+  <ul class="buttons unstyled">
+    <li>
+      <a
+        href="https://github.com/{{ site.project.github.org }}"
+        rel="me"
+        class="social github"
+        title="Go to github.com/{{ site.project.github.org }}"
+        target="_blank"
+      ></a>
+    </li>
+    <li>
+      <a
+        href="http://www.twitter.com/{{ site.project.twitter }}"
+        rel="me"
+        class="social twitter"
+        title="Go to twitter.com/{{ site.project.twitter }}"
+        target="_blank"
+      ></a>
+    </li>
+    <li>
+      <a
+        href="https://github.com/{{ site.project.github.org }}/OBO/Feedback/issues/new"
+        rel="me"
+        class="social mail"
+        title="Leave feedback for {{ site.project.name  }}"
+        target="_blank"
+      ></a>
+    </li>
+  </ul>
 </div>

--- a/_includes/archive.html
+++ b/_includes/archive.html
@@ -1,6 +1,9 @@
 <h2>Past Posts</h2>
 <ul>
   {% for post in site.posts %}
-    <li>{{ post.date | date: "%Y - %B" }} <a href="{{ post.url }}">{{ post.title }}</a></li>	
+  <li>
+    {{ post.date | date: "%Y - %B" }}
+    <a href="{{ post.url }}">{{ post.title }}</a>
+  </li>
   {% endfor %}
 </ul>

--- a/_includes/docs_toc.md
+++ b/_includes/docs_toc.md
@@ -1,23 +1,21 @@
-
-
 [Operations Committee](/docs/OperationsCommittee.html)
 
-  * [Mission Statement](/docs/MissionStatement.html)
-  * [Membership](/docs/Membership.html)
-  * [Meetings](/docs/CommitteeMeetings.html)
-  * [Policy Decisions](/docs/OperationsCommitteePolicyDecisions.html)
-  * [Mailing Lists](/docs/MailingLists.html)
-  * [OBO Calendar](/docs/OBOCalendar.html)
+- [Mission Statement](/docs/MissionStatement.html)
+- [Membership](/docs/Membership.html)
+- [Meetings](/docs/CommitteeMeetings.html)
+- [Policy Decisions](/docs/OperationsCommitteePolicyDecisions.html)
+- [Mailing Lists](/docs/MailingLists.html)
+- [OBO Calendar](/docs/OBOCalendar.html)
 
 [Editorial Working Group](/docs/EditorialWG.html)
 
-  * [Review Process](/docs/ReviewProcessGuidelines.html)
-  * [Review Criteria](/docs/ReviewCriteriaPolicies.html)
+- [Review Process](/docs/ReviewProcessGuidelines.html)
+- [Review Criteria](/docs/ReviewCriteriaPolicies.html)
 
 [Technical Working Group](/docs/TechnicalWG.html)
 
-  * [PURL Requests](/docs/Policy_for_OBO_namespace_and_associated_PURL_requests.html)
-  * [OBO PURL Configuration](/docs/OBOPURLDomain.html)
-  * [Ontology tools and resources](/resources)
+- [PURL Requests](/docs/Policy_for_OBO_namespace_and_associated_PURL_requests.html)
+- [OBO PURL Configuration](/docs/OBOPURLDomain.html)
+- [Ontology tools and resources](/resources)
 
 [Outreach Working Group](/docs/OutreachWG.html)

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -1,102 +1,236 @@
 <nav class="navbar navbar-default">
-    <!-- Brand and toggle get grouped for better mobile display -->
-    <div class="navbar-header">
-      <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#bs-example-navbar-collapse-1" aria-expanded="false">
-        <span class="sr-only">Toggle navigation</span>
-        <span class="icon-bar"></span>
-        <span class="icon-bar"></span>
-        <span class="icon-bar"></span>
-      </button>
+  <!-- Brand and toggle get grouped for better mobile display -->
+  <div class="navbar-header">
+    <button
+      type="button"
+      class="navbar-toggle collapsed"
+      data-toggle="collapse"
+      data-target="#bs-example-navbar-collapse-1"
+      aria-expanded="false"
+    >
+      <span class="sr-only">Toggle navigation</span>
+      <span class="icon-bar"></span>
+      <span class="icon-bar"></span>
+      <span class="icon-bar"></span>
+    </button>
 
-      <a class="navbar-brand" href="/">
-        <img style="max-height: 16px;" src="/images/foundrylogo.png"/>
-        OBO Foundry
-      </a>
-    </div>
+    <a class="navbar-brand" href="/">
+      <img style="max-height: 16px" src="/images/foundrylogo.png" />
+      OBO Foundry
+    </a>
+  </div>
 
-    <!-- Collect the nav links, forms, and other content for toggling -->
-    <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
-      <ul class="nav navbar-nav">
+  <!-- Collect the nav links, forms, and other content for toggling -->
+  <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
+    <ul class="nav navbar-nav">
+      <li class="dropdown">
+        <a
+          href="#"
+          class="dropdown-toggle"
+          data-toggle="dropdown"
+          role="button"
+          aria-haspopup="true"
+          aria-expanded="false"
+          >About <span class="caret"></span
+        ></a>
+        <ul class="dropdown-menu">
+          <li><a href="/about-OBO-Foundry.html">About the OBO Foundry</a></li>
+          <li><a href="/docs/COC.html">Code of Conduct</a></li>
+          <li>
+            <a href="/docs/OperationsCommittee.html">Operations Committee</a>
+          </li>
+          <li>
+            <a href="/docs/SOP.html" style="padding-left: 3em"
+              >Standard Operating Procedures</a
+            >
+          </li>
+          <li>
+            <a href="/docs/EditorialWG.html" style="padding-left: 3em"
+              >Editorial Working Group</a
+            >
+          </li>
+          <li>
+            <a href="/docs/TechnicalWG.html" style="padding-left: 3em"
+              >Technical Working Group</a
+            >
+          </li>
+          <li>
+            <a href="/docs/OutreachWG.html" style="padding-left: 3em"
+              >Outreach Working Group</a
+            >
+          </li>
+          <li>
+            <a href="https://github.com/OBOFoundry/OBOFoundry.github.io"
+              >GitHub Project</a
+            >
+          </li>
+          <li>
+            <a href="https://github.com/OBOFoundry">GitHub Organization</a>
+          </li>
+          <!-- <li><a href="/allnews.html">OBO Foundry News</a></li> -->
+          <!-- <li><a href="https://twitter.com/OBOFoundry">@OBOFoundry Twitter Feed</a></li> -->
+        </ul>
+      </li>
 
-        <li class="dropdown">
-          <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">About <span class="caret"></span></a>
-          <ul class="dropdown-menu">
-            <li><a href="/about-OBO-Foundry.html">About the OBO Foundry</a></li>
-            <li><a href="/docs/COC.html">Code of Conduct</a></li>
-            <li><a href="/docs/OperationsCommittee.html">Operations Committee</a></li>
-            <li><a href="/docs/SOP.html" style="padding-left: 3em">Standard Operating Procedures</a></li>
-            <li><a href="/docs/EditorialWG.html" style="padding-left: 3em">Editorial Working Group</a></li>
-            <li><a href="/docs/TechnicalWG.html" style="padding-left: 3em">Technical Working Group</a></li>
-            <li><a href="/docs/OutreachWG.html" style="padding-left: 3em">Outreach Working Group</a></li>
-            <li><a href="https://github.com/OBOFoundry/OBOFoundry.github.io">GitHub Project</a></li>
-            <li><a href="https://github.com/OBOFoundry">GitHub Organization</a></li>
-            <!-- <li><a href="/allnews.html">OBO Foundry News</a></li> -->
-            <!-- <li><a href="https://twitter.com/OBOFoundry">@OBOFoundry Twitter Feed</a></li> -->            
-          </ul>
-        </li>
+      <li class="dropdown">
+        <a
+          href="#"
+          class="dropdown-toggle"
+          data-toggle="dropdown"
+          role="button"
+          aria-haspopup="true"
+          aria-expanded="false"
+          >Principles <span class="caret"></span
+        ></a>
+        <ul class="dropdown-menu">
+          {% for p in site.principles %}
+          <li>
+            <a href="/principles/{{p.id}}.html">{{p.title}}</a>
+          </li>
+          {% endfor %}
+        </ul>
+      </li>
 
-        <li class="dropdown">
-          <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Principles <span class="caret"></span></a>
-          <ul class="dropdown-menu">
-            {% for p in site.principles %}
-            <li>
-              <a href="/principles/{{p.id}}.html">{{p.title}}</a>
-            </li>
-            {% endfor %}
-          </ul>
-        </li>
+      <li class="dropdown">
+        <a
+          href="#"
+          class="dropdown-toggle"
+          data-toggle="dropdown"
+          role="button"
+          aria-haspopup="true"
+          aria-expanded="false"
+          >Ontologies <span class="caret"></span
+        ></a>
+        <ul class="dropdown-menu">
+          <li><a href="/">Ontology Table</a></li>
+          <li><a href="/id-policy.html">ID Policy</a></li>
+          <li>
+            <a href="http://dashboard.obofoundry.org/dashboard/index.html"
+              >OBO Dashboard</a
+            >
+          </li>
+          <li role="separator" class="divider"></li>
+          <li>
+            <a
+              href="https://github.com/OBOFoundry/OBOFoundry.github.io/tree/master/ontology"
+              >Ontologies Metadata Source</a
+            >
+          </li>
+          <li>
+            <a
+              href="https://github.com/OBOFoundry/OBOFoundry.github.io/blob/master/registry/"
+              >Combined Metadata</a
+            >
+          </li>
+          <li>
+            <a
+              href="https://raw.githubusercontent.com/OBOFoundry/OBOFoundry.github.io/master/registry/ontologies.yml"
+              >Ontology YAML</a
+            >
+          </li>
+          <li>
+            <a
+              href="https://raw.githubusercontent.com/OBOFoundry/OBOFoundry.github.io/master/registry/ontologies.jsonld"
+              >Ontology JSON-LD <i>alpha</i></a
+            >
+          </li>
+          <li>
+            <a
+              href="https://raw.githubusercontent.com/OBOFoundry/OBOFoundry.github.io/master/registry/ontologies.ttl"
+              >Ontology RDF/Turtle <i>alpha</i></a
+            >
+          </li>
+        </ul>
+      </li>
 
-        <li class="dropdown">
-          <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Ontologies <span class="caret"></span></a>
-          <ul class="dropdown-menu">
-            <li><a href="/">Ontology Table</a></li>
-            <li><a href="/id-policy.html">ID Policy</a></li>
-            <li><a href="http://dashboard.obofoundry.org/dashboard/index.html">OBO Dashboard</a></li>
-            <li role="separator" class="divider"></li>
-            <li><a href="https://github.com/OBOFoundry/OBOFoundry.github.io/tree/master/ontology">Ontologies Metadata Source</a></li>
-            <li><a href="https://github.com/OBOFoundry/OBOFoundry.github.io/blob/master/registry/">Combined Metadata</a></li>
-            <li><a href="https://raw.githubusercontent.com/OBOFoundry/OBOFoundry.github.io/master/registry/ontologies.yml">Ontology YAML</a></li>
-            <li><a href="https://raw.githubusercontent.com/OBOFoundry/OBOFoundry.github.io/master/registry/ontologies.jsonld">Ontology JSON-LD <i>alpha</i></a></li>
-            <li><a href="https://raw.githubusercontent.com/OBOFoundry/OBOFoundry.github.io/master/registry/ontologies.ttl">Ontology RDF/Turtle <i>alpha</i></a></li>
-          </ul>
-        </li>
-        
-        <li>
-          <a href="/resources">Resources</a>
-        </li>
-        
-        <li class="dropdown">
-          <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Citation <span class="caret"></span></a>
-          <ul class="dropdown-menu">
-            <li><a href="/docs/Citation.html">Cite Ontologies</a></li>
-            <li><a href="/registry/publications.html">Cite the OBO Foundry</a></li>
-            <li><a href="/registry/publications.html">Publications Related to the OBO Foundry</a></li>
-          </ul>
-        </li>
+      <li>
+        <a href="/resources">Resources</a>
+      </li>
 
-        <li class="dropdown">
-          <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Participate <span class="caret"></span></a>
-          <ul class="dropdown-menu">
-            <li><a href="https://github.com/OBOFoundry/OBOFoundry.github.io/issues">OBO Foundry Issue Tracker</a></li>
-            <li><a href="https://groups.google.com/forum/#!forum/obo-discuss">OBO-Discuss Mail List</a></li>
-            <li><a href="https://groups.google.com/forum/#!members/obo-tools">OBO-Tools Mail List</a></li>
-            <li><a href="https://obo-communitygroup.slack.com/archives/C01DP18L5GW">OBO Community Slack channel</a></li>
-             <li><a href="/faq/how-do-i-register-my-ontology.html">Submit your ontology</a></li>
-          </ul>
-        </li>
+      <li class="dropdown">
+        <a
+          href="#"
+          class="dropdown-toggle"
+          data-toggle="dropdown"
+          role="button"
+          aria-haspopup="true"
+          aria-expanded="false"
+          >Citation <span class="caret"></span
+        ></a>
+        <ul class="dropdown-menu">
+          <li><a href="/docs/Citation.html">Cite Ontologies</a></li>
+          <li>
+            <a href="/registry/publications.html">Cite the OBO Foundry</a>
+          </li>
+          <li>
+            <a href="/registry/publications.html"
+              >Publications Related to the OBO Foundry</a
+            >
+          </li>
+        </ul>
+      </li>
 
-        <li>
-          <a href="/faq/index.html">FAQ</a>
-        </li>
+      <li class="dropdown">
+        <a
+          href="#"
+          class="dropdown-toggle"
+          data-toggle="dropdown"
+          role="button"
+          aria-haspopup="true"
+          aria-expanded="false"
+          >Participate <span class="caret"></span
+        ></a>
+        <ul class="dropdown-menu">
+          <li>
+            <a href="https://github.com/OBOFoundry/OBOFoundry.github.io/issues"
+              >OBO Foundry Issue Tracker</a
+            >
+          </li>
+          <li>
+            <a href="https://groups.google.com/forum/#!forum/obo-discuss"
+              >OBO-Discuss Mail List</a
+            >
+          </li>
+          <li>
+            <a href="https://groups.google.com/forum/#!members/obo-tools"
+              >OBO-Tools Mail List</a
+            >
+          </li>
+          <li>
+            <a href="https://obo-communitygroup.slack.com/archives/C01DP18L5GW"
+              >OBO Community Slack channel</a
+            >
+          </li>
+          <li>
+            <a href="/faq/how-do-i-register-my-ontology.html"
+              >Submit your ontology</a
+            >
+          </li>
+        </ul>
+      </li>
 
-      </ul>
-      <form class="navbar-form navbar-right" role="search" action="https://ontobee.org/search" method="get">
-        <div class="form-group">
-          <input name="ontology" type="hidden" value="">
-          <input name="submit" type="hidden" value="Search terms">
-          <input name="keywords" type="text" class="form-control" placeholder="Search Ontobee">
-        </div>
-        <button type="submit" class="btn btn-default">Submit</button>
-      </form>
-    </div><!-- /.navbar-collapse -->
+      <li>
+        <a href="/faq/index.html">FAQ</a>
+      </li>
+    </ul>
+    <form
+      class="navbar-form navbar-right"
+      role="search"
+      action="https://ontobee.org/search"
+      method="get"
+    >
+      <div class="form-group">
+        <input name="ontology" type="hidden" value="" />
+        <input name="submit" type="hidden" value="Search terms" />
+        <input
+          name="keywords"
+          type="text"
+          class="form-control"
+          placeholder="Search Ontobee"
+        />
+      </div>
+      <button type="submit" class="btn btn-default">Submit</button>
+    </form>
+  </div>
+  <!-- /.navbar-collapse -->
 </nav>

--- a/_includes/news.html
+++ b/_includes/news.html
@@ -1,27 +1,33 @@
 {% for post in site.posts offset: 0 limit: 50 %}
 <div class="row">
-  <div class="span7">    
+  <div class="span7">
     <div class="row">
       <div class="span2 hidden-phone hidden-tablet">
-        <a href="{{ post.url }}" >
-            <img class="listImage img-rounded" border="0" src="{{ post.image }}" alt="{{ post.title }} image">
+        <a href="{{ post.url }}">
+          <img
+            class="listImage img-rounded"
+            border="0"
+            src="{{ post.image }}"
+            alt="{{ post.title }} image"
+          />
         </a>
       </div>
       <div class="span5">
-		<h4><strong><a href="{{ post.url }}">{{ post.title }}</a></strong></h4>      
+        <h4>
+          <strong><a href="{{ post.url }}">{{ post.title }}</a></strong>
+        </h4>
+        <p>{{ post.summary }}</p>
         <p>
-          {{ post.summary }}
-        </p>
-		<p>
-          <i class="icon-calendar"></i> {{ post.date | date: "%B %e, %Y" }}
-          | <i class="icon-comment"></i> <a href="{{ site.baseurl }}{{ post.url }}#disqus_thread"></a>     
-		  <br />
-                  <!-- <i class="icon-tags"></i> Tags :{% for tag in post.tags %} <a href="/tags/{{ tag }}" rel="tooltip" title="View posts tagged with &quot;{{ tag }}&quot;"><span class="label label-info">{{ tag }}</span></a>  {% if forloop.last != true %} {% endif %} {% endfor %}		            -->
+          <i class="icon-calendar"></i> {{ post.date | date: "%B %e, %Y" }} |
+          <i class="icon-comment"></i>
+          <a href="{{ site.baseurl }}{{ post.url }}#disqus_thread"></a>
+          <br />
+          <!-- <i class="icon-tags"></i> Tags :{% for tag in post.tags %} <a href="/tags/{{ tag }}" rel="tooltip" title="View posts tagged with &quot;{{ tag }}&quot;"><span class="label label-info">{{ tag }}</span></a>  {% if forloop.last != true %} {% endif %} {% endfor %}		            -->
         </p>
         <p><a href="{{ post.url }}">Read more</a></p>
       </div>
-    </div>    
-	<hr>
+    </div>
+    <hr />
   </div>
 </div>
 {% endfor %}

--- a/_includes/ontobee.html
+++ b/_includes/ontobee.html
@@ -1,10 +1,25 @@
-<form id="form_term_search" action="index.php" method="get" style="padding-top:20px; padding-bottom:20px;">
+<form
+  id="form_term_search"
+  action="index.php"
+  method="get"
+  style="padding-top: 20px; padding-bottom: 20px"
+>
   <div class="ui-widget">
     <strong>
       <label for="keywords">Keywords: </label>
     </strong>
-    <input aria-haspopup="true" aria-autocomplete="list" role="textbox" autocomplete="off" class="ui-autocomplete-input" id="keywords" name="keywords" size="30" value="">
-    <input name="Submit2" value="Search terms" type="submit">
-    <input name="o" id="ontology" value="OBO" type="hidden">
+    <input
+      aria-haspopup="true"
+      aria-autocomplete="list"
+      role="textbox"
+      autocomplete="off"
+      class="ui-autocomplete-input"
+      id="keywords"
+      name="keywords"
+      size="30"
+      value=""
+    />
+    <input name="Submit2" value="Search terms" type="submit" />
+    <input name="o" id="ontology" value="OBO" type="hidden" />
   </div>
 </form>

--- a/_includes/ontobee_search.html
+++ b/_includes/ontobee_search.html
@@ -1,7 +1,22 @@
-<form id="form_term_search" action="https://ontobee.org/browser/index.php" method="get" style="padding-top:20px; padding-bottom:20px;">
+<form
+  id="form_term_search"
+  action="https://ontobee.org/browser/index.php"
+  method="get"
+  style="padding-top: 20px; padding-bottom: 20px"
+>
   <div class="ui-widget">
-    <input aria-haspopup="true" aria-autocomplete="list" role="textbox" autocomplete="off" class="ui-autocomplete-input" id="keywords" name="keywords" size="30" value="">
-    <input name="Submit2" value="Search OBO" type="submit">
-    <input name="o" id="ontology" value="OBO" type="hidden">
+    <input
+      aria-haspopup="true"
+      aria-autocomplete="list"
+      role="textbox"
+      autocomplete="off"
+      class="ui-autocomplete-input"
+      id="keywords"
+      name="keywords"
+      size="30"
+      value=""
+    />
+    <input name="Submit2" value="Search OBO" type="submit" />
+    <input name="o" id="ontology" value="OBO" type="hidden" />
   </div>
 </form>

--- a/_includes/ontology_table.html
+++ b/_includes/ontology_table.html
@@ -1,121 +1,163 @@
 <!--this file has been replaced with the table_widget.html-->
 <!--use when javascript is not active-->
-Download table as: [ <a href="/registry/ontologies.yml">YAML</a> | <a href="/registry/ontologies.jsonld">JSON-LD</a> | <a href="/registry/ontologies.ttl">RDF/Turtle</a>  ]
+Download table as: [ <a href="/registry/ontologies.yml">YAML</a> |
+<a href="/registry/ontologies.jsonld">JSON-LD</a> |
+<a href="/registry/ontologies.ttl">RDF/Turtle</a> ]
 <table class="table">
   <tbody>
-    {% for ont in site.ontologies %}
-      {% if ont.in_foundry_order %}
-      <tr>
+    {% for ont in site.ontologies %} {% if ont.in_foundry_order %}
+    <tr>
       {% elsif ont.is_obsolete %}
-      <tr class="obsolete">
+    </tr>
+
+    <tr class="obsolete">
       {% elsif ont.activity_status == "orphaned" %}
-      <tr class="obsolete">
+    </tr>
+
+    <tr class="obsolete">
       {% elsif ont.activity_status == "inactive" %}
-      <tr class="obsolete">
+    </tr>
+
+    <tr class="obsolete">
       {% endif %}
       <td>
-         <a href="ontology/{{ ont.id }}.html" >
-           {% if ont.is_obsolete %}
-           <s>
-             {{ ont.id }}
-           </s>
-           {% else %}
-           {{ ont.id }}
-           {% endif %}
-         </a>
-      </td>
-      <td>
-        {% if ont.is_obsolete %}
-        <s>
-          {{ ont.title }}
-        </s>
-        {% else %}
-        {{ ont.title }}
-        {% endif %}
-        {% if ont.license %}
-        <a href="{{ont.license.url}}"><img width="100px" src="{{ont.license.logo}}" alt="{{ont.license.label}}"/></a>
-        {% endif %}
-      </td>
-      <td>
-        {% if ont.is_obsolete %}
-            <s>
-              {{ ont.description | truncate: 140 }}
-            </s>
-            <mark>obsolete</mark>
-        {% elsif ont.activity_status == "inactive" %}
-            {{ ont.description | truncate: 140 }}
-            <mark>inactive</mark>
-        {% else %}
-            {{ ont.description | truncate: 140 }}
-        {% endif %}
-        <small>
-          <a href="ontology/{{ ont.id }}.html" > Detail </a>
-        </small>
-      </td>
-      <td>
-        <a href="ontology/{{ont.id}}.html" class="btn btn-default" aria-label="More details for {{ ont.title }}" title="More details">
-            <span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span>
+        <a href="ontology/{{ ont.id }}.html">
+          {% if ont.is_obsolete %}
+          <s> {{ ont.id }} </s>
+          {% else %} {{ ont.id }} {% endif %}
         </a>
       </td>
       <td>
-        <a href="{{ont.homepage}}" class="btn btn-default" aria-label="Go to the homepage for {{ ont.title }}" title="Project home">
-            <span class="glyphicon glyphicon-home" aria-hidden="true"></span>
+        {% if ont.is_obsolete %}
+        <s> {{ ont.title }} </s>
+        {% else %} {{ ont.title }} {% endif %} {% if ont.license %}
+        <a href="{{ont.license.url}}"
+          ><img
+            width="100px"
+            src="{{ont.license.logo}}"
+            alt="{{ont.license.label}}"
+        /></a>
+        {% endif %}
+      </td>
+      <td>
+        {% if ont.is_obsolete %}
+        <s> {{ ont.description | truncate: 140 }} </s>
+        <mark>obsolete</mark>
+        {% elsif ont.activity_status == "inactive" %} {{ ont.description |
+        truncate: 140 }}
+        <mark>inactive</mark>
+        {% else %} {{ ont.description | truncate: 140 }} {% endif %}
+        <small>
+          <a href="ontology/{{ ont.id }}.html"> Detail </a>
+        </small>
+      </td>
+      <td>
+        <a
+          href="ontology/{{ont.id}}.html"
+          class="btn btn-default"
+          aria-label="More details for {{ ont.title }}"
+          title="More details"
+        >
+          <span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span>
+        </a>
+      </td>
+      <td>
+        <a
+          href="{{ont.homepage}}"
+          class="btn btn-default"
+          aria-label="Go to the homepage for {{ ont.title }}"
+          title="Project home"
+        >
+          <span class="glyphicon glyphicon-home" aria-hidden="true"></span>
         </a>
       </td>
       <td>
         {% if ont.tracker %}
-        <a href="{{ont.tracker}}" class="btn btn-default" aria-label="Go to the tracker for {{ ont.title }}" title="Tracker">
-            <span class="glyphicon glyphicon-comment" aria-hidden="true"></span>
+        <a
+          href="{{ont.tracker}}"
+          class="btn btn-default"
+          aria-label="Go to the tracker for {{ ont.title }}"
+          title="Tracker"
+        >
+          <span class="glyphicon glyphicon-comment" aria-hidden="true"></span>
         </a>
         {% endif %}
       </td>
 
       <td>
         {% if ont.contact %}
-        <a href="mailto:{{ont.contact.email}}" class="btn btn-default" aria-label="Send an email to {{ont.contact.label}}, the contact person for {{ ont.title }}" title="Email ontology devs">
-            <span class="glyphicon glyphicon-envelope" aria-hidden="true"></span>
+        <a
+          href="mailto:{{ont.contact.email}}"
+          class="btn btn-default"
+          aria-label="Send an email to {{ont.contact.label}}, the contact person for {{ ont.title }}"
+          title="Email ontology devs"
+        >
+          <span class="glyphicon glyphicon-envelope" aria-hidden="true"></span>
         </a>
         {% endif %}
       </td>
 
       <td>
-        <a href="http://purl.obolibrary.org/obo/{{ont.id}}.owl" class="btn btn-default" aria-label="Download {{ ont.title }} in the OWL format" title="Download file">
-            <span class="glyphicon glyphicon-download" aria-hidden="true"></span>
+        <a
+          href="http://purl.obolibrary.org/obo/{{ont.id}}.owl"
+          class="btn btn-default"
+          aria-label="Download {{ ont.title }} in the OWL format"
+          title="Download file"
+        >
+          <span class="glyphicon glyphicon-download" aria-hidden="true"></span>
         </a>
       </td>
 
       <td>
-        <a href="https://ontobee.org/browser/index.php?o={{ont.id}}" class="btn btn-default" aria-label="Browse {{ ont.title }} on OntoBee" title="Browse on Ontobee">
-            <span class="glyphicon glyphicon-eye-open" aria-hidden="true"></span>
+        <a
+          href="https://ontobee.org/browser/index.php?o={{ont.id}}"
+          class="btn btn-default"
+          aria-label="Browse {{ ont.title }} on OntoBee"
+          title="Browse on Ontobee"
+        >
+          <span class="glyphicon glyphicon-eye-open" aria-hidden="true"></span>
         </a>
       </td>
 
       <td>
         {% if ont.publications %}
-        <a href="{{ont.publications.first.id}}" class="btn btn-default" aria-label="View the primary publication for {{ ont.title }}" title="Publications list">
-            <span class="glyphicon glyphicon-book" aria-hidden="true"></span>
+        <a
+          href="{{ont.publications.first.id}}"
+          class="btn btn-default"
+          aria-label="View the primary publication for {{ ont.title }}"
+          title="Publications list"
+        >
+          <span class="glyphicon glyphicon-book" aria-hidden="true"></span>
         </a>
         {% endif %}
       </td>
 
       <td>
         {% if ont.in_foundry_order %}
-        <a href="/principles/fp-000-summary.html" class="btn btn-default" aria-label="View the OBO Foundry criteria for the Foundry status of {{ ont.title }}">
-            <span class="glyphicon glyphicon-star" aria-hidden="true"></span>
+        <a
+          href="/principles/fp-000-summary.html"
+          class="btn btn-default"
+          aria-label="View the OBO Foundry criteria for the Foundry status of {{ ont.title }}"
+        >
+          <span class="glyphicon glyphicon-star" aria-hidden="true"></span>
         </a>
         {% endif %}
       </td>
 
       <td>
-        {% if ont.repository %}
-          {% if ont.repository contains "https://github.com/" %}
-          <a href="{{ ont.repository }}" aria-label="Go to the repository page for {{ ont.title }}">
-            <img alt="GitHub Repo stars" src="https://img.shields.io/github/stars/{{ ont.repository | remove: 'https://github.com/' }}?style=social" />
-          </a>
-          {% endif %}
-        {% endif %}
+        {% if ont.repository %} {% if ont.repository contains
+        "https://github.com/" %}
+        <a
+          href="{{ ont.repository }}"
+          aria-label="Go to the repository page for {{ ont.title }}"
+        >
+          <img
+            alt="GitHub Repo stars"
+            src="https://img.shields.io/github/stars/{{ ont.repository | remove: 'https://github.com/' }}?style=social"
+          />
+        </a>
+        {% endif %} {% endif %}
       </td>
-
     </tr>
 
     {% endfor %}

--- a/_includes/review_table.html
+++ b/_includes/review_table.html
@@ -1,32 +1,24 @@
 <table class="tg">
   <tbody>
-		<tr>
-			<th class="tg-lbaf">Ontology Name</th>
-			<th class="tg-lbaf">Date</th>
-			<th class="tg-lbaf">Review</th>
-		</tr>
-    {% for ont in site.ontologies %}
-		  {% if ont.review %}
-		  <tr>
-				<td class="tg-yp4a">
-					<a href="../ontology/{{ ont.id }}.html">{{ont.title}}</a>
-				</td>
-				<td class="tg-yp4a">
-					{% if ont.review %}
-					  {{ont.review.date}}
-					{% else %}
-					  n/a
-					{% endif %}
-				</td>
-				<td class="tg-yp4a">
-					{% if ont.review.document %}
-					  <a href="{{ont.review.document.link}}">{{ont.review.document.label}}</a>
-					{% else %}
-					  n/a
-					{% endif %}
-				</td>
-			</tr>
-		  {% endif %}
-		{% endfor %}
-	</tbody>
+    <tr>
+      <th class="tg-lbaf">Ontology Name</th>
+      <th class="tg-lbaf">Date</th>
+      <th class="tg-lbaf">Review</th>
+    </tr>
+    {% for ont in site.ontologies %} {% if ont.review %}
+    <tr>
+      <td class="tg-yp4a">
+        <a href="../ontology/{{ ont.id }}.html">{{ont.title}}</a>
+      </td>
+      <td class="tg-yp4a">
+        {% if ont.review %} {{ont.review.date}} {% else %} n/a {% endif %}
+      </td>
+      <td class="tg-yp4a">
+        {% if ont.review.document %}
+        <a href="{{ont.review.document.link}}">{{ont.review.document.label}}</a>
+        {% else %} n/a {% endif %}
+      </td>
+    </tr>
+    {% endif %} {% endfor %}
+  </tbody>
 </table>

--- a/_includes/table_widget.html
+++ b/_includes/table_widget.html
@@ -1,36 +1,58 @@
 <div>
-    Download table as: [
-    <a href="/registry/ontologies.yml">YAML</a> |
-    <a href="/registry/ontologies.jsonld">JSON-LD</a> |
-    <a href="/registry/ontologies.ttl">RDF/Turtle</a>
-    ]
+  Download table as: [
+  <a href="/registry/ontologies.yml">YAML</a> |
+  <a href="/registry/ontologies.jsonld">JSON-LD</a> |
+  <a href="/registry/ontologies.ttl">RDF/Turtle</a>
+  ]
 </div>
 
-<div style="padding-bottom: 10px; padding-top: 20px;">
-    <label for="searchVal">Search Table</label>
-    <input type="text" style="width: 60%;" class="form-control" id="searchVal" placeholder="Search table ...">
+<div style="padding-bottom: 10px; padding-top: 20px">
+  <label for="searchVal">Search Table</label>
+  <input
+    type="text"
+    style="width: 60%"
+    class="form-control"
+    id="searchVal"
+    placeholder="Search table ..."
+  />
 </div>
 
 <div class="row">
-    <div class="col-md-3">
-        <label for="dd-domains">Ontology Domains:</label>
-        <select id="dd-domains">
-        </select>
-    </div>
-    <div class="form-group form-check col-md-3">
-        <input type="checkbox" class="form-check-input" id="groupByDomain" data-filter="domain" checked>
-        <label class="form-check-label" for="groupByDomain">Group By Domain</label>
-    </div>
-    <div class="form-group form-check col-md-3">
-        <input type="checkbox" class="form-check-input" id="hideInactive" data-filter="activity_status" checked>
-        <label class="form-check-label" for="hideInactive">Hide Inactive</label>
-    </div>
-    <div class="form-group form-check col-md-3">
-        <input type="checkbox" class="form-check-input" id="hideObsolete" data-filter="is_obsolete" checked>
-        <label class="form-check-label" for="hideObsolete">Hide Obsolete</label>
-    </div>
+  <div class="col-md-3">
+    <label for="dd-domains">Ontology Domains:</label>
+    <select id="dd-domains"></select>
+  </div>
+  <div class="form-group form-check col-md-3">
+    <input
+      type="checkbox"
+      class="form-check-input"
+      id="groupByDomain"
+      data-filter="domain"
+      checked
+    />
+    <label class="form-check-label" for="groupByDomain">Group By Domain</label>
+  </div>
+  <div class="form-group form-check col-md-3">
+    <input
+      type="checkbox"
+      class="form-check-input"
+      id="hideInactive"
+      data-filter="activity_status"
+      checked
+    />
+    <label class="form-check-label" for="hideInactive">Hide Inactive</label>
+  </div>
+  <div class="form-group form-check col-md-3">
+    <input
+      type="checkbox"
+      class="form-check-input"
+      id="hideObsolete"
+      data-filter="is_obsolete"
+      checked
+    />
+    <label class="form-check-label" for="hideObsolete">Hide Obsolete</label>
+  </div>
 </div>
 
 <!--below dic is been populated by javascript with table content-->
-<div id="tableDiv">
-</div>
+<div id="tableDiv"></div>

--- a/_includes/tag_sidebar.html
+++ b/_includes/tag_sidebar.html
@@ -1,1 +1,8 @@
-<i class="icon-tags"></i> Tags :<br>{% for tag in site.tags %} <a href="/tags/{{ tag[0] }}" rel="tooltip" title="View posts tagged with &quot;{{ tag[0] }}&quot;"><span class="label label-info">{{ tag[0] }}</span></a>  {% if forloop.last != true %} {% endif %} {% endfor %}
+<i class="icon-tags"></i> Tags :<br />{% for tag in site.tags %}
+<a
+  href="/tags/{{ tag[0] }}"
+  rel="tooltip"
+  title='View posts tagged with "{{ tag[0] }}"'
+  ><span class="label label-info">{{ tag[0] }}</span></a
+>
+{% if forloop.last != true %} {% endif %} {% endfor %}

--- a/_layouts/browse_layout.html
+++ b/_layouts/browse_layout.html
@@ -1,33 +1,26 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
     <title>{{ page.title }}</title>
-    <meta name="viewport" content="width=device-width">
-    <meta name="description" content="Ontology Website">    
-    <meta name="author" content="Chris Mungall">
+    <meta name="viewport" content="width=device-width" />
+    <meta name="description" content="Ontology Website" />
+    <meta name="author" content="Chris Mungall" />
     <script src="{{ site.baseurl}}js/all.js" type="text/javascript"></script>
-    <link href="{{ site.baseurl}}css/all.css" rel="stylesheet">
-    
+    <link href="{{ site.baseurl}}css/all.css" rel="stylesheet" />
   </head>
   <body data-spy="scroll" data-target=".subnav" data-offset="50">
-
     {% include navbar.html %}
 
-
     <div class="container">
-        <div class="content">
-            <div class="row">
-                <div class="span7 columns">
-                  {{ content }}
-
-                </div>
-            </div>
+      <div class="content">
+        <div class="row">
+          <div class="span7 columns">{{ content }}</div>
         </div>
+      </div>
     </div>
 
     {% include footer.html %}
-
   </body>
 </html>

--- a/_layouts/check.html
+++ b/_layouts/check.html
@@ -1,65 +1,64 @@
 ---
 layout: default
 ---
+
 <div class="content">
   <div>
     <div class="page-header">
-      <h1>
-        {{ page.title }}
-      </h1>      
-    <p>
-      {{page.summary}}
-    </p>
+      <h1>{{ page.title }}</h1>
+      <p>{{page.summary}}</p>
     </div>
-
   </div>
-   
+
   <div class="col-md-12">
     <div class="row">
       <div class="col-md-3">
         <ul>
-        {% for p in site.principles %}
-        <li>
-          <a href="../{{p.id}}.html">{{p.title}}</a>
-        </li>
-        {% endfor %}
+          {% for p in site.principles %}
+          <li>
+            <a href="../{{p.id}}.html">{{p.title}}</a>
+          </li>
+          {% endfor %}
         </ul>
-{% if page.id %}
+        {% if page.id %}
         <div class="btn-group" role="group" aria-label="Source">
-          <a href="https://github.com/OBOFoundry/OBOFoundry.github.io/blob/master/principles/{{page.id}}.md">
-            <button type="button" 
-                    data-toggle="tooltip" 
-                    title="See FAQ entry: How I do propose edits to principles?" 
-                    html="true"
-                    class="btn btn-default">
+          <a
+            href="https://github.com/OBOFoundry/OBOFoundry.github.io/blob/master/principles/{{page.id}}.md"
+          >
+            <button
+              type="button"
+              data-toggle="tooltip"
+              title="See FAQ entry: How I do propose edits to principles?"
+              html="true"
+              class="btn btn-default"
+            >
               View
             </button>
           </a>
-          <a href="https://github.com/OBOFoundry/OBOFoundry.github.io/edit/master/principles/checks/{{page.id}}.md">
-
-            <button type="button" 
-                    data-toggle="tooltip" 
-                    title="See FAQ entry: How I do propose edits to principles?" 
-                    html="true"
-                    class="btn btn-default">
-              Edit</button>
+          <a
+            href="https://github.com/OBOFoundry/OBOFoundry.github.io/edit/master/principles/checks/{{page.id}}.md"
+          >
+            <button
+              type="button"
+              data-toggle="tooltip"
+              title="See FAQ entry: How I do propose edits to principles?"
+              html="true"
+              class="btn btn-default"
+            >
+              Edit
+            </button>
           </a>
           <!-- <button type="button" class="btn btn-default">Help</button> -->
         </div>
-{% endif %}
+        {% endif %}
         <div>
-          This page is generated via <a href="{{site.repo_src}}_layouts/principle.html">_layouts/check.html</a>. See <a href="/faq/how-do-i-edit-content.html">edit guide</a>
+          This page is generated via
+          <a href="{{site.repo_src}}_layouts/principle.html"
+            >_layouts/check.html</a
+          >. See <a href="/faq/how-do-i-edit-content.html">edit guide</a>
         </div>
-
       </div>
-      <div class="col-md-9">
-        {{ content }}
-      </div>
+      <div class="col-md-9">{{ content }}</div>
     </div>
-
-    
   </div>
-
-
 </div>
-    

--- a/_layouts/community.html
+++ b/_layouts/community.html
@@ -1,32 +1,39 @@
 ---
 layout: default
 ---
+
 <div class="content">
   <div>
     <div class="page-header">
       <h1>
         {% if page.depicted_by %}
-        <img alt="logo" src="{{page.depicted_by}}"/>
-        {% endif %}
-        {{ page.title }}
+        <img alt="logo" src="{{page.depicted_by}}" />
+        {% endif %} {{ page.title }}
         <small>{{ page.tagline }}</small>
-      </h1>      
-      <p>
-        {{page.description}}
-      </p>
+      </h1>
+      <p>{{page.description}}</p>
       {% if page.twitter %}
-      <iframe style="position: static; visibility: visible; width: 190px; height: 20px;" 
-              data-twttr-rendered="true" title="Twitter Follow Button" 
-              class="twitter-follow-button twitter-follow-button" 
-              src="http://platform.twitter.com/widgets/follow_button.a64cf823bcb784855b86e2970134bd2a.en.html#_=1438577078419&amp;dnt=false&amp;id=twitter-widget-0&amp;lang=en&amp;screen_name={{page.twitter}}&amp;show_count=true&amp;show_screen_name=true&amp;size=m" 
-              allowtransparency="true" scrolling="no" id="twitter-widget-0" frameborder="0">
+      <iframe
+        style="
+          position: static;
+          visibility: visible;
+          width: 190px;
+          height: 20px;
+        "
+        data-twttr-rendered="true"
+        title="Twitter Follow Button"
+        class="twitter-follow-button twitter-follow-button"
+        src="http://platform.twitter.com/widgets/follow_button.a64cf823bcb784855b86e2970134bd2a.en.html#_=1438577078419&amp;dnt=false&amp;id=twitter-widget-0&amp;lang=en&amp;screen_name={{page.twitter}}&amp;show_count=true&amp;show_screen_name=true&amp;size=m"
+        allowtransparency="true"
+        scrolling="no"
+        id="twitter-widget-0"
+        frameborder="0"
+      >
       </iframe>
-      {% endif %}
-      {% if page.google_plus %}
+      {% endif %} {% if page.google_plus %}
       <a href="https://plus.google.com/{{page.google_plus}}">G+</a>
       {% endif %}
     </div>
-
   </div>
 
   {% if page.is_obsolete %}
@@ -43,27 +50,20 @@ layout: default
   {% endif %}
 
   <div class="col-md-12">
-
     <div class="row">
       <div class="col-md-8">
-
-
         <div>
           <h2>Ontologies</h2>
           <table class="table">
             <tbody>
-
               {% for p in page.ontologies %}
               <tr>
                 <td>
                   <a href="http://obofoundry.org/ontology/{{p.id}}">{{p.id}}</a>
                 </td>
+                <td>{{p.role}}</td>
                 <td>
-                  {{p.role}}
-                </td>
-                <td>
-                  {{p.description}}
-                  {% if p.page %}
+                  {{p.description}} {% if p.page %}
                   <a href="{{p.page}}"> [page]</a>
                   {% endif %}
                 </td>
@@ -74,13 +74,16 @@ layout: default
         </div>
 
         {{ content }}
-        
-
       </div>
       <div class="col-md-4">
-        <dl class="dl-horizontal" style="dd { margin-left: 0 }">
-
-
+        <dl
+          class="dl-horizontal"
+          style="
+            dd {
+              margin-left: 0;
+            }
+          "
+        >
           <dt>Homepage</dt>
           <dd>
             <a href="{{page.homepage}}">{{page.homepage}}</a>
@@ -89,9 +92,7 @@ layout: default
           <dd>
             <a href="{{p}}">{{p}}</a>
           </dd>
-          {% endfor %}
-
-          {% if page.biosharing %}
+          {% endfor %} {% if page.biosharing %}
           <dd>
             <a href="{{page.biosharing}}">{{page.biosharing}}</a>
           </dd>
@@ -102,135 +103,156 @@ layout: default
           <dd>
             <a href="https://github.com/{{member}}">@{{member}}</a>
           </dd>
-          {% endfor %}
-
-          {% if page.taxon %}
+          {% endfor %} {% if page.taxon %}
           <dt>Taxon</dt>
           <dd>
-            <a href="http://amigo.geneontology.org/amigo/term/{{page.taxon.id}}">{{page.taxon.label}}</a>
+            <a href="http://amigo.geneontology.org/amigo/term/{{page.taxon.id}}"
+              >{{page.taxon.label}}</a
+            >
           </dd>
-          {% endif %}
-
-          {% if page.exampleClass %}
+          {% endif %} {% if page.exampleClass %}
           <dt>Example</dt>
           <dd>
-            <a href="http://purl.obolibrary.org/obo/{{page.exampleClass}}">{{page.exampleClass}}</a>
+            <a href="http://purl.obolibrary.org/obo/{{page.exampleClass}}"
+              >{{page.exampleClass}}</a
+            >
           </dd>
-          {% endif %}
-
-          {% if page.publications %}
+          {% endif %} {% if page.publications %}
           <dt>Cite</dt>
           {% for p in page.publications %}
           <dd>
             <small><a href="{{p.id}}">{{p.title}}</a></small>
           </dd>
-          {% endfor %}
-          {% endif %}
-
-          {% if page.funded_by %}
+          {% endfor %} {% endif %} {% if page.funded_by %}
           <dt>Funding</dt>
           {% for x in page.funded_by %}
-          <dd>
-            {{x}}
-          </dd>
-          {% endfor %}
-          {% endif %}
-
-          {% if page.used_by %}
+          <dd>{{x}}</dd>
+          {% endfor %} {% endif %} {% if page.used_by %}
           <dt>Used by</dt>
           {% for x in page.used_by %}
           <dd>
             <a href="{{x.url}}">{{x.label}}</a>
           </dd>
-          {% endfor %}
-          {% endif %}
-
-          {% if page.dependencies %}
+          {% endfor %} {% endif %} {% if page.dependencies %}
           <dt>Dependencies</dt>
           {% for x in page.dependencies %}
           <dd>
             <a href="{{x.id}}">{{x.id}}</a>
           </dd>
-          {% endfor %}
-          {% endif %}
-
-
-
+          {% endfor %} {% endif %}
         </dl>
-        
+
         {% if page.id %}
         <div class="btn-group" role="group" aria-label="Source">
-          <a href="https://github.com/OBOFoundry/OBOFoundry.github.io/blob/master/community/{{page.id}}.md">
-            <button type="button" 
-                    data-toggle="tooltip" 
-                    title="See FAQ entry: How is metadata stored?" 
-                    html="true"
-                    class="btn btn-default">
+          <a
+            href="https://github.com/OBOFoundry/OBOFoundry.github.io/blob/master/community/{{page.id}}.md"
+          >
+            <button
+              type="button"
+              data-toggle="tooltip"
+              title="See FAQ entry: How is metadata stored?"
+              html="true"
+              class="btn btn-default"
+            >
               View
             </button>
           </a>
-          <a href="https://github.com/OBOFoundry/OBOFoundry.github.io/edit/master/community/{{page.id}}.md">
-
-            <button type="button" 
-                    data-toggle="tooltip" 
-                    title="See FAQ entry: How I do edit my metadata?" 
-                    html="true"
-                    class="btn btn-default">
-              Edit</button>
+          <a
+            href="https://github.com/OBOFoundry/OBOFoundry.github.io/edit/master/community/{{page.id}}.md"
+          >
+            <button
+              type="button"
+              data-toggle="tooltip"
+              title="See FAQ entry: How I do edit my metadata?"
+              html="true"
+              class="btn btn-default"
+            >
+              Edit
+            </button>
           </a>
-          <a href="https://github.com/OBOFoundry/purl.obolibrary.org/blob/master/config/{{page.id}}.yml">
-
-            <button type="button" 
-                    data-toggle="tooltip" 
-                    title="See FAQ entry: How I do edit my PURL?" 
-                    html="true"
-                    class="btn btn-default">
-              PURL</button>
+          <a
+            href="https://github.com/OBOFoundry/purl.obolibrary.org/blob/master/config/{{page.id}}.yml"
+          >
+            <button
+              type="button"
+              data-toggle="tooltip"
+              title="See FAQ entry: How I do edit my PURL?"
+              html="true"
+              class="btn btn-default"
+            >
+              PURL
+            </button>
           </a>
           <!-- <button type="button" class="btn btn-default">Help</button> -->
-        </div>{% endif %}
+        </div>
+        {% endif %}
       </div>
 
-
-{% if page.id %}      <div class="row">
-
+      {% if page.id %}
+      <div class="row">
         <footer class="footer">
           <div class="container">
             <p class="text-muted">
-              Edit the metadata for this page: <a href="https://github.com/OBOFoundry/OBOFoundry.github.io/edit/master/community/{{page.id}}.md">{{page.id}}.md</a> (GitHub will help you create a fork and pull request.)
-
+              Edit the metadata for this page:
+              <a
+                href="https://github.com/OBOFoundry/OBOFoundry.github.io/edit/master/community/{{page.id}}.md"
+                >{{page.id}}.md</a
+              >
+              (GitHub will help you create a fork and pull request.)
             </p>
           </div>
         </footer>
-      </div>{% endif %}
-
+      </div>
+      {% endif %}
     </div>
 
     {% if page.comments %}
-    <div>	
-      <div >    
+    <div>
+      <div>
         <h2>Comments Section</h2>
-        <p>Feel free to comment on the post but keep it clean and on topic.</p>	
+        <p>Feel free to comment on the post but keep it clean and on topic.</p>
         <div id="disqus_thread"></div>
         <script type="text/javascript">
           /* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */
-          var disqus_shortname = '{{ site.comments.disqus.short_name }}';
+          var disqus_shortname = "{{ site.comments.disqus.short_name }}";
 
           /* * * DON'T EDIT BELOW THIS LINE * * */
-          (function() {
-          var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-          dsq.src = 'http://' + disqus_shortname + '.disqus.com/embed.js';
-          (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
+          (function () {
+            var dsq = document.createElement("script");
+            dsq.type = "text/javascript";
+            dsq.async = true;
+            dsq.src = "http://" + disqus_shortname + ".disqus.com/embed.js";
+            (
+              document.getElementsByTagName("head")[0] ||
+              document.getElementsByTagName("body")[0]
+            ).appendChild(dsq);
           })();
         </script>
-        <noscript>Please enable JavaScript to view the <a href="http://disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>
-        <a href="http://disqus.com" class="dsq-brlink">comments powered by <span class="logo-disqus">Disqus</span></a>
+        <noscript
+          >Please enable JavaScript to view the
+          <a href="http://disqus.com/?ref_noscript"
+            >comments powered by Disqus.</a
+          ></noscript
+        >
+        <a href="http://disqus.com" class="dsq-brlink"
+          >comments powered by <span class="logo-disqus">Disqus</span></a
+        >
       </div>
     </div>
     {% endif %}
-    
-    <!-- Twitter -->
-    <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0];if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src="//platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>
 
+    <!-- Twitter -->
+    <script>
+      !(function (d, s, id) {
+        var js,
+          fjs = d.getElementsByTagName(s)[0];
+        if (!d.getElementById(id)) {
+          js = d.createElement(s);
+          js.id = id;
+          js.src = "//platform.twitter.com/widgets.js";
+          fjs.parentNode.insertBefore(js, fjs);
+        }
+      })(document, "script", "twitter-wjs");
+    </script>
   </div>
 </div>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,6 +1,6 @@
 ---
-theme :
-  name : bootstrap-3
+theme:
+  name: bootstrap-3
 ---
-{% include JB/setup %}
-{% include themes/bootstrap-3/default.html %}
+
+{% include JB/setup %} {% include themes/bootstrap-3/default.html %}

--- a/_layouts/doc.html
+++ b/_layouts/doc.html
@@ -1,57 +1,52 @@
 ---
 layout: default
 ---
+
 <div class="content">
   <div>
     <div class="page-header">
-      <h1>
-        {{ page.title }}
-      </h1>      
+      <h1>{{ page.title }}</h1>
     </div>
-
   </div>
-   
-  <div class="col-md-12">
 
+  <div class="col-md-12">
     <div class="row">
       <div class="col-md-3">
-        {% capture my_include %}{% include docs_toc.md %}{% endcapture %}
-        {{ my_include | markdownify }}
-        {% if page.id %}
+        {% capture my_include %}{% include docs_toc.md %}{% endcapture %} {{
+        my_include | markdownify }} {% if page.id %}
         <div class="btn-group" role="group" aria-label="Source">
-          <a href="https://github.com/OBOFoundry/OBOFoundry.github.io/blob/master/docs/{{page.id}}.md">
-            <button type="button" 
-                    data-toggle="tooltip" 
-                    title="See FAQ entry: How is metadata stored?" 
-                    html="true"
-                    class="btn btn-default">
+          <a
+            href="https://github.com/OBOFoundry/OBOFoundry.github.io/blob/master/docs/{{page.id}}.md"
+          >
+            <button
+              type="button"
+              data-toggle="tooltip"
+              title="See FAQ entry: How is metadata stored?"
+              html="true"
+              class="btn btn-default"
+            >
               View
             </button>
           </a>
-          <a href="https://github.com/OBOFoundry/OBOFoundry.github.io/edit/master/docs/{{page.id}}.md">
-
-            <button type="button" 
-                    data-toggle="tooltip" 
-                    title="See FAQ entry: How I do edit my metadata?" 
-                    html="true"
-                    class="btn btn-default">
-              Edit</button>
+          <a
+            href="https://github.com/OBOFoundry/OBOFoundry.github.io/edit/master/docs/{{page.id}}.md"
+          >
+            <button
+              type="button"
+              data-toggle="tooltip"
+              title="See FAQ entry: How I do edit my metadata?"
+              html="true"
+              class="btn btn-default"
+            >
+              Edit
+            </button>
           </a>
           <!-- <button type="button" class="btn btn-default">Help</button> -->
-        </div>{% endif %}
+        </div>
+        {% endif %}
       </div>
 
-      <div class="col-md-9">
-
-        {{ content }}
-        
-      </div>
-
-
-
+      <div class="col-md-9">{{ content }}</div>
     </div>
-
   </div>
-
 </div>
-    

--- a/_layouts/faq.html
+++ b/_layouts/faq.html
@@ -1,28 +1,24 @@
 ---
 layout: default
 ---
+
 <div class="content">
   <div>
     <div class="page-header">
-      <h1>
-        FAQ: {{ page.title }}
-      </h1>
+      <h1>FAQ: {{ page.title }}</h1>
       {% if page.summary %}
-        <p>
-          {{page.summary}}
-        </p>
+      <p>{{page.summary}}</p>
       {% endif %}
     </div>
-
   </div>
 
   <div class="col-md-12">
     {{ content }}
-    <br/>
-    <strong>Was this helpful?</strong> Please contact us if you have questions or something is not clear. <a href="https://github.com/OBOFoundry/OBOFoundry.github.io/issues/new">File an issue on GitHub</a>
+    <br />
+    <strong>Was this helpful?</strong> Please contact us if you have questions
+    or something is not clear.
+    <a href="https://github.com/OBOFoundry/OBOFoundry.github.io/issues/new"
+      >File an issue on GitHub</a
+    >
   </div>
-
-
-
 </div>
-    

--- a/_layouts/ontology_detail.html
+++ b/_layouts/ontology_detail.html
@@ -1,35 +1,42 @@
 ---
 layout: default
 ---
+
 <div class="content">
   <div>
     <div class="page-header">
       <h1>
         {% if page.depicted_by %}
-        <img alt="logo" src="{{page.depicted_by}}" style="max-height: 1em;" />
-        {% endif %}
-        {{ page.title }}
+        <img alt="logo" src="{{page.depicted_by}}" style="max-height: 1em" />
+        {% endif %} {{ page.title }}
       </h1>
-      <p>
-        {{page.description}}
-      </p>
-      {% if page.repository %}
-        {% if page.repository contains "https://github.com/" %}
-        <a href="{{ page.repository }}">
-          <img alt="GitHub Repo stars" src="https://img.shields.io/github/stars/{{ page.repository | remove: 'https://github.com/' }}" />
-          <img alt="GitHub contributors" src="https://img.shields.io/github/contributors/{{ page.repository | remove: 'https://github.com/' }}" />
-          <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/{{ page.repository | remove: 'https://github.com/' }}" />
-          <!--<img alt="GitHub issues" src="https://img.shields.io/github/issues/{{ page.repository | remove: 'https://github.com/' }}" />-->
-        </a>
-        {% endif %}
-      {% endif %}
-      {% if page.twitter %}
-        <a href="https://twitter.com/{{ page.twitter }}">
-          <img alt="Twitter Follow" src="https://img.shields.io/twitter/follow/{{ page.twitter }}?style=social">
-        </a>
+      <p>{{page.description}}</p>
+      {% if page.repository %} {% if page.repository contains
+      "https://github.com/" %}
+      <a href="{{ page.repository }}">
+        <img
+          alt="GitHub Repo stars"
+          src="https://img.shields.io/github/stars/{{ page.repository | remove: 'https://github.com/' }}"
+        />
+        <img
+          alt="GitHub contributors"
+          src="https://img.shields.io/github/contributors/{{ page.repository | remove: 'https://github.com/' }}"
+        />
+        <img
+          alt="GitHub last commit"
+          src="https://img.shields.io/github/last-commit/{{ page.repository | remove: 'https://github.com/' }}"
+        />
+        <!--<img alt="GitHub issues" src="https://img.shields.io/github/issues/{{ page.repository | remove: 'https://github.com/' }}" />-->
+      </a>
+      {% endif %} {% endif %} {% if page.twitter %}
+      <a href="https://twitter.com/{{ page.twitter }}">
+        <img
+          alt="Twitter Follow"
+          src="https://img.shields.io/twitter/follow/{{ page.twitter }}?style=social"
+        />
+      </a>
       {% endif %}
     </div>
-
   </div>
 
   {% if page.is_obsolete %}
@@ -43,38 +50,34 @@ layout: default
     </div>
     {% endfor %}
   </div>
-  {% endif %}
-
-  {% if page.activity_status == "inactive" %}{% unless page.is_obsolete %}
+  {% endif %} {% if page.activity_status == "inactive" %}{% unless
+  page.is_obsolete %}
   <div>
     <div class="alert alert-warning" role="alert">
-      This ontology is inactive. For more information see <a href="/docs/OntologyStatus.html">here</a>.
+      This ontology is inactive. For more information see
+      <a href="/docs/OntologyStatus.html">here</a>.
     </div>
   </div>
-  {% endunless %}{% endif %}
-
-  {% if page.activity_status == "orphaned" %}{% unless page.is_obsolete %}
+  {% endunless %}{% endif %} {% if page.activity_status == "orphaned" %}{%
+  unless page.is_obsolete %}
   <div>
     <div class="alert alert-warning" role="alert">
-      This ontology is orphaned. For more information see <a href="/docs/OntologyStatus.html">here</a>.
+      This ontology is orphaned. For more information see
+      <a href="/docs/OntologyStatus.html">here</a>.
     </div>
   </div>
-  {% endunless %}{% endif %}
-
-  {% if page.preferredPrefix %}
-  {% assign upperPrefix = page.preferredPrefix | upcase %}
-  {% if upperPrefix != page.preferredPrefix %}
+  {% endunless %}{% endif %} {% if page.preferredPrefix %} {% assign upperPrefix
+  = page.preferredPrefix | upcase %} {% if upperPrefix != page.preferredPrefix
+  %}
   <div>
     <div class="alert alert-info" role="alert">
-      This ontology uses a mixed-case prefix. Identifiers and URIs
-      should use: "{{ page.preferredPrefix }}".
+      This ontology uses a mixed-case prefix. Identifiers and URIs should use:
+      "{{ page.preferredPrefix }}".
     </div>
   </div>
-  {% endif %}
-  {% endif %}
+  {% endif %} {% endif %}
 
   <div class="col-md-12">
-
     <div class="row">
       <div class="col-md-8">
         <!-- TODO: each ontology should configure which browsers to be exposed in -->
@@ -97,26 +100,20 @@ layout: default
         <a href="{{b.url}}">
           <button type="button" class="btn btn-default">{{b.label}}</button>
         </a>
-        {% endfor %}
-
-        {{ content }}
+        {% endfor %} {{ content }}
 
         <div>
           <h2>Products</h2>
           <table class="table">
             <tbody>
-
               {% for p in page.products %}
               <tr>
                 <td>
                   <a href="http://purl.obolibrary.org/obo/{{p.id}}">{{p.id}}</a>
                 </td>
+                <td>{{p.title}}</td>
                 <td>
-                  {{p.title}}
-                </td>
-                <td>
-                  {{p.description}}
-                  {% if p.page %}
+                  {{p.description}} {% if p.page %}
                   <a href="{{p.page}}"> [page]</a>
                   {% endif %}
                 </td>
@@ -130,31 +127,32 @@ layout: default
           <h2>Usages</h2>
           {% for p in page.usages %}
           <dl class="dl-horizontal">
-            <dt>User</dt> <dd><a href="{{p.user}}">{{p.user}}</a></dd>
-            <dt>Description</dt><dd>{{p.description}}</dd>
+            <dt>User</dt>
+            <dd><a href="{{p.user}}">{{p.user}}</a></dd>
+            <dt>Description</dt>
+            <dd>{{p.description}}</dd>
             {% if p.type %}
-            <dt>Type</dt> <dd>{{p.type}}</dd>
-            {% endif %}
-            {% if p.seeAlso %}
-            <dt>See also</dt> <dd><a href="{{p.seeAlso}}">{{p.seeAlso}}</a></dd>
-            {% endif %}
-            {% if p.examples %}
+            <dt>Type</dt>
+            <dd>{{p.type}}</dd>
+            {% endif %} {% if p.seeAlso %}
+            <dt>See also</dt>
+            <dd><a href="{{p.seeAlso}}">{{p.seeAlso}}</a></dd>
+            {% endif %} {% if p.examples %}
             <dt>Examples</dt>
             <dd>
               <ul style="padding-left: 20px">
-              {% for example in p.examples %}
+                {% for example in p.examples %}
                 <li><a href="{{example.url}}">{{example.description}}</a></li>
-              {% endfor %}
+                {% endfor %}
               </ul>
             </dd>
-            {% endif %}
-            {% if p.publications %}
+            {% endif %} {% if p.publications %}
             <dt>Publications</dt>
             <dd>
               <ul style="padding-left: 20px">
-              {% for publication in p.publications %}
+                {% for publication in p.publications %}
                 <li><a href="{{publication.id}}">{{publication.title}}</a></li>
-              {% endfor %}
+                {% endfor %}
               </ul>
             </dd>
             {% endif %}
@@ -162,28 +160,26 @@ layout: default
           {% endfor %}
         </div>
         {% endif %}
-
-
       </div>
-
 
       <div class="col-md-4">
         <dl class="dl-horizontal" style="margin-left: 0">
-
           <dt>
             ID Space
-            <span data-toggle="tooltip"
-                  title="ID prefix"
-                  data-html="true">
+            <span data-toggle="tooltip" title="ID prefix" data-html="true">
             </span>
           </dt>
           <dd>
-            <a href="http://purl.obolibrary.org/obo/{{page.id}}/">{{page.id}}</a>
+            <a href="http://purl.obolibrary.org/obo/{{page.id}}/"
+              >{{page.id}}</a
+            >
           </dd>
 
           <dt>PURL</dt>
           <dd>
-            <a href="http://purl.obolibrary.org/obo/{{page.id}}.owl">http://purl.obolibrary.org/obo/{{page.id}}.owl</a>
+            <a href="http://purl.obolibrary.org/obo/{{page.id}}.owl"
+              >http://purl.obolibrary.org/obo/{{page.id}}.owl</a
+            >
           </dd>
 
           <dt>License</dt>
@@ -192,14 +188,19 @@ layout: default
             <a href="{{page.license.url}}">{{page.license.label}}</a>
             {% if page.license.alert %}
             <div class="alert alert-danger" role="alert">
-              <span class="glyphicon glyphicon-exclamation-sign" aria-hidden="true"></span>
+              <span
+                class="glyphicon glyphicon-exclamation-sign"
+                aria-hidden="true"
+              ></span>
               <span class="sr-only">Warning:</span>
               {{page.license.alert}}
             </div>
-            {% endif %}
-            {% else %}
+            {% endif %} {% else %}
             <div class="alert alert-danger" role="alert">
-              <span class="glyphicon glyphicon-exclamation-sign" aria-hidden="true"></span>
+              <span
+                class="glyphicon glyphicon-exclamation-sign"
+                aria-hidden="true"
+              ></span>
               <span class="sr-only">Warning:</span>
               Not entered
             </div>
@@ -214,9 +215,7 @@ layout: default
           <dd>
             <a href="{{p}}">{{p}}</a>
           </dd>
-          {% endfor %}
-
-          {% if page.biosharing %}
+          {% endfor %} {% if page.biosharing %}
           <dd>
             <a href="{{page.biosharing}}">{{page.biosharing}}</a>
           </dd>
@@ -242,154 +241,166 @@ layout: default
           <dd>
             <a href="{{page.mailing_list}}">{{page.mailing_list}}</a>
           </dd>
-          {% endif %}
-
-          {% if page.taxon %}
+          {% endif %} {% if page.taxon %}
           <dt>Taxon</dt>
           <dd>
-            <a href="http://amigo.geneontology.org/amigo/term/{{page.taxon.id}}">{{page.taxon.label}}</a>
+            <a href="http://amigo.geneontology.org/amigo/term/{{page.taxon.id}}"
+              >{{page.taxon.label}}</a
+            >
           </dd>
-          {% endif %}
-
-          {% if page.exampleClass %}
+          {% endif %} {% if page.exampleClass %}
           <dt>Example</dt>
           <dd>
-            <a href="http://purl.obolibrary.org/obo/{{page.exampleClass}}">{{page.exampleClass}}</a>
+            <a href="http://purl.obolibrary.org/obo/{{page.exampleClass}}"
+              >{{page.exampleClass}}</a
+            >
           </dd>
-          {% endif %}
-
-          {% if page.publications %}
+          {% endif %} {% if page.publications %}
           <dt>Cite</dt>
           {% for p in page.publications %}
           <dd>
             <small><a href="{{p.id}}">{{p.title}}</a></small>
           </dd>
-          {% endfor %}
-          {% endif %}
-
-          {% if page.funded_by %}
+          {% endfor %} {% endif %} {% if page.funded_by %}
           <dt>Funding</dt>
           {% for x in page.funded_by %}
-          <dd>
-            {{x}}
-          </dd>
-          {% endfor %}
-          {% endif %}
-
-          {% if page.used_by %}
+          <dd>{{x}}</dd>
+          {% endfor %} {% endif %} {% if page.used_by %}
           <dt>Used by</dt>
           {% for x in page.used_by %}
           <dd>
             <a href="{{x.url}}">{{x.label}}</a>
           </dd>
-          {% endfor %}
-          {% endif %}
-
-          {% if page.dependencies %}
+          {% endfor %} {% endif %} {% if page.dependencies %}
           <dt>Dependencies</dt>
           {% for x in page.dependencies %}
           <dd>
             <a href="{{x.id}}">{{x.id}}</a>
           </dd>
-          {% endfor %}
-          {% endif %}
-
-          {% if page.jobs %}
+          {% endfor %} {% endif %} {% if page.jobs %}
           <dt>Jobs</dt>
           {% for p in page.jobs %}
           <dd>
             {% if p.type == "travis-cl" or p.id contains "travis" %}
             <a href="{{p.id}}">
-              <img alt="Build Status" src="{{p.id}}.svg?branch=master"/>
+              <img alt="Build Status" src="{{p.id}}.svg?branch=master" />
             </a>
             {% else %}
             <a href="{{p.id}}">{{p.type}}</a>
             {% endif %}
           </dd>
-          {% endfor %}
-          {% endif %}
-
-          {% if page.review.date and page.review.document %}
+          {% endfor %} {% endif %} {% if page.review.date and
+          page.review.document %}
           <dt>OBO Review</dt>
-          <dd>{{page.review.date}} <a href="{{page.review.document.link}}">{{page.review.document.label}}</a><dd>
-          {% endif %}
-
+          <dd>
+            {{page.review.date}}
+            <a href="{{page.review.document.link}}"
+              >{{page.review.document.label}}</a
+            >
+          </dd>
+          <dd>{% endif %}</dd>
         </dl>
 
-
         <div class="btn-group" role="group" aria-label="Source">
-          <a href="https://github.com/OBOFoundry/OBOFoundry.github.io/blob/master/ontology/{{page.id}}.md">
-            <button type="button"
-                    data-toggle="tooltip"
-                    title="See FAQ entry: How is metadata stored?"
-                    data-html="true"
-                    class="btn btn-default">
+          <a
+            href="https://github.com/OBOFoundry/OBOFoundry.github.io/blob/master/ontology/{{page.id}}.md"
+          >
+            <button
+              type="button"
+              data-toggle="tooltip"
+              title="See FAQ entry: How is metadata stored?"
+              data-html="true"
+              class="btn btn-default"
+            >
               View
             </button>
           </a>
-          <a href="https://github.com/OBOFoundry/OBOFoundry.github.io/edit/master/ontology/{{page.id}}.md">
-
-            <button type="button"
-                    data-toggle="tooltip"
-                    title="See FAQ entry: How I do edit my metadata?"
-                    data-html="true"
-                    class="btn btn-default">
-              Edit</button>
+          <a
+            href="https://github.com/OBOFoundry/OBOFoundry.github.io/edit/master/ontology/{{page.id}}.md"
+          >
+            <button
+              type="button"
+              data-toggle="tooltip"
+              title="See FAQ entry: How I do edit my metadata?"
+              data-html="true"
+              class="btn btn-default"
+            >
+              Edit
+            </button>
           </a>
-          <a href="https://github.com/OBOFoundry/purl.obolibrary.org/blob/master/config/{{page.id}}.yml">
-
-            <button type="button"
-                    data-toggle="tooltip"
-                    title="See FAQ entry: How I do edit my PURL?"
-                    data-html="true"
-                    class="btn btn-default">
-              PURL</button>
+          <a
+            href="https://github.com/OBOFoundry/purl.obolibrary.org/blob/master/config/{{page.id}}.yml"
+          >
+            <button
+              type="button"
+              data-toggle="tooltip"
+              title="See FAQ entry: How I do edit my PURL?"
+              data-html="true"
+              class="btn btn-default"
+            >
+              PURL
+            </button>
           </a>
           <div>
-            Generated by: <a href="{{site.repo_src}}_layouts/ontology_detail.html">_layouts/ontology_detail.html</a><br/> See <a href="/faq/how-do-i-edit-metadata.html">metadata guide</a>
+            Generated by:
+            <a href="{{site.repo_src}}_layouts/ontology_detail.html"
+              >_layouts/ontology_detail.html</a
+            ><br />
+            See <a href="/faq/how-do-i-edit-metadata.html">metadata guide</a>
           </div>
           <!-- <button type="button" class="btn btn-default">Help</button> -->
         </div>
       </div>
 
-
-
       <div class="row">
-
         <footer class="footer">
           <div class="container">
             <p class="text-muted">
-              Edit the metadata for this page: <a href="https://github.com/OBOFoundry/OBOFoundry.github.io/edit/master/ontology/{{page.id}}.md">{{page.id}}.md</a> (GitHub will help you create a fork and pull request.)
-
+              Edit the metadata for this page:
+              <a
+                href="https://github.com/OBOFoundry/OBOFoundry.github.io/edit/master/ontology/{{page.id}}.md"
+                >{{page.id}}.md</a
+              >
+              (GitHub will help you create a fork and pull request.)
             </p>
           </div>
         </footer>
       </div>
-
     </div>
 
     {% if page.comments %}
     <div>
-      <div >
+      <div>
         <h2>Comments Section</h2>
         <p>Feel free to comment on the post but keep it clean and on topic.</p>
         <div id="disqus_thread"></div>
         <script type="text/javascript">
           /* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */
-          var disqus_shortname = '{{ site.comments.disqus.short_name }}';
+          var disqus_shortname = "{{ site.comments.disqus.short_name }}";
 
           /* * * DON'T EDIT BELOW THIS LINE * * */
-          (function() {
-          var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-          dsq.src = 'http://' + disqus_shortname + '.disqus.com/embed.js';
-          (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
+          (function () {
+            var dsq = document.createElement("script");
+            dsq.type = "text/javascript";
+            dsq.async = true;
+            dsq.src = "http://" + disqus_shortname + ".disqus.com/embed.js";
+            (
+              document.getElementsByTagName("head")[0] ||
+              document.getElementsByTagName("body")[0]
+            ).appendChild(dsq);
           })();
         </script>
-        <noscript>Please enable JavaScript to view the <a href="http://disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>
-        <a href="http://disqus.com" class="dsq-brlink">comments powered by <span class="logo-disqus">Disqus</span></a>
+        <noscript
+          >Please enable JavaScript to view the
+          <a href="http://disqus.com/?ref_noscript"
+            >comments powered by Disqus.</a
+          ></noscript
+        >
+        <a href="http://disqus.com" class="dsq-brlink"
+          >comments powered by <span class="logo-disqus">Disqus</span></a
+        >
       </div>
     </div>
     {% endif %}
-
   </div>
 </div>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -9,7 +9,7 @@ layout: default
 
         <div class="span7 columns">
             {{ page.summary }}
-            </br>
+            <br />
         </div>
         <div>
           <img class="listImage img-rounded" border="0" src="{{ page.image }}" alt="{{ page.title }} image">
@@ -34,7 +34,7 @@ layout: default
               <i class="icon-calendar"></i> {{ page.date | date: "%B %e, %Y" }}
               | <i class="icon-comment"></i> <a href="{{ page.url }}#disqus_thread"></a>     
               <br />
-              <a href="https://twitter.com/share" class="twitter-share-button" data-via="{{ site.project.twitter }}">Tweet</a> <g:plusone size="medium"></g:plusone></h5>
+              <a href="https://twitter.com/share" class="twitter-share-button" data-via="{{ site.project.twitter }}">Tweet</a>
             </p>
         </div>
     </div>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -1,77 +1,121 @@
 ---
 layout: default
 ---
-<div class="content">    
-    <div class="row">	
-        <div class="span7 column">
-            <h1>{{ page.title }}</h1>
-        </div>
 
-        <div class="span7 columns">
-            {{ page.summary }}
-            <br />
-        </div>
-        <div>
-          <img class="listImage img-rounded" border="0" src="{{ page.image }}" alt="{{ page.title }} image">
-        </div>
-    </div>
-    
-    <div class="row">	
-        <div class="span7 columns">
-            {{ content }}
-        </div>
-    </div>
-    
-    <div class="pager hidden-phone hidden-tablet">
-        <a class="prev" href="{{ page.previous.url }}" title="Previous Post: {{page.previous.title}}"><i class="icon-arrow-left icon-white"></i></a>
-        <a class="next" href="{{ page.next.url }}" title="Previous Post: {{page.next.title}}"><i class="icon-arrow-right icon-white"></i></a>
-    </div>
-    
-    <div class="row">	
-        <div class="span7 column">
-            <p>
-              <i>{{ page.author}}</i>
-              <i class="icon-calendar"></i> {{ page.date | date: "%B %e, %Y" }}
-              | <i class="icon-comment"></i> <a href="{{ page.url }}#disqus_thread"></a>     
-              <br />
-              <a href="https://twitter.com/share" class="twitter-share-button" data-via="{{ site.project.twitter }}">Tweet</a>
-            </p>
-        </div>
+<div class="content">
+  <div class="row">
+    <div class="span7 column">
+      <h1>{{ page.title }}</h1>
     </div>
 
-    {% if page.comments %}
-    <div class="row">	
-        <div class="span7 columns">    
-            <h2>Comments Section</h2>
-            <p>Feel free to comment on the post but keep it clean and on topic.</p>	
-            <div id="disqus_thread"></div>
-            <script type="text/javascript">
-                /* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */
-                var disqus_shortname = '{{ site.comments.disqus.short_name }}';
-
-                /* * * DON'T EDIT BELOW THIS LINE * * */
-                (function() {
-                    var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-                    dsq.src = 'http://' + disqus_shortname + '.disqus.com/embed.js';
-                    (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
-                })();
-            </script>
-            <noscript>Please enable JavaScript to view the <a href="http://disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>
-            <a href="http://disqus.com" class="dsq-brlink">comments powered by <span class="logo-disqus">Disqus</span></a>
-        </div>
+    <div class="span7 columns">
+      {{ page.summary }}
+      <br />
     </div>
-    {% endif %}
-    
-    <!-- Twitter -->
-    <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0];if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src="//platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>
+    <div>
+      <img
+        class="listImage img-rounded"
+        border="0"
+        src="{{ page.image }}"
+        alt="{{ page.title }} image"
+      />
+    </div>
+  </div>
 
-    <!-- Google + -->
-    <script type="text/javascript">
-      (function() {
-        var po = document.createElement('script'); po.type = 'text/javascript'; po.async = true;
-        po.src = 'https://apis.google.com/js/plusone.js';
-        var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(po, s);
-      })();
-    </script>
+  <div class="row">
+    <div class="span7 columns">{{ content }}</div>
+  </div>
+
+  <div class="pager hidden-phone hidden-tablet">
+    <a
+      class="prev"
+      href="{{ page.previous.url }}"
+      title="Previous Post: {{page.previous.title}}"
+      ><i class="icon-arrow-left icon-white"></i
+    ></a>
+    <a
+      class="next"
+      href="{{ page.next.url }}"
+      title="Previous Post: {{page.next.title}}"
+      ><i class="icon-arrow-right icon-white"></i
+    ></a>
+  </div>
+
+  <div class="row">
+    <div class="span7 column">
+      <p>
+        <i>{{ page.author}}</i>
+        <i class="icon-calendar"></i> {{ page.date | date: "%B %e, %Y" }} |
+        <i class="icon-comment"></i> <a href="{{ page.url }}#disqus_thread"></a>
+        <br />
+        <a
+          href="https://twitter.com/share"
+          class="twitter-share-button"
+          data-via="{{ site.project.twitter }}"
+          >Tweet</a
+        >
+      </p>
+    </div>
+  </div>
+
+  {% if page.comments %}
+  <div class="row">
+    <div class="span7 columns">
+      <h2>Comments Section</h2>
+      <p>Feel free to comment on the post but keep it clean and on topic.</p>
+      <div id="disqus_thread"></div>
+      <script type="text/javascript">
+        /* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */
+        var disqus_shortname = "{{ site.comments.disqus.short_name }}";
+
+        /* * * DON'T EDIT BELOW THIS LINE * * */
+        (function () {
+          var dsq = document.createElement("script");
+          dsq.type = "text/javascript";
+          dsq.async = true;
+          dsq.src = "http://" + disqus_shortname + ".disqus.com/embed.js";
+          (
+            document.getElementsByTagName("head")[0] ||
+            document.getElementsByTagName("body")[0]
+          ).appendChild(dsq);
+        })();
+      </script>
+      <noscript
+        >Please enable JavaScript to view the
+        <a href="http://disqus.com/?ref_noscript"
+          >comments powered by Disqus.</a
+        ></noscript
+      >
+      <a href="http://disqus.com" class="dsq-brlink"
+        >comments powered by <span class="logo-disqus">Disqus</span></a
+      >
+    </div>
+  </div>
+  {% endif %}
+
+  <!-- Twitter -->
+  <script>
+    !(function (d, s, id) {
+      var js,
+        fjs = d.getElementsByTagName(s)[0];
+      if (!d.getElementById(id)) {
+        js = d.createElement(s);
+        js.id = id;
+        js.src = "//platform.twitter.com/widgets.js";
+        fjs.parentNode.insertBefore(js, fjs);
+      }
+    })(document, "script", "twitter-wjs");
+  </script>
+
+  <!-- Google + -->
+  <script type="text/javascript">
+    (function () {
+      var po = document.createElement("script");
+      po.type = "text/javascript";
+      po.async = true;
+      po.src = "https://apis.google.com/js/plusone.js";
+      var s = document.getElementsByTagName("script")[0];
+      s.parentNode.insertBefore(po, s);
+    })();
+  </script>
 </div>
-    

--- a/_layouts/principle.html
+++ b/_layouts/principle.html
@@ -1,70 +1,67 @@
 ---
 layout: default
 ---
+
 <div class="content">
-
-
-  <div>	
+  <div>
     <div class="page-header">
       <h1>
-				{% if page.title == "Overview" %}
-        Principles: {{ page.title }}
-				{% else %}
-        Principle: {{ page.title }}
-				{% endif %}
-      </h1>      
-    <p>
-      {{page.summary}}
-    </p>
+        {% if page.title == "Overview" %} Principles: {{ page.title }} {% else
+        %} Principle: {{ page.title }} {% endif %}
+      </h1>
+      <p>{{page.summary}}</p>
     </div>
-
   </div>
-   
+
   <div class="col-md-12">
     <div class="row">
       <div class="col-md-3">
         <ul>
-        {% for p in site.principles %}
-        <li>
-          <a href="{{p.id}}.html">{{p.title}}</a>
-        </li>
-        {% endfor %}
+          {% for p in site.principles %}
+          <li>
+            <a href="{{p.id}}.html">{{p.title}}</a>
+          </li>
+          {% endfor %}
         </ul>
         {% if page.id %}
         <div class="btn-group" role="group" aria-label="Source">
-          <a href="https://github.com/OBOFoundry/OBOFoundry.github.io/blob/master/principles/{{page.id}}.md">
-            <button type="button" 
-                    data-toggle="tooltip" 
-                    title="See FAQ entry: How I do propose edits to principles?" 
-                    html="true"
-                    class="btn btn-default">
+          <a
+            href="https://github.com/OBOFoundry/OBOFoundry.github.io/blob/master/principles/{{page.id}}.md"
+          >
+            <button
+              type="button"
+              data-toggle="tooltip"
+              title="See FAQ entry: How I do propose edits to principles?"
+              html="true"
+              class="btn btn-default"
+            >
               View
             </button>
           </a>
-          <a href="https://github.com/OBOFoundry/OBOFoundry.github.io/edit/master/principles/{{page.id}}.md">
-
-            <button type="button" 
-                    data-toggle="tooltip" 
-                    title="See FAQ entry: How I do propose edits to principles?" 
-                    html="true"
-                    class="btn btn-default">
-              Edit</button>
+          <a
+            href="https://github.com/OBOFoundry/OBOFoundry.github.io/edit/master/principles/{{page.id}}.md"
+          >
+            <button
+              type="button"
+              data-toggle="tooltip"
+              title="See FAQ entry: How I do propose edits to principles?"
+              html="true"
+              class="btn btn-default"
+            >
+              Edit
+            </button>
           </a>
           <!-- <button type="button" class="btn btn-default">Help</button> -->
-        </div>{% endif %}
-        <div>
-          This page is generated via <a href="{{site.repo_src}}_layouts/principle.html">_layouts/principle.html</a>. See <a href="/faq/how-do-i-edit-content.html">edit guide</a>
         </div>
-
+        {% endif %}
+        <div>
+          This page is generated via
+          <a href="{{site.repo_src}}_layouts/principle.html"
+            >_layouts/principle.html</a
+          >. See <a href="/faq/how-do-i-edit-content.html">edit guide</a>
+        </div>
       </div>
-      <div class="col-md-9">
-        {{ content }}
-      </div>
+      <div class="col-md-9">{{ content }}</div>
     </div>
-
-    
   </div>
-
-
 </div>
-    

--- a/_posts/2015-08-11-welcome.md
+++ b/_posts/2015-08-11-welcome.md
@@ -1,12 +1,12 @@
 ---
 layout: post
-title:  "Sneak peek at the new OBO Foundry site"
-date:   2015-08-11
+title: "Sneak peek at the new OBO Foundry site"
+date: 2015-08-11
 categories: update
 summary: The old OBO Foundry website is about to be retired. We have a soft release of the new site available for viewing and editing metadata
-image: 'http://obofoundry.org/images/foundrylogo.png'
+image: "http://obofoundry.org/images/foundrylogo.png"
 tags:
- - announce
+  - announce
 ---
 
 This is a sneak preview of the [new OBO Foundry website](http://obofoundry.github.io). The site is
@@ -15,12 +15,12 @@ report any issues [on the issue tracker](https://github.com/OBOFoundry/OBOFoundr
 
 The new site incorporates a number of improvements from the old legacy site:
 
- * An improved [ontology table](http://obofoundry.github.io)
- * A richer [ontology registry](https://github.com/OBOFoundry/OBOFoundry.github.io/blob/master/registry/ontologies.yml) that allows us to capture more information about each ontology
- * A more modern underlying infrastructure (GitHub pages) that allow us to be more responsive ( [here is the source](https://github.com/OBOFoundry/OBOFoundry.github.io) ).
- * The ability for ontology maintainers [to edit their own metadata and submit pull requests](http://obofoundry.github.io/faq/how-do-i-edit-metadata.html)
- * Customizable ontology pages -- see for example the page for the [Human Phenotype Ontology](http://obofoundry.github.io/ontology/hp.html)
- * Better integration with [OntoBee](http://ontobee.org/) and other ontology browsers
+- An improved [ontology table](http://obofoundry.github.io)
+- A richer [ontology registry](https://github.com/OBOFoundry/OBOFoundry.github.io/blob/master/registry/ontologies.yml) that allows us to capture more information about each ontology
+- A more modern underlying infrastructure (GitHub pages) that allow us to be more responsive ( [here is the source](https://github.com/OBOFoundry/OBOFoundry.github.io) ).
+- The ability for ontology maintainers [to edit their own metadata and submit pull requests](http://obofoundry.github.io/faq/how-do-i-edit-metadata.html)
+- Customizable ontology pages -- see for example the page for the [Human Phenotype Ontology](http://obofoundry.github.io/ontology/hp.html)
+- Better integration with [OntoBee](http://ontobee.org/) and other ontology browsers
 
 ## Next Steps
 

--- a/_posts/2015-09-22-DO.md
+++ b/_posts/2015-09-22-DO.md
@@ -1,12 +1,12 @@
 ---
 layout: post
-title:  "Disease Ontology newest member of the OBO Foundry"
-date:   2015-09-22
+title: "Disease Ontology newest member of the OBO Foundry"
+date: 2015-09-22
 categories: update
 summary: The OBO Foundry Operations Committee is pleased to announce the inclusion of the Disease Ontology (DO) as a full member of the the OBO Foundry.
-image: 'http://www.disease-ontology.org/media/images/DO_logo.jpg'
+image: "http://www.disease-ontology.org/media/images/DO_logo.jpg"
 tags:
- - announce
+  - announce
 ---
 
 The OBO Foundry Operations Committee is pleased to announce the inclusion of the Disease Ontology (DO) as a full member of the the OBO Foundry.

--- a/_posts/2015-10-01-mro.md
+++ b/_posts/2015-10-01-mro.md
@@ -1,11 +1,11 @@
 ---
 layout: post
-title:  "MHC restriction ontology (MRO) has been registered with the OBO Library"
-date:   2015-10-01
+title: "MHC restriction ontology (MRO) has been registered with the OBO Library"
+date: 2015-10-01
 categories: update
-summary:  The MHC Restriction Ontology has been added to the OBO Registry.
+summary: The MHC Restriction Ontology has been added to the OBO Registry.
 tags:
- - announce
+  - announce
 ---
 
 Full details can be found on [the ontology metadata page](/ontology/mro.html).

--- a/_posts/2016-03-15-ACS.md
+++ b/_posts/2016-03-15-ACS.md
@@ -1,11 +1,9 @@
 ---
 layout: post
-title:  "ACS meeting SAn Diego"
-date:   2016-03-15
+title: "ACS meeting SAn Diego"
+date: 2016-03-15
 categories: update
 summary: A number of OBO - operations committee folks will be at the ACS conference in San Diego 3/15 - 3/17. If you are in town, join us at the conference or Wednesday night for drinks at the CINF data summit reception
-
 ---
-
 
 https://www.eventbrite.com/e/cinf-data-summit-reception-registration-21838230736

--- a/_posts/2016-03-22-Biocuration_2016.md
+++ b/_posts/2016-03-22-Biocuration_2016.md
@@ -1,10 +1,9 @@
 ---
 layout: post
-title:  "Biocuration meeting in Geneva"
-date:   2016-03-22
+title: "Biocuration meeting in Geneva"
+date: 2016-03-22
 categories: update
-summary: The OBO Foundry in 2016 - talk in Geneva, April 11th. Session 2 - Biocuration 2016 meeting. 
-
+summary: The OBO Foundry in 2016 - talk in Geneva, April 11th. Session 2 - Biocuration 2016 meeting.
 ---
 
 http://www.isb-sib.ch/events/biocuration2016/agenda

--- a/_posts/2016-04-07-TutorialInChina.md
+++ b/_posts/2016-04-07-TutorialInChina.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title:  "OBO Foundry Tutorial in China"
-date:   2016-04-07
+title: "OBO Foundry Tutorial in China"
+date: 2016-04-07
 categories: update
-summary: Two-day OBO Foundry tutorials were given in Beijing, China from 4/7 - 4/8. 
+summary: Two-day OBO Foundry tutorials were given in Beijing, China from 4/7 - 4/8.
 ---

--- a/_posts/2016-04-15-MIRO.md
+++ b/_posts/2016-04-15-MIRO.md
@@ -1,16 +1,15 @@
 ---
 layout: post
-title:  "Take the Minimal Information for Reporting an Ontology (MIRO) Survey!"
-date:   2016-04-15
+title: "Take the Minimal Information for Reporting an Ontology (MIRO) Survey!"
+date: 2016-04-15
 categories: update
 summary: "James Malone, Robert Stevens and Chris Mungall would like you to take a survey on the importance of a set of guidelines for reporting on ontologies"
-
 ---
 
 I have been working with Robert Stevens and James Malone on some
 guidelines for Minimal Information for Reporting an Ontology
 (MIRO). This effort is not affiliated with the OBO Foundry, but shares
-some of the aims.  We'd like your input, there is a survey that should
+some of the aims. We'd like your input, there is a survey that should
 take you only 10 minutes here:
 
 https://jamesmalone.typeform.com/to/uJIhzR
@@ -28,7 +27,7 @@ information we'd have in a registry such as the OBO library).
 We'd like to find out what as wide a collection of people as we can
 reasonably reach think are the minimal information for reporting on an
 ontology. These guidelines will then be available to the community of
-authors and reviewers  to help make the process of disseminating
+authors and reviewers to help make the process of disseminating
 information about an ontology more consistent and contain what readers
 need to see. These can form guidelines for both reviewers and authors of
 papers. To do this we'd like to have as much ontology community input as
@@ -42,7 +41,6 @@ We appreciate your help and feedback!
 
 Robert Stevens (1), James Malone (2) and Chris Mungall (3)
 
- 1. University of Manchester, UK
- 2. FactBio, UK
- 3. Lawrence Berkeley National Laboratory, USA
-
+1.  University of Manchester, UK
+2.  FactBio, UK
+3.  Lawrence Berkeley National Laboratory, USA

--- a/_posts/2016-04-19-ECO-OBI-workshop.md
+++ b/_posts/2016-04-19-ECO-OBI-workshop.md
@@ -1,9 +1,10 @@
 ---
 layout: post
-title:  "ECO-OBI Workshop: Scientific Evidence"
-date:   2016-04-19
+title: "ECO-OBI Workshop: Scientific Evidence"
+date: 2016-04-19
 categories: update
 summary: You are cordially invited to attend a collaborative workshop between the Evidence and Conclusion Ontology (ECO) and the Ontology for Biomedical Investigations (OBI) on May 11 and 12. We will discuss modeling evidence, synergy between the groups, and related topics.
 ---
+
 The meeting will be held at the Institute for Genome Sciences (IGS), University of Maryland School of Medicine, University of Maryland, Baltimore, on Wednesday May 11 and Thursday May 12.
-Please contact: mchibucos@som.umaryland.edu or the OBI developer list at obi-devel@lists.sourceforge.net if you are interested in participating. 
+Please contact: mchibucos@som.umaryland.edu or the OBI developer list at obi-devel@lists.sourceforge.net if you are interested in participating.

--- a/_posts/2016-11-26-S3-switch.md
+++ b/_posts/2016-11-26-S3-switch.md
@@ -1,18 +1,17 @@
 ---
 layout: post
-title:  "URL changed for central OBO builds"
-date:   2016-11-26
+title: "URL changed for central OBO builds"
+date: 2016-11-26
 categories: update
 summary: "The URL for central OBO builds has changed from berkeleybop.org/ontologies to ontologies.berkeleybop.org"
-
 ---
 
 All ontologies in the OBO library have a permanent URL (PURL) that
 always resolves to the OWL for the ontology (most ontologies have a
 PURL that resolves to an OBO Format version too). For example:
 
- * http://purl.obolibrary.org/pato.owl
- * http://purl.obolibrary.org/pato.obo
+- http://purl.obolibrary.org/pato.owl
+- http://purl.obolibrary.org/pato.obo
 
 Additionally, some ontologies may have additional artefacts/products
 such as slims available within their namespace.
@@ -35,6 +34,3 @@ using Amazon S3 plus CloudFront).
 
 If you are a providers of ontologies and you have made use of the
 central OBO build, then your PURLs have been switched to use the new scheme as part of [this pull request](https://github.com/OBOFoundry/purl.obolibrary.org/pull/262).
-
-
-

--- a/_posts/2017-11-07-ServicesGrant.md
+++ b/_posts/2017-11-07-ServicesGrant.md
@@ -1,22 +1,21 @@
 ---
 layout: post
-title:  "OBO services - grant"
-date:   2017-11-07
+title: "OBO services - grant"
+date: 2017-11-07
 categories: update
 summary: "Good news - we managed to secure some funding for a revamp of the OBO services infrastructure"
-
 ---
 
 Dear OBO community,
 
-We are happy to announce some good news: A three year R24 grant through the BD2K initiative to support OBO services was funded (finally, after being in administrative Nirvana for over half a year, and still on hold because NIH is trying to determine if it is human subject research(!)). Below are the specific Aims that this grant is intended to support. Much of it will be dedicated to 'do things right' and built a more long term sustainable and easier to maintain version of the existing technical infrastructure. But there will also be support for establishing some new capability, and those should help making OBO work in general, such as automating aspects of the ontology review process. 
+We are happy to announce some good news: A three year R24 grant through the BD2K initiative to support OBO services was funded (finally, after being in administrative Nirvana for over half a year, and still on hold because NIH is trying to determine if it is human subject research(!)). Below are the specific Aims that this grant is intended to support. Much of it will be dedicated to 'do things right' and built a more long term sustainable and easier to maintain version of the existing technical infrastructure. But there will also be support for establishing some new capability, and those should help making OBO work in general, such as automating aspects of the ontology review process.
 
-A few things to note: 
-- The funding is very much limited, and much of it is committed to upgrade the OBO 'plumbing' to protect us from potential disasters going forward. Which by definition means there won't be immediate visible improvements. But in the longer term, this should free up volunteer developer time that is now being spent on putting out fires to instead work on new capabilities. 
-- As we are implementing new checks on ontologies (both in the OBO registry and on the ontology files themselves), there will be an increase in notifications to ontology developers of areas for improvement in their ontologies. Please don't take those as criticisms on your work. We are trying to ensure that the agreed upon standards in OBO can and are being enforced. In several cases, such as ensuring that the ontology is released under an open license, there are many possible way to do this which are all perfectly fine. But agreeing on a single convention will make it easy to automate checking if an ontology confirms with the convention. We will rely on feedback from the OBO community what is a useful degree of stringency, and what is overreach. We plan to announce our activities here, and constructive feedback is very much welcome. 
-- If you want to be engaged and contribute to this process, consider joining one of the groups in the OBO operations committee, described at 
-http://www.obofoundry.org/docs/OperationsCommittee . Membership means work, and there is lots of it, so volunteers are always welcome. 
+A few things to note:
 
+- The funding is very much limited, and much of it is committed to upgrade the OBO 'plumbing' to protect us from potential disasters going forward. Which by definition means there won't be immediate visible improvements. But in the longer term, this should free up volunteer developer time that is now being spent on putting out fires to instead work on new capabilities.
+- As we are implementing new checks on ontologies (both in the OBO registry and on the ontology files themselves), there will be an increase in notifications to ontology developers of areas for improvement in their ontologies. Please don't take those as criticisms on your work. We are trying to ensure that the agreed upon standards in OBO can and are being enforced. In several cases, such as ensuring that the ontology is released under an open license, there are many possible way to do this which are all perfectly fine. But agreeing on a single convention will make it easy to automate checking if an ontology confirms with the convention. We will rely on feedback from the OBO community what is a useful degree of stringency, and what is overreach. We plan to announce our activities here, and constructive feedback is very much welcome.
+- If you want to be engaged and contribute to this process, consider joining one of the groups in the OBO operations committee, described at
+  http://www.obofoundry.org/docs/OperationsCommittee . Membership means work, and there is lots of it, so volunteers are always welcome.
 
 Best,
 
@@ -32,4 +31,3 @@ Aim 1: Upgrade OBO Services Infrastructure for Long Term Sustainability. The tec
 Aim 2: Enhance OBO Services Infrastructure to Add New Capabilities. Adding a small number of new capabilities will multiply the benefits of our services. We will develop a suite of standardized, automated quality control tests and reports, first for individual ontologies and second for groups of interdependent ontologies. Third, we will update standard software tools to run these quality control tests, and integrate these tools more fully with our services. Fourth, we will deploy a monitoring system to measure the stability and usage of our services.
 
 Aim 3: Enlarge, Train and Sustain the OBO Service Developer Community. Successfully running the OBO services requires developers that can maintain them. To increase the number of developers capable and willing to contribute, we propose a one-time investment to thoroughly improve the technical documentation of the services in order to lower barriers for new developers to get started in participating. In parallel, we propose several training and outreach activities to enlarge the developer community.
-

--- a/about-OBO-Foundry.html
+++ b/about-OBO-Foundry.html
@@ -5,21 +5,58 @@ title: About the OBO Foundry
 
 <h1>About the OBO Foundry</h1>
 
-<p>The mission of the OBO Foundry is to develop a family of interoperable ontologies that are both logically well-formed and scientifically accurate.
-To achieve this, OBO Foundry participants follow and contribute to the development of an evolving set of <a href="/principles/fp-000-summary.html">principles</a>
-including <a href="/principles/fp-001-open.html">open use</a>, <a href="/principles/fp-010-collaboration.html">collaborative development</a>,
-<a href="/principles/fp-005-delineated-content.html">non-overlapping and strictly-scoped content</a>, and common <a href="/principles/fp-002-format.html">syntax</a>
-and <a href="/principles/fp-007-relations.html">relations</a>,
-based on ontology models that work well, such as the <a target="_new" href="http://geneontology.org/">Gene Ontology (GO)</a>. 
-       
-<p>The OBO Foundry is overseen by an <a href="http://obofoundry.org/docs/OperationsCommittee.html">Operations Committee</a> with
-<a href="/docs/EditorialWG.html">Editorial</a>, <a href="/docs/TechnicalWG.html">Technical</a> and <a href="/docs/OutreachWG.html">Outreach</a> working groups.
-      
-<p>You can contribute to the OBO Foundry by submitting issues or pull requests to our GitHub repo, <a href="https://github.com/OBOFoundry/OBOFoundry.github.io">OBOFoundry/OBOFoundry.github.io</a>,
-or by joining our mailing list <a href="https://groups.google.com/forum/#!forum/obo-discuss">https://groups.google.com/forum/#!forum/obo-discuss</a>.
-If you'd like to submit your ontology for possible inclusion in the OBO Foundry, please follow the instructions <a href="http://www.obofoundry.org/faq/how-do-i-register-my-ontology.html">here</a>.
+<p>
+  The mission of the OBO Foundry is to develop a family of interoperable
+  ontologies that are both logically well-formed and scientifically accurate. To
+  achieve this, OBO Foundry participants follow and contribute to the
+  development of an evolving set of
+  <a href="/principles/fp-000-summary.html">principles</a> including
+  <a href="/principles/fp-001-open.html">open use</a>,
+  <a href="/principles/fp-010-collaboration.html">collaborative development</a>,
+  <a href="/principles/fp-005-delineated-content.html"
+    >non-overlapping and strictly-scoped content</a
+  >, and common <a href="/principles/fp-002-format.html">syntax</a> and
+  <a href="/principles/fp-007-relations.html">relations</a>, based on ontology
+  models that work well, such as the
+  <a target="_new" href="http://geneontology.org/">Gene Ontology (GO)</a>.
 </p>
 
-<p> An overview of the OBO Foundry can be found in these publications:
-<a href="http://www.ncbi.nlm.nih.gov/pmc/articles/PMC2814061/">The OBO Foundry: coordinated evolution of ontologies to support biomedical data integration</a> and <a href="https://academic.oup.com/database/article/doi/10.1093/database/baab069/6410158">OBO Foundry in 2021: operationalizing open data principles to evaluate ontologies</a>.
-       See also this <a href="https://github.com/jamesaoverton/obo-tutorial">OBO tutorial</a>.</p>
+<p>
+  The OBO Foundry is overseen by an
+  <a href="http://obofoundry.org/docs/OperationsCommittee.html"
+    >Operations Committee</a
+  >
+  with <a href="/docs/EditorialWG.html">Editorial</a>,
+  <a href="/docs/TechnicalWG.html">Technical</a> and
+  <a href="/docs/OutreachWG.html">Outreach</a> working groups.
+</p>
+
+<p>
+  You can contribute to the OBO Foundry by submitting issues or pull requests to
+  our GitHub repo,
+  <a href="https://github.com/OBOFoundry/OBOFoundry.github.io"
+    >OBOFoundry/OBOFoundry.github.io</a
+  >, or by joining our mailing list
+  <a href="https://groups.google.com/forum/#!forum/obo-discuss"
+    >https://groups.google.com/forum/#!forum/obo-discuss</a
+  >. If you'd like to submit your ontology for possible inclusion in the OBO
+  Foundry, please follow the instructions
+  <a href="http://www.obofoundry.org/faq/how-do-i-register-my-ontology.html"
+    >here</a
+  >.
+</p>
+
+<p>
+  An overview of the OBO Foundry can be found in these publications:
+  <a href="http://www.ncbi.nlm.nih.gov/pmc/articles/PMC2814061/"
+    >The OBO Foundry: coordinated evolution of ontologies to support biomedical
+    data integration</a
+  >
+  and
+  <a
+    href="https://academic.oup.com/database/article/doi/10.1093/database/baab069/6410158"
+    >OBO Foundry in 2021: operationalizing open data principles to evaluate
+    ontologies</a
+  >. See also this
+  <a href="https://github.com/jamesaoverton/obo-tutorial">OBO tutorial</a>.
+</p>

--- a/about-OBO-Foundry.html
+++ b/about-OBO-Foundry.html
@@ -13,7 +13,7 @@ and <a href="/principles/fp-007-relations.html">relations</a>,
 based on ontology models that work well, such as the <a target="_new" href="http://geneontology.org/">Gene Ontology (GO)</a>. 
        
 <p>The OBO Foundry is overseen by an <a href="http://obofoundry.org/docs/OperationsCommittee.html">Operations Committee</a> with
-<a href="/docs/EditorialWG.html">Editorial</a>, <a href="/docs/TechnicalWG.html">Technical</a> and <a href="/docs/OutreachWG.html">Outreach</a> working groups.</a>
+<a href="/docs/EditorialWG.html">Editorial</a>, <a href="/docs/TechnicalWG.html">Technical</a> and <a href="/docs/OutreachWG.html">Outreach</a> working groups.
       
 <p>You can contribute to the OBO Foundry by submitting issues or pull requests to our GitHub repo, <a href="https://github.com/OBOFoundry/OBOFoundry.github.io">OBOFoundry/OBOFoundry.github.io</a>,
 or by joining our mailing list <a href="https://groups.google.com/forum/#!forum/obo-discuss">https://groups.google.com/forum/#!forum/obo-discuss</a>.

--- a/allnews.html
+++ b/allnews.html
@@ -4,4 +4,3 @@ title: OBO
 ---
 
 {% include news.html %}
-

--- a/browse.html
+++ b/browse.html
@@ -5,14 +5,37 @@ title: Browse
 
 <div>
   <ul>
-    <li> <a rel="nofollow" class="external text"
-            href="https://ontobee.org/browser/index.php?o=OBO">OntoBee</a></li>
-    <li> <a rel="nofollow" class="external text" 
-            href="http://ols.wordvis.com/ont=OBO">OLSVis</a></li>
-    <li> <a rel="nofollow" class="external text"
-            href="http://www.ebi.ac.uk/ontology-lookup/browse.do?ontName=OBO">OLS</a></li> 
-    <li> <a rel="nofollow" class="external text"
-            href="http://bioportal.bioontology.org/ontologies/1404/?p=terms">BioPortal</a>
+    <li>
+      <a
+        rel="nofollow"
+        class="external text"
+        href="https://ontobee.org/browser/index.php?o=OBO"
+        >OntoBee</a
+      >
+    </li>
+    <li>
+      <a
+        rel="nofollow"
+        class="external text"
+        href="http://ols.wordvis.com/ont=OBO"
+        >OLSVis</a
+      >
+    </li>
+    <li>
+      <a
+        rel="nofollow"
+        class="external text"
+        href="http://www.ebi.ac.uk/ontology-lookup/browse.do?ontName=OBO"
+        >OLS</a
+      >
+    </li>
+    <li>
+      <a
+        rel="nofollow"
+        class="external text"
+        href="http://bioportal.bioontology.org/ontologies/1404/?p=terms"
+        >BioPortal</a
+      >
     </li>
   </ul>
 </div>

--- a/community/anatomy.md
+++ b/community/anatomy.md
@@ -3,40 +3,40 @@ layout: community
 id: anatomy
 title: Anatomy Portal
 members:
- - cmungall
- - mellybelly
- - dosumis
- - balhoff
- - ANiknejad
- - fbastian
- - jaiswalp
+  - cmungall
+  - mellybelly
+  - dosumis
+  - balhoff
+  - ANiknejad
+  - fbastian
+  - jaiswalp
 ontologies:
- - id: uberon
-   description: "covers all animals. Can bridge species-specific AOs"
- - id: po
-   description: "covers all plants"
- - id: fao
-   description: "covers all multicellular fungi"
- - id: ma
-   description: "mouse (adult)"
- - id: emapa
-   description: "mouse (embryonic)"
- - id: ddanat
-   description: "dicty (slime mold)"
- - id: plana
-   description: "planaria"
- - id: fma
-   description: "human"
- - id: ehdaa2
-   description: "human (developmental)"
- - id: zfa
-   description: "zebrafish"
- - id: xao
-   description: "xenopus"
- - id: fbbt
-   description: "Drosophila"
- - id: wbbt
-   description: "C elegans"
+  - id: uberon
+    description: "covers all animals. Can bridge species-specific AOs"
+  - id: po
+    description: "covers all plants"
+  - id: fao
+    description: "covers all multicellular fungi"
+  - id: ma
+    description: "mouse (adult)"
+  - id: emapa
+    description: "mouse (embryonic)"
+  - id: ddanat
+    description: "dicty (slime mold)"
+  - id: plana
+    description: "planaria"
+  - id: fma
+    description: "human"
+  - id: ehdaa2
+    description: "human (developmental)"
+  - id: zfa
+    description: "zebrafish"
+  - id: xao
+    description: "xenopus"
+  - id: fbbt
+    description: "Drosophila"
+  - id: wbbt
+    description: "C elegans"
 ---
 
 Welcome to the OBO Foundry Anatomy Portal!
@@ -49,21 +49,21 @@ describes how they relate to one another.
 The Common Anatomy Reference Ontology (CARO) provides an upper-level
 structure that should be used as superclasses in OBO anatomy ontologies.
 
- * [caro](/ontology/caro.html)
+- [caro](/ontology/caro.html)
 
 ## Subcellular
 
 We take the term anatomy to include subcellular anatomy, which is
 covered in GO.
 
- * [go](/ontology/go.html)
+- [go](/ontology/go.html)
 
 Note that some ontologies (WBbt, FBbt) include their own more specific subcellular components
 
 ## Cells
 
- * Plants: [po](/ontology/po.html)
- * Animals: [cl](/ontology/cl.html)
+- Plants: [po](/ontology/po.html)
+- Animals: [cl](/ontology/cl.html)
 
 Note that some ontologies (PO, FBbt) include their own more specific cell types
 
@@ -73,17 +73,17 @@ Note that some ontologies (PO, FBbt) include their own more specific cell types
 
 The Plant Ontology (PO) covers all viridiplantae, and includes cell types as well as tissues/organs
 
- * [po](/ontology/po.html)
+- [po](/ontology/po.html)
 
 ### Fungal
 
 The Plant Ontology (PO) covers all multicellular fungi, and includes cell types as well as multi-cell structures
 
- * [fao](/ontology/fao.html)
+- [fao](/ontology/fao.html)
 
 ### Slime Mold
 
- * [ddanat](/ontology/ddanat.html)
+- [ddanat](/ontology/ddanat.html)
 
 ### Animals
 
@@ -91,34 +91,34 @@ Uberon is a multi-species anatom ontology covering metazoa
 (animals). It can be used to bridge other species-specific animal
 anatomy ontologies, see the documentation for details.
 
- * [uberon](/ontology/uberon.html)
+- [uberon](/ontology/uberon.html)
 
 Species or taxon-specific anatomy ontologies
 
- * Vertebrates
-     * Vertebrate non-mammalian
-        * [zfa](/ontology/zfa.html)
-        * [xao](/ontology/xao.html)
-     * Mammals
-        * Mouse
-           * [ma](/ontology/ma.html) (adult)
-           * [emapa](/ontology/emapa.html) (all stages)
-        * Human
-           * [fma](/ontology/fma.html) (adult)
-           * [ehdaa2](/ontology/ehdaa2.html) (embryo)
- * Non-vertebrate animals
-     * model organism
-        * [fbbt](/ontology/fbbt.html)
-        * [wbbt](/ontology/wbbt.html)
-        * [plana](/ontology/plana.html)
-        * coming soon - echinoderm
-     * non-model organism
-        * Sponges: [poro](/ontology/poro.html)
-        * Ctenophores: [cteno](/ontology/cteno.html)
-        * Cephalopods: [ceph](/ontology/ceph.html)
- 
- ## Stage Ontologies
- 
- We have a separate github repo:
- 
- * https://github.com/obophenotype/developmental-stage-ontologies
+- Vertebrates
+  - Vertebrate non-mammalian
+    - [zfa](/ontology/zfa.html)
+    - [xao](/ontology/xao.html)
+  - Mammals
+    - Mouse
+      - [ma](/ontology/ma.html) (adult)
+      - [emapa](/ontology/emapa.html) (all stages)
+    - Human
+      - [fma](/ontology/fma.html) (adult)
+      - [ehdaa2](/ontology/ehdaa2.html) (embryo)
+- Non-vertebrate animals
+  - model organism
+    - [fbbt](/ontology/fbbt.html)
+    - [wbbt](/ontology/wbbt.html)
+    - [plana](/ontology/plana.html)
+    - coming soon - echinoderm
+  - non-model organism
+    - Sponges: [poro](/ontology/poro.html)
+    - Ctenophores: [cteno](/ontology/cteno.html)
+    - Cephalopods: [ceph](/ontology/ceph.html)
+
+## Stage Ontologies
+
+We have a separate github repo:
+
+- https://github.com/obophenotype/developmental-stage-ontologies

--- a/community/microbial.md
+++ b/community/microbial.md
@@ -10,27 +10,27 @@ homepage: http://obofoundry.org/community/microbial
 # - pbuttigieg
 # - todo
 ontologies:
- - id: envo
-   description: "For annotating microbial habitats"
-   role: ""
- - id: micro
-   description: "traits and phenotypes"
-   role: ""
- - id: mco
-   description: "microbial conditions"
-   role: ""
- - id: ohmi
-   description: "host-microbiome interactions"
-   role: ""
- - id: omp
-   description: "phenotypes"
-   role: ""
- - id: phipo
-   description: "pathogen-host phenotypes"
-   role: ""
- - id: go
-   description: "For annotating microbial function"
-   role: ""
+  - id: envo
+    description: "For annotating microbial habitats"
+    role: ""
+  - id: micro
+    description: "traits and phenotypes"
+    role: ""
+  - id: mco
+    description: "microbial conditions"
+    role: ""
+  - id: ohmi
+    description: "host-microbiome interactions"
+    role: ""
+  - id: omp
+    description: "phenotypes"
+    role: ""
+  - id: phipo
+    description: "pathogen-host phenotypes"
+    role: ""
+  - id: go
+    description: "For annotating microbial function"
+    role: ""
 ---
 
 This OBO community group is for coordinating the efforts of different ontologies for annotating traits and functions of microbes, either in isolation or in the host of host-microbiome interactions, or microbial communities.
@@ -45,4 +45,4 @@ There are a number of ontologies for describing microbial phenotypes, such as [M
 
 For functional annotation of microbial genes, the [GO](https://obofoundry.org/ontology/go) is the recommended OBO ontology.
 
-The [Genome Standards Consortium](http://gensc.org/) (GSC) coordinates the usage of many of these ontologies through minimal information standards such as the [MIxS](http://gensc.org/mixs/) 
+The [Genome Standards Consortium](http://gensc.org/) (GSC) coordinates the usage of many of these ontologies through minimal information standards such as the [MIxS](http://gensc.org/mixs/)

--- a/docs/COC.md
+++ b/docs/COC.md
@@ -6,37 +6,38 @@ title: Code of Conduct
 
 # Code of Conduct
 
-This code of conduct outlines expectations of the Open Biological Ontologies (OBO) community. The OBO community is committed to providing a welcoming and inspiring environment for all community members, and we expect this code of conduct to be honored by each community member. Herein, we provide specifics regarding appropriate code of conduct, including recommendations for conflict resolution. The OBO community strives to: 
+This code of conduct outlines expectations of the Open Biological Ontologies (OBO) community. The OBO community is committed to providing a welcoming and inspiring environment for all community members, and we expect this code of conduct to be honored by each community member. Herein, we provide specifics regarding appropriate code of conduct, including recommendations for conflict resolution. The OBO community strives to:
 
-**Be welcoming and patient** 
+**Be welcoming and patient**
 
 We want and need all comers to contribute to our collective goals of creating a robust suite of interoperable and effective ontologies. Cooperation from all members is needed to help ensure a safe and welcoming environment for everybody. We strive to be a community that that welcomes and supports persons of all backgrounds and identities. This includes, but is not limited to, members of any race, ethnicity, culture, national origin, immigration status, social and economic class, educational level, sex, sexual orientation, gender identity and expression, age, physical size, family status, political belief, religion, and mental or physical ability.
 
-**Be considerate** 
+**Be considerate**
 
 Your work will be used by other people, and you will depend on the work of others. Any decision you take will affect other community members. The consequences of your actions should be considered when making decisions. Remember that we're a large community, so you might not be communicating in someone else's primary language or share their area of expertise. This can present a challenge, but with thoughtful consideration, all communications between community members can be, and should be, considerate of the perspectives of others.
 
-**Be respectful** 
+**Be respectful**
 
-Community members are likely to disagree on issues. This is to be expected (especially amongst ontologists!),  within our large, diverse group of individuals. However, we aim to support, at all times, constructive discourse when disagreements arise. This may lead to frustration from time to time, but we cannot allow frustration to turn into disrespectful behavior, mannerisms, or attacks. Our collective productivity very much depends on a supportive community, where people feel comfortable or not threatened when they need to disagree or propose alternative strategies.
+Community members are likely to disagree on issues. This is to be expected (especially amongst ontologists!), within our large, diverse group of individuals. However, we aim to support, at all times, constructive discourse when disagreements arise. This may lead to frustration from time to time, but we cannot allow frustration to turn into disrespectful behavior, mannerisms, or attacks. Our collective productivity very much depends on a supportive community, where people feel comfortable or not threatened when they need to disagree or propose alternative strategies.
 
-**Be careful in choice of words** 
+**Be careful in choice of words**
 
-Be thoughtful in your use of words, as others may interpret them differently than may have been intended. If you see others using potentially disrespectful or alienating langauge, please let them know even if it was not intended for you. Often those feeling uncomfortable may not feel comfortable doing or saying anything. It is important that we collectively self-correct. 
+Be thoughtful in your use of words, as others may interpret them differently than may have been intended. If you see others using potentially disrespectful or alienating langauge, please let them know even if it was not intended for you. Often those feeling uncomfortable may not feel comfortable doing or saying anything. It is important that we collectively self-correct.
 
-**Be kind to everyone** 
+**Be kind to everyone**
 
 Do not insult or put down other community members. Harassment and other exclusionary behavior are not acceptable. This includes, but is not limited to: violent threats or language directed against another person; discriminatory jokes and language; posts of sexually explicit or violent material; posts (or threat of posts) of other person’s personally identifying information (“doxing”); photography or recordings; personal insults, especially those using racist or sexist terms; unwelcome sexual attention; advocating for, or encouraging, any of the above behavior; and repeated harassment of others. Harassment also includes offensive verbal comments related to gender, gender identity and expression, age, sexual orientation, disability, physical appearance, body size, race, religion, deliberate intimidation, stalking, sustained disruption of talks or other events. In general, if someone asks you to stop, then stop.
 
-**Try to understand the cause of disagreements** 
+**Try to understand the cause of disagreements**
 
 Disagreements, both social and technical, happen all the time. It is important that we constructively resolve disagreements and differing views. Remember that we are a diverse group. Diversity contributes to the strength of our community, which is composed of people from a wide range of backgrounds. However, diversity also means that different persons will have different perspectives on issues. While you may not always understand why someone holds a particular viewpoint, that does not necessarily mean that a viewpoint is wrong. Instead of blame, anger, hostility, or argumentation, focus on resolving disagreements and learning from mistakes.
 
 # Ethics Statement
 
-All members of the OBO community will be expected to abide by the highest ethical standards, for example, in accordance with the NIH standards for ethical conduct (https://oir.nih.gov/sourcebook/ethical-conduct). Plagiarism will not be tolerated. 
+All members of the OBO community will be expected to abide by the highest ethical standards, for example, in accordance with the NIH standards for ethical conduct (https://oir.nih.gov/sourcebook/ethical-conduct). Plagiarism will not be tolerated.
 
 # Diversity Statement
+
 We encourage every member of the OBO community to participate, and we are committed to building a community for all. Although we may not always be successful, we seek to treat every person as fairly and equally as possible. If a community member makes a mistake, then we expect that person to own responsibility for the error and correct it. If a person has been harmed or offended as a result of another person’s action, and if a community member is witness, then both members own responsibility to listen carefully and respectfully to person who has been harmed and make every effort to not repeat the behaviour, as well as to make every effort to correct the damage.
 
 Although this list cannot be exhaustive, we explicitly honor diversity in age, gender, gender identity or expression, culture, ethnicity, language, national origin, political beliefs, profession, race, religion, sexual orientation, socioeconomic status, and technical ability. We will not tolerate discrimination based on any of the protected characteristics above, including participants with disabilities.
@@ -47,17 +48,15 @@ Although this list cannot be exhaustive, we explicitly honor diversity in age, g
 
 The OBO-COC team is intentionally small with only three members, in order to best support confidential handling of issues. Members of the OBO-COC team are nominated by the community and voted on by the OBO-Operations committee. The term shall be 2 years, but may be renewed.
 
-**Reporting issues** 
+**Reporting issues**
 
 If a community member experiences or witnesses unacceptable behavior, or if any other concern arises, then please report it by contacting a member of the OBO-COC team. If the issue involves a member of the COC-team, then please contact a different member. If these options are not sufficient, consider contacting a member of the OBO-Operations committee and/or your local ombuds office.
 
 All reports to OBO-COC will be handled with discretion and will receive serious attention. Reports should include the following:
 
- -  Name of person submitting the report. Names (real, nicknames, or pseudonyms) of any individuals involved. If there are additional witnesses, please include them as well. 
- - An account of the incident and whether it is ongoing. 
- - A link to any publicly available record (e.g., a mailing list archive, ticket, or a public Slack log), if applicable.
- - Any additional information that may be helpful.
+- Name of person submitting the report. Names (real, nicknames, or pseudonyms) of any individuals involved. If there are additional witnesses, please include them as well.
+- An account of the incident and whether it is ongoing.
+- A link to any publicly available record (e.g., a mailing list archive, ticket, or a public Slack log), if applicable.
+- Any additional information that may be helpful.
 
 If a community member files a report, then a member of the OBO-COC team will personally contact that person, review the incident with them, follow up with any additional questions, and make a decision with you as to how to proceed. All information will be held in confidence at the direction of the person reporting the incident.
-
-

--- a/docs/Citation.md
+++ b/docs/Citation.md
@@ -8,7 +8,6 @@ title: Citation
 
 Open Biological and Biomedical Ontologies are used in a diversity of ways. The following guidelines are intended to promote proper attribution of the ontology creators and contributors, and to promote reproducibility in informatics applications.
 
-
 ## Referring to a single term
 
 When referring to a single ontology term, use the full [Internationalized Resource Identifier (IRI)](http://tools.ietf.org/html/rfc3987), for example:
@@ -25,7 +24,6 @@ We also recommend including the primary label of the term in quotation marks bef
 
 > 'heart' ([UBERON:0000948](http://purl.obolibrary.org/obo/UBERON_0000948))
 
-
 ## Referring to an ontology
 
 To facilitate reproducibility, be specific about the version of the ontology that you are referring to by using an ontology version IRI that contains the release date:
@@ -40,10 +38,9 @@ When referring to an ontology in general (not a specific version) you can use it
 
 The ontology IRI or ontology version IRI should be accompanied by a citation of the ontology, in any context where citations are appropriate.
 
-
 ## Citing an ontology
 
-Some ontologies recommend citation of specific publications. Please see their respective homepages for this information. For example, [Uberon](http://obofoundry.org/ontology/uberon) lists two publications under "Cite." 
+Some ontologies recommend citation of specific publications. Please see their respective homepages for this information. For example, [Uberon](http://obofoundry.org/ontology/uberon) lists two publications under "Cite."
 
 In addition to the recommended publication, you should also cite the ontology using its IRI and the [new data citation extension to JATS](https://peerj.com/articles/cs-1/). When no specific publication is recommended, you must cite the ontology by its IRI. Here is an example citation:
 

--- a/docs/CommitteeMeetings.md
+++ b/docs/CommitteeMeetings.md
@@ -23,6 +23,7 @@ Chairs are assigned on a rotating basis. The chair should create agenda, host ca
 Our meeting minutes are shared on Google Docs. Access is restricted to OFOC members.
 
 ### 2017
+
 - 2017-06-27 Chris M.
 - 2017-06-13 Bjoern
 - 2017-05-30 Lynn
@@ -30,12 +31,13 @@ Our meeting minutes are shared on Google Docs. Access is restricted to OFOC memb
 - 2017-05-02 Darren (Cancelled due to low attendance)
 - [2017-04-18 James](https://docs.google.com/document/d/1_5zjIBcRw4SliACiJ-0wOT286_AghyC_rI5wgRyZBV4/edit#)
 - 2017-04-04 Cancelled
-- [2017-03-21 Darren](https://docs.google.com/document/d/1XPV4RyVKa2RdPtcwek9kBEdZTLZjGWRJhCXBcpvJA3A/edit#heading=h.sgf6as8e4yz) 
+- [2017-03-21 Darren](https://docs.google.com/document/d/1XPV4RyVKa2RdPtcwek9kBEdZTLZjGWRJhCXBcpvJA3A/edit#heading=h.sgf6as8e4yz)
 - 2017-03-07 Ramona
 - 2017-02-21 Lynn
 - [2017-02-21 and 2017-03-07 Meeting Notes](https://docs.google.com/document/d/1gxbh5Csuh7GxCx0EKzjkvZZ88jLdAyMW7ez0V2eKc-M/edit)
 
 ### 2016
+
 - 2016-07-26 Bjoern
 - 2016-07-12 Philippe (tentatively)
 - 2016-06-28 Jie

--- a/docs/CompletedReviews.md
+++ b/docs/CompletedReviews.md
@@ -3,10 +3,10 @@ layout: doc
 id: CompletedReviews
 title: CompletedReviews
 ---
-## Introduction ##
+
+## Introduction
 
 This page lists OBO Foundry ontologies that have gone through the current [review process](http://obofoundry.org/docs/ReviewProcessGuidelines). OBO Foundry ontologies added in 2010 were reviewed using a similar but non-identical process.
-
 
 <style type="text/css">
   .tg  {border-collapse:collapse;border-spacing:0;border-color:#ccc;}
@@ -16,6 +16,4 @@ This page lists OBO Foundry ontologies that have gone through the current [revie
   .tg .tg-lbaf{font-weight:bold;border-color:#333333;vertical-align:top}
 </style>
 
-
 {% include review_table.html %}
-

--- a/docs/EditorialWG.md
+++ b/docs/EditorialWG.md
@@ -4,27 +4,27 @@ id: EditorialWG
 title: EditorialWG
 ---
 
-# Introduction #
+# Introduction
 
 This page describes members and activities of the OBO Foundry Editorial Working Group.
 
-
-# Details #
+# Details
 
 The primary task of the Editorial WG is to facilitate the review of candidate OBO Foundry ontologies. This task includes developing the principles against which ontologies are reviewed, developing the review process itself, conducting the reviews, and setting policies governing the process.
 
-# Scope #
+# Scope
+
 The OBO Foundry Editorial WG will:
 
-  * create guidelines for ontology review process (how we do reviews, operationally)
-  * create policies for ontology review criteria (what aspects of an ontology and which ontologies we should review)
-  * manage the ontology review process
+- create guidelines for ontology review process (how we do reviews, operationally)
+- create policies for ontology review criteria (what aspects of an ontology and which ontologies we should review)
+- manage the ontology review process
 
 Current activities are focused on creating guidelines for reviews. Once those guidelines are in place, the working group will shift its focus to carrying out the review process, with an aim of reducing the backlog of ontologies awaiting review.
 
-# Draft guidelines and policies #
+# Draft guidelines and policies
 
-## Ontology Review ##
+## Ontology Review
 
 [Ontology review process guidelines](/docs/ReviewProcessGuidelines.html)
 
@@ -32,15 +32,17 @@ Current activities are focused on creating guidelines for reviews. Once those gu
 
 [Ontology review management guidelines](/docs/ReviewManagementGuidelines.html)
 
-## Principles Review ##
+## Principles Review
 
 [Principles review workflow](/docs/PrinciplesReviewWorkflow.html)
 
-# Members #
+# Members
+
 See the [membership page](/docs/Membership.html) for a list of current members.
 
 Membership in the OBO Foundry Editorial WG is open to all members of the OBO Foundry Operations Committee who are willing to actively participate. If you are interested in joining the working group, send an email to the mailing list.<br>
 <br>
+
 <h1>Contact Us</h1>
 
 The best way to contact the OBO Foundry Editorial Working Group is through the <a href='https://github.com/OBOFoundry/OBOFoundry.github.io/issues/'>issue tracker</a>.<br>

--- a/docs/MailingLists.md
+++ b/docs/MailingLists.md
@@ -4,13 +4,13 @@ id: MailingLists
 title: MailingLists
 ---
 
-# Introduction #
+# Introduction
 
 A page listing the current mailing-lists in use by the group. Access to content and/or posting may be restricted as mentioned below.
 
-# Details #
+# Details
 
-  * [obo-operations-committee](https://groups.google.com/forum/?fromgroups#!forum/obo-operations-committee) - restricted access and subscription, non-members may post
-  * [Technical group](https://groups.google.com/forum/?fromgroups#!forum/obo-foundry-technical-working-group) - restricted access and subscription, non-members may post
-  * [Editorial working group](https://groups.google.com/forum/?fromgroups#!forum/obo-foundry-editorial-working-group) - restricted access and subscription, non-members may post
-  * [Outreach working group](https://groups.google.com/forum/?fromgroups#!forum/obo-foundry-outreach-working-group) - restricted access and subscription, non-members may post
+- [obo-operations-committee](https://groups.google.com/forum/?fromgroups#!forum/obo-operations-committee) - restricted access and subscription, non-members may post
+- [Technical group](https://groups.google.com/forum/?fromgroups#!forum/obo-foundry-technical-working-group) - restricted access and subscription, non-members may post
+- [Editorial working group](https://groups.google.com/forum/?fromgroups#!forum/obo-foundry-editorial-working-group) - restricted access and subscription, non-members may post
+- [Outreach working group](https://groups.google.com/forum/?fromgroups#!forum/obo-foundry-outreach-working-group) - restricted access and subscription, non-members may post

--- a/docs/Membership.md
+++ b/docs/Membership.md
@@ -4,66 +4,68 @@ id: Membership
 title: Membership
 ---
 
-# Introduction #
+# Introduction
 
 The OBO Foundry Operations Committee discusses, oversees, and ensures the completion of the fundamental day-to-day activities of the Foundry. The Committee is composed of three working groups. Anyone who is active in a working group (active being based on both attendance at WG meetings and actual work done for working groups) is considered a member of the Operations Committee.
 
-# Working Groups #
+# Working Groups
 
 There are currently three working groups:
-- [Editorial Working Group](EditorialWG.html) 
+
+- [Editorial Working Group](EditorialWG.html)
 - [Technical Working Group](TechnicalWG.html)
 - [Outreach Working Group](OutreachWG.html)
 
 More information [here](/docs/OperationsCommittee.html)
 
-# Members #
+# Members
+
 Membership in working groups: T=technical working group, O=outreach working group, E=editorial working group
 
 Current members of the OBO Foundry Operations Committee are (in alphabetical order of surname):
 
- * Jim Balhoff (T), RENCI, University of North Carolina, Chapel Hill, NC, USA
- * Matt Brush (T), Unversity of Colorado Anschutz Medical Campus, Auroa, CO, USA
- * Pier Luigi Buttigieg (E, O), Alfred Wegener Institute, Helmholtz Centre for Polar and Marine Research, Bremerhaven, Germany
- * Seth Carbon (T), Lawrence Berkeley National Laboratory, Berkeley, CA, USA
- * Alexander Diehl (T), University at Buffalo, Buffalo, NY, USA
- * [Damion Dooley](https://orcid.org/0000-0002-8844-9165) (O), Centre for Infectious Disease Genomics and One Health, Simon Fraser University, BC, Canada
- * [Bill Duncan](https://orcid.org/0000-0001-9625-1899) (E), University of Florida, Gainseville, FL, USA
- * Hector Guzman-Orozco (O), La Jolla Institute for Immunology, La Jolla, CA, USA
- * Nomi Harris (O, T), Lawrence Berkeley National Laboratory, Berkeley, CA, USA
- * [Melissa Haendel](https://www.ohsu.edu/people/melissa-haendel/AFE044BDE8046E5D6FBDA51F448BDE2A) (O), Unversity of Colorado Anschutz Medical Campus, Auroa, CO, USA
- * Rebecca Jackson (T), Intelligent Medical Objects (IMO), Rosemont, IL, USA
- * Nico Matentzoglu (T), Semanticly, Athens, Greece
- * [Chris Mungall](https://github.com/cmungall/) (T), Lawrence Berkeley National Laboratory, Berkeley, CA, USA
- * [Darren Natale](http://pir.georgetown.edu/pirwww/aboutpir/natalebio.shtml) (E), Georgetown University Medical Center, Washington DC, USA
- * David Osumi-Sutherland (O), EMBL-EBI, Cambridge, UK
- * [James A. Overton](http://james.overton.ca) (T), [Knocean Inc.](http://knocean.com), Toronto, Canada
- * Bjoern Peters (E), La Jolla Institute for Immunology, La Jolla, CA, USA
- * [Philippe Rocca-Serra](https://eng.ox.ac.uk/people/philippe-rocca-serra/) (O), University of Oxford e-Research Centre, Department of Engineering Science, Oxford, UK
- * [Alan Ruttenberg](http://sciencecommons.org/about/whoweare/ruttenberg/) (O), University at Buffalo, Buffalo, USA
- * [Richard Scheuermann](https://www.jcvi.org/about/rscheuermann) (O), J. Craig Venter Institute, La Jolla, CA, USA
- * [Lynn Schriml](http://www.medschool.umaryland.edu/profiles/Schriml-Lynn/) (E, O), University of Maryland School of Medicine, Baltimore, MD, USA
- * Barry Smith (O), University at Buffalo, Buffalo, NY, USA
- * Chris Stoeckert (E, O), University of Pennsylvania, Philadelphia, PA, USA
- * [Nicole Vasilevsky](http://orcid.org/0000-0001-5208-3432) (E, O), Unversity of Colorado Anschutz Medical Campus, Auroa, CO, USA
- * Shawn Tan (T), European Bioinformatics Institute, Cambridge, UK 
- * Randi Vita (O), La Jolla Institute for Immunology, La Jolla, CA, USA
- * [Ramona Walls](http://www.cyverse.org/ramona-walls) (E, T), CyVerse, University of Arizona, Tucson, AZ, USA
- * [Jie Zheng](http://cbil.upenn.edu/profile-staff_bio/39) (T, O), University of Pennsylvania, Philadelphia, PA, USA
- 
+- Jim Balhoff (T), RENCI, University of North Carolina, Chapel Hill, NC, USA
+- Matt Brush (T), Unversity of Colorado Anschutz Medical Campus, Auroa, CO, USA
+- Pier Luigi Buttigieg (E, O), Alfred Wegener Institute, Helmholtz Centre for Polar and Marine Research, Bremerhaven, Germany
+- Seth Carbon (T), Lawrence Berkeley National Laboratory, Berkeley, CA, USA
+- Alexander Diehl (T), University at Buffalo, Buffalo, NY, USA
+- [Damion Dooley](https://orcid.org/0000-0002-8844-9165) (O), Centre for Infectious Disease Genomics and One Health, Simon Fraser University, BC, Canada
+- [Bill Duncan](https://orcid.org/0000-0001-9625-1899) (E), University of Florida, Gainseville, FL, USA
+- Hector Guzman-Orozco (O), La Jolla Institute for Immunology, La Jolla, CA, USA
+- Nomi Harris (O, T), Lawrence Berkeley National Laboratory, Berkeley, CA, USA
+- [Melissa Haendel](https://www.ohsu.edu/people/melissa-haendel/AFE044BDE8046E5D6FBDA51F448BDE2A) (O), Unversity of Colorado Anschutz Medical Campus, Auroa, CO, USA
+- Rebecca Jackson (T), Intelligent Medical Objects (IMO), Rosemont, IL, USA
+- Nico Matentzoglu (T), Semanticly, Athens, Greece
+- [Chris Mungall](https://github.com/cmungall/) (T), Lawrence Berkeley National Laboratory, Berkeley, CA, USA
+- [Darren Natale](http://pir.georgetown.edu/pirwww/aboutpir/natalebio.shtml) (E), Georgetown University Medical Center, Washington DC, USA
+- David Osumi-Sutherland (O), EMBL-EBI, Cambridge, UK
+- [James A. Overton](http://james.overton.ca) (T), [Knocean Inc.](http://knocean.com), Toronto, Canada
+- Bjoern Peters (E), La Jolla Institute for Immunology, La Jolla, CA, USA
+- [Philippe Rocca-Serra](https://eng.ox.ac.uk/people/philippe-rocca-serra/) (O), University of Oxford e-Research Centre, Department of Engineering Science, Oxford, UK
+- [Alan Ruttenberg](http://sciencecommons.org/about/whoweare/ruttenberg/) (O), University at Buffalo, Buffalo, USA
+- [Richard Scheuermann](https://www.jcvi.org/about/rscheuermann) (O), J. Craig Venter Institute, La Jolla, CA, USA
+- [Lynn Schriml](http://www.medschool.umaryland.edu/profiles/Schriml-Lynn/) (E, O), University of Maryland School of Medicine, Baltimore, MD, USA
+- Barry Smith (O), University at Buffalo, Buffalo, NY, USA
+- Chris Stoeckert (E, O), University of Pennsylvania, Philadelphia, PA, USA
+- [Nicole Vasilevsky](http://orcid.org/0000-0001-5208-3432) (E, O), Unversity of Colorado Anschutz Medical Campus, Auroa, CO, USA
+- Shawn Tan (T), European Bioinformatics Institute, Cambridge, UK
+- Randi Vita (O), La Jolla Institute for Immunology, La Jolla, CA, USA
+- [Ramona Walls](http://www.cyverse.org/ramona-walls) (E, T), CyVerse, University of Arizona, Tucson, AZ, USA
+- [Jie Zheng](http://cbil.upenn.edu/profile-staff_bio/39) (T, O), University of Pennsylvania, Philadelphia, PA, USA
+
 New members: follow the instructions on the [onboarding doc](https://docs.google.com/document/d/1MKhNTjZjGx6Ls72dybIV2ajYtbqtwP7O4lwxN2v3RBA/edit#heading=h.10q6n5qc13dp)
 
 Alumni:
 
- * Michael Ashburner
- * Colin Batchelor
- * Mathias Brochhausen
- * [Melanie Courtot](http://purl.org/net/mcourtot) 
- * Eric Douglass
- * Janna Hastings
- * Simon Jupp (OBO Industry Liaison)
- * [Suzanna Lewis](https://github.com/selewis)
- * James Malone (OBO Industry Liaison)
- * Gareth Owen
- * Susanna-Assunta Sansone
- * Carlo Tornial
+- Michael Ashburner
+- Colin Batchelor
+- Mathias Brochhausen
+- [Melanie Courtot](http://purl.org/net/mcourtot)
+- Eric Douglass
+- Janna Hastings
+- Simon Jupp (OBO Industry Liaison)
+- [Suzanna Lewis](https://github.com/selewis)
+- James Malone (OBO Industry Liaison)
+- Gareth Owen
+- Susanna-Assunta Sansone
+- Carlo Tornial

--- a/docs/MissionStatement.md
+++ b/docs/MissionStatement.md
@@ -4,23 +4,24 @@ id: MissionStatement
 title: MissionStatement
 ---
 
-# Mission statement of the OBO Foundry Operations Committee #
+# Mission statement of the OBO Foundry Operations Committee
 
 The OBO Foundry Operations Committee aims to facilitate the flow of operations within the OBO Foundry, in collaboration with the OBO Foundry Coordinating Editors and external invited experts. Such operations include, but are not limited to, establishment of policies, review of resources, outreach and education.
 
-## Organization of the OBO Foundry Operations Committee ##
+## Organization of the OBO Foundry Operations Committee
+
 To best perform those activities, the OBO Foundry Operations Committee is divided into working groups. The working groups are self-organized and membership is contingent upon active participation. All active members are required to take on tasks to maintain active standing. Policies are proposed and voted upon by active members. A process for policy approval will be formalized.
 
 Current working groups include:
 
-  * **OBO Foundry Editorial working group**
+- **OBO Foundry Editorial working group**
 
 The [OBO Foundry Editorial working group](EditorialWG.md) is involved in reviewing OBO Foundry ontologies and policy setting. Primary tasks are to conduct reviews, but also include all activities that enable that process, such as tool building for automated validation, website maintenance of the review results, or leading calls and taking notes.
 
-  * **OBO Foundry Technical working group**
+- **OBO Foundry Technical working group**
 
 The [OBO Foundry Technical working group](TechnicalWG.md) is involved in maintaining the technical infrastructure for the OBO Foundry. This includes establishment of policies to be implemented in common tools, website maintenance, calls, etc.
 
-  * **OBO Foundry Outreach working group**
+- **OBO Foundry Outreach working group**
 
 The [OBO Foundry Outreach working group](OutreachWG.md) is involved in public relations for the OBO Foundry. This includes monitoring and following up discussions on mailing lists, preparing documentation and educational materials, and presenting OBO Foundry activities at workshops, conferences, or other venues.

--- a/docs/NewOBOFC.md
+++ b/docs/NewOBOFC.md
@@ -4,7 +4,7 @@ id: OFOCMember
 title: Becoming a member of the OBO Operations Committee
 ---
 
-Note: This is _not_ a formal process, but rather a piece of documentation to make the current _informal_ process more transparent. 
+Note: This is _not_ a formal process, but rather a piece of documentation to make the current _informal_ process more transparent.
 
 The OBO Foundry Operations Committee aims to facilitate the flow of operations within the OBO Foundry.
 
@@ -12,15 +12,16 @@ Potential members of the Operations Committee are identified from two possible s
 
 1. The candidate is formally nominated via email to the Operations Committee. This may or may not be preceded by an informal discussion during a committee call.
 2. Current members, via email, express approval or raise objections in the form of conflicts or concerns.
-<br> a. If conflicts/concerns arise, they are discussed at the next available OFOC call to find resolution.
-<br> b. If no consensus is reached, a formal vote is taken.
+   <br> a. If conflicts/concerns arise, they are discussed at the next available OFOC call to find resolution.
+   <br> b. If no consensus is reached, a formal vote is taken.
 3. Upon either (a) initial approval without objections, (b) resolution of conflicts/concerns, or (c) positive outcome of a formal vote, the candidate is formally invited, via email, to join the Operations Committee. At this time, the candidate is provided an explanation of the various duties expected from members (e.g. chairing calls, addressing issues on GitHub, joining a working group).
 4. The applicant confirms they are willing to take up some of these duties.
 
 Note that new members are strongly encouraged to become members of one of the subcommittees: [Editorial Working Group](https://obofoundry.org/docs/EditorialWG.html)
- or [Technical Working Group](https://obofoundry.org/docs/TechnicalWG.html). 
+or [Technical Working Group](https://obofoundry.org/docs/TechnicalWG.html).
 
 ## Onboarding
+
 Once a candidate has gone through the steps above and been confirmed as a new OFOC member, they need to onboard.
 Currently, the onboarding steps to be taken by or on behalf of a new OFOC member are listed in a Google doc called "OBO Operations Onboarding" in the OBO Operations gdrive folder.
 This may in the future become a public GitHub doc, if that can be done safely.

--- a/docs/NewOntologyRegistrationInstructions.md
+++ b/docs/NewOntologyRegistrationInstructions.md
@@ -13,37 +13,49 @@ Please see [this guide](Policy_for_OBO_namespace_and_associated_PURL_requests.ht
 Please review the [OBO Foundry Principles](http://obofoundry.org/principles/fp-000-summary.html) before proceeding with this submission
 
 ## Ontology title
+
 Concise title of your ontology (e.g, "Gene Ontology")
 
 ## Requested ID space
+
 Prefix of ontology in lowercase (e.g., bfo, uberon, chebi, pato). The OBO Foundry ID policy is described [here](http://obofoundry.org/id-policy.html). Specifically, please see the guidelines for [allocating IDSPACEs](http://obofoundry.org/id-policy.html#allocating-idspaces). Note that ontology prefixes should have at least 4 letters, though you will see older ontologies with 2 or 3-letter prefixes.
 
 ## Ontology location
+
 Home page or URL of ontology. This can be a GitHub URL.
 
 ## Contact person
+
 Name, email address, and GitHub username of contact person. The OBO Foundry policy on contact person is described [here](http://obofoundry.org/principles/fp-011-locus-of-authority.html).
 
 ## Issue tracker
+
 URL for submitting and responding to suggestions, requests, etc. (e.g., https://github.com/geneontology/go-ontology/issues/).
 
 ## Ontology license
+
 Current license. Note that the OBO Foundry accepts CC0 or CC-BY. The OBO Foundry license policy is described in [Principle 1, Open Licensing](http://www.obofoundry.org/principles/fp-001-open.html).
 
 ## Available ontology formats
+
 Note that OWL-RDF/XML is the only required format. The OBO Foundry format policy is described in [Principle 2](http://obofoundry.org/principles/fp-002-format.html).
 
 ## What domain is the ontology intended to cover?
+
 For example, the GO covers the processes, functions and cellular locations of gene products. The OBO Foundry policy on scope of an ontology is described in [Principle 5](http://obofoundry.org/principles/fp-005-delineated-content.html).
 
 ## Related OBO Foundry ontologies
+
 What other ontologies are you aware of that intersect with your domain, and what are your plans for collaborating with them? The OBO Foundry policy on collaboration is described in [Principle 10, Collaboration](http://obofoundry.org/principles/fp-010-collaboration.html).
 
 ## Intended use/related projects
+
 Is your ontology serving the need of one or more specific projects? If so, please describe them. The OBO Foundry policy on documented users is described in [Principle 9](http://obofoundry.org/principles/fp-009-users.html).
 
 ## Data source
+
 Which resources, if any, were used to generate the ontology? E.g., NCBITaxon was created from the NCBI taxonomy resource; the Protein Ontology uses, in part, UniProtKB.
 
 ## Additional comments or remarks
+
 Any other significant information that you'd like us to know.

--- a/docs/OBOCalendar.md
+++ b/docs/OBOCalendar.md
@@ -4,12 +4,11 @@ id: OBOCalendar
 title: OBOCalendar
 ---
 
-# Introduction #
+# Introduction
 
 Information about the OBO Foundry shared calendar
 
-
-# Details #
+# Details
 
 The calendar is publicly available to view at http://www.google.com/calendar/embed?src=cW8yM2Q3NDliajh0ZGwwb2VlNnRhdnBoc3NAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ. Please see below for how to add it to your own calendar.
 
@@ -26,7 +25,7 @@ Having all the information centralized would make it easier to identify possible
 
 Maintenance of the calendar is done on a per request basis, and only approved people have editing rights to prevent spamming.
 
-# Add the OBO Foundry calendar to your own #
+# Add the OBO Foundry calendar to your own
 
 The iCal URL of the OBO foundry calendar is https://www.google.com/calendar/ical/qo23d749bj8tdl0oee6tavphss%40group.calendar.google.com/public/basic.ics
 
@@ -34,6 +33,6 @@ To add it to your google calendar, select Other calendars in the left menu, then
 
 (based on information from http://support.google.com/calendar/bin/answer.py?hl=en&answer=37100)
 
-# Warning #
+# Warning
 
 When replying to a calendar invitation **you need to accept/decline in your own copy of the event**. Declining an event in the shared calendar deletes it for everybody.

--- a/docs/OperationsCommittee.md
+++ b/docs/OperationsCommittee.md
@@ -16,4 +16,5 @@ The members of the Operations Committee are listed [here](Membership.html).
 See a description of our activities in our [mission statement](MissionStatement.html).
 
 ## Interested in joining?
+
 If you are interested in becoming part of the OBO Operations Committee, please see [this page](NewOBOFC.html) to find out about the nomination and onboarding process.

--- a/docs/OperationsCommitteePolicyDecisions.md
+++ b/docs/OperationsCommitteePolicyDecisions.md
@@ -6,32 +6,33 @@ title: OperationsCommitteePolicyDecisions
 
 **This policy has been formally adopted on October 16th 2013. Do not edit this page without consulting with the OBO Foundry Operations Committee.** Comments should be added to the [tracker](http://code.google.com/p/obo-foundry-operations-committee/issues/list).
 
-# How to add a new policy #
+# How to add a new policy
 
-## When policy is recommended by a working group ##
+## When policy is recommended by a working group
 
 1. Working group approves the policy
-  * WG may determine on their own how to approve a policy, but, generally, there should be an opportunity for all WG members to participate in the decision.
-  * Suggest that WG circulate the policy on their internal list for two weeks before final approval.
+
+- WG may determine on their own how to approve a policy, but, generally, there should be an opportunity for all WG members to participate in the decision.
+- Suggest that WG circulate the policy on their internal list for two weeks before final approval.
 
 2. After approval by the WG, the proposed policy is circulated on the Operation Committee mailing list for _one week_ for comments.
 
 3. After approval by the Operations Committee, the wiki page(s) summarizing the policy are frozen and then announced on obo-discuss
-  * Allow _two_ weeks for discussion on obo-discuss
+
+- Allow _two_ weeks for discussion on obo-discuss
 
 4. WG makes any adjustments necessary based on feedback from obo-discuss. If these are substantive changes, re-announce the revised policy and allow another two weeks for comment. If minor changes or none, the WG can finalize the policy at the end of the two week review period.
 
 5. Finalized policy is announce on obo-discuss and wiki page is frozen.
 
-## When policy is arises from general meetings and is not within the jurisdiction of a working group ##
+## When policy is arises from general meetings and is not within the jurisdiction of a working group
 
 Proposed policy is brought up at a general meeting or via the group email list.
 
 There should be at least _two weeks_ between when a policy is first raised (via email or at a meeting) before any decision is made on the policy. This means that is a policy cannot be approved at the same meeting during which it is first raised, because all members of the group must have the opportunity to comment on the proposal, and some members may be absent from a meeting.
 
+# Notes
 
-
-# Notes #
 The WG who creates the wiki page should include a header to specify if the page shows a policy that is under review or finalized (locked).
 
 Whenever possible, policy decisions should go through the appropriate working group before review by the operations committee.

--- a/docs/OutreachWG.md
+++ b/docs/OutreachWG.md
@@ -4,16 +4,16 @@ id: OutreachWG
 title: OutreachWG
 ---
 
-# Introduction #
+# Introduction
 
 This page describes members and activities of the OBO Foundry Outreach Working Group.
 
-
-# Details #
+# Details
 
 The OBO Foundry Outreach WG is involved in public relations for the OBO Foundry. This includes monitoring and following up discussions on mailing lists, preparing documentation and educational materials, and presenting OBO Foundry activities at workshops, conferences, or other venues.
 
-# Members #
+# Members
+
 See the [membership page](/docs/Membership.html) for a list of current members.
 
 <h1>Contact Us</h1>

--- a/docs/Policy_for_OBO_namespace_and_associated_PURL_requests.md
+++ b/docs/Policy_for_OBO_namespace_and_associated_PURL_requests.md
@@ -14,36 +14,33 @@ title: OBO Foundry membership requirements and technical details
 
 4. Before you participate in our community, please read and agree to follow our [Code of Conduct](http://obofoundry.org/docs/COC.html).
 
-
 # Requirements for OBO Membership
 
 1. A project should exist, with work started. We will not "pre-book" IDSPACEs and domains for potential future resources.
-2. A project must be doing original work within the biological ontology community. 
-    * We will not provide an IDSPACE for a project that is issuing new identifier for existing ontologies.
-    * If there is clear overlap with an existing domain ontology, you must demonstrate a good faith effort to work with that ontology to provide any new terms needed.
+2. A project must be doing original work within the biological ontology community.
+   - We will not provide an IDSPACE for a project that is issuing new identifier for existing ontologies.
+   - If there is clear overlap with an existing domain ontology, you must demonstrate a good faith effort to work with that ontology to provide any new terms needed.
 3. The required IDSPACE must be available. We do not allow two-letter IDSPACEs and strongly discourage three-letter IDSPACEs that contain the letter "O". For more details, please see the guidelines for [allocating IDSPACEs](http://obofoundry.org/id-policy.html#allocating-idspaces).
 4. The resource must be publicly available when released. The general expectation is that the ontology source code is available on a public repository such as GitHub.
 5. There must be a contact person for the resource. The contact person for resources must be subscribed to our main communication channel, the [obo-discuss](https://groups.google.com/forum/#!forum/obo-discuss) mailing list.
 6. The requestor and/or contact person should be ready to discuss issues such as whether the ontology is orthogonal, whether there is potential to collaborate with existing efforts.
-7. It is expected that solicitation of a IDSPACE is done _before_ the IDSPACE is used for identifiers. A common strategy is to develop an ontology, request a IDSPACE, and translate the initial URIs used to the PURLs some time before the initial release.  **There is no guarantee that you will be granted your IDSPACE, even if you have been using it in your file**.
-8. As of 4th May 2021, every new ontology submission is required to pass the [OBO Dashboard](http://dashboard.obofoundry.org/) quality control, which means that they are not allowed to have any substantial errors (anything "red"). The only exceptions to this requirement are (1) `Users`, and (2) results in the `Report` that pertain to terms from imported (external) ontologies. Your ontology will be set up in a [provisional Dashboard](https://obofoundry.github.io/obo-nor.github.io/dashboard/index.html) as soon as the GitHub submission request is made. OBO foundry will provide support to help you fix any issues your submission might have. 
-
+7. It is expected that solicitation of a IDSPACE is done _before_ the IDSPACE is used for identifiers. A common strategy is to develop an ontology, request a IDSPACE, and translate the initial URIs used to the PURLs some time before the initial release. **There is no guarantee that you will be granted your IDSPACE, even if you have been using it in your file**.
+8. As of 4th May 2021, every new ontology submission is required to pass the [OBO Dashboard](http://dashboard.obofoundry.org/) quality control, which means that they are not allowed to have any substantial errors (anything "red"). The only exceptions to this requirement are (1) `Users`, and (2) results in the `Report` that pertain to terms from imported (external) ontologies. Your ontology will be set up in a [provisional Dashboard](https://obofoundry.github.io/obo-nor.github.io/dashboard/index.html) as soon as the GitHub submission request is made. OBO foundry will provide support to help you fix any issues your submission might have.
 
 # Process
 
 ## 1. Submitting your ontology to request the IDSPACE
 
 1. Submit your request on our [GitHub tracker](https://github.com/OBOFoundry/OBOFoundry.github.io/issues). Select `New Issue` and then select `New Ontology Request`. Fill out the requested information as completely as possible.
-2. Send an email to [obo-discuss](mailto:obo-discuss@googlegroups.com) with your request to allow community feedback (you may need to [apply to join group](https://groups.google.com/forum/#!forum/obo-discuss) first.) Be sure to include the link to the issue you created in step 1. 
-3. (_Optional_): If you would like to join the obo-community Slack, please indicate this in your email. 
+2. Send an email to [obo-discuss](mailto:obo-discuss@googlegroups.com) with your request to allow community feedback (you may need to [apply to join group](https://groups.google.com/forum/#!forum/obo-discuss) first.) Be sure to include the link to the issue you created in step 1.
+3. (_Optional_): If you would like to join the obo-community Slack, please indicate this in your email.
 
 We expect general discussion to take place on the obo-discuss list, while technical follow-up will take place on the tracker.
 
 Example of such request for ECTO:
 
-* [tracker issue](https://github.com/OBOFoundry/OBOFoundry.github.io/issues/397)
-* [obo-discuss message](https://groups.google.com/forum/#!msg/obo-discuss/Mfbrg5cJ2lM/17HfTEnJDAAJ)
-
+- [tracker issue](https://github.com/OBOFoundry/OBOFoundry.github.io/issues/397)
+- [obo-discuss message](https://groups.google.com/forum/#!msg/obo-discuss/Mfbrg5cJ2lM/17HfTEnJDAAJ)
 
 ## 2. Response
 
@@ -52,7 +49,6 @@ After your submission to the GitHub tracker, your ontology will be set up in a [
 After the ontology passes Dashboard quality control, please allow time for members of the community to provide feedback and for the Operations Committee to review the request. If you don't hear back from us after 4 weeks, you can follow-up via the tracker issue you created.
 
 Based on this discussion, the Operations Committee will either approve the IDSPACE request, ask for changes, or decline your request.
-
 
 ## 3. Approval
 

--- a/docs/PrinciplesReviewWorkflow.md
+++ b/docs/PrinciplesReviewWorkflow.md
@@ -6,14 +6,14 @@ title: PrincipleReviewProcess
 
 This page describes the process for reviewing, updating, and creating [OBO Foundry Principles](http://obofoundry.github.io/principles/fp-000-summary.html).
 
-  * Discuss the principle on working group call
-  * Write up proposed revisions as a GitHub issue (not a pull request)
-  * Inform the Editorial WG via email that the ticket needs discussion (if it doesn’t happen automatically)
-  * Two-week commenting period on GitHub issue tracker
-  * Make any incremental improvements on the tracker
-  * When the Editorial WG agrees on a final version, discuss on an Operations Committee call or via the issue  tracke
-  * Make a pull request
-  * Two-week commenting period on the pull request
-  * Upload final changes to OBO Foundry web site for public viewing.
+- Discuss the principle on working group call
+- Write up proposed revisions as a GitHub issue (not a pull request)
+- Inform the Editorial WG via email that the ticket needs discussion (if it doesn’t happen automatically)
+- Two-week commenting period on GitHub issue tracker
+- Make any incremental improvements on the tracker
+- When the Editorial WG agrees on a final version, discuss on an Operations Committee call or via the issue tracke
+- Make a pull request
+- Two-week commenting period on the pull request
+- Upload final changes to OBO Foundry web site for public viewing.
 
 The need for a new principle can arise when an existing principle tries to cover too much and requires splitting, or as new needs arise within the community.

--- a/docs/RegistrationChecklist.md
+++ b/docs/RegistrationChecklist.md
@@ -1,17 +1,17 @@
 # Minimum Ontology Registration Request Checklist
 
-The _Minimum Ontology Registration Request Checklist_ (MORRC) is intended to provide a first pass to fairly evaluate ontology registration requests to the OBO foundry. 
+The _Minimum Ontology Registration Request Checklist_ (MORRC) is intended to provide a first pass to fairly evaluate ontology registration requests to the OBO foundry.
 The goal is to formalize what is currently an ad-hoc process, to filter out ontologies that are clearly out of scope for OBO. It is intentionally weaker than full
 conformance, because (a) we want to allow registration of imperfect ontologies (b) partial conformance is easier to quickly and objectively check.
 
-Note this does not change the existing process in any way. Anyone from the OBO community is free to object to the ontology on the basis of any of these checks. 
+Note this does not change the existing process in any way. Anyone from the OBO community is free to object to the ontology on the basis of any of these checks.
 However, if no objections are raised during the review period as specified by the guidelines (typically two weeks from the next OBO foundry operations committee meeting), then the ontology becomes registered. Once registered an ontology is never unregistered.
 
-We use ISO language here for SHOULD/MUST. Anyone is free to raise an objection based on a SHOULD but this is informative and non-blocking. 
+We use ISO language here for SHOULD/MUST. Anyone is free to raise an objection based on a SHOULD but this is informative and non-blocking.
 If a MUST is clearly violated then this is basis for exclusion/delaying registration.
 
-
 The checklist is intended for
+
 1. OBO Operations Committee members to evaluate the requests
 2. Ontology maintainers to ensure their ontology is eligible for admission prior to making a request
 
@@ -26,15 +26,15 @@ A Google sheets version of the checklist is available [here](https://docs.google
 - Principle 2: [Common Format](http://obofoundry.org/principles/fp-002-format.html)
   - The ontology MUST be conformant with this principle
   - The ontology MUST be parseable in Protégé, ROBOT or OWLAPI and be logically consistent and coherent with a standard OWL reasoner such as ELK or HermiT (i.e. there should be no unintended unsatisfiable classes)
-- Principle 3: [URI/Identifier Space](http://obofoundry.org/principles/fp-003-uris.html) 
+- Principle 3: [URI/Identifier Space](http://obofoundry.org/principles/fp-003-uris.html)
   - The ontology MUST be conformant with this principle, with the caveat the prefix is not yet registered
   - The requested namespace MUST be available (not already used by another ontology)
-- Principle 4: [Versioning](http://obofoundry.org/principles/fp-004-versioning.html) 
+- Principle 4: [Versioning](http://obofoundry.org/principles/fp-004-versioning.html)
   - The ontology MUST have a versionIRI
-- Principle 5: [Scope](http://obofoundry.org/principles/fp-005-delineated-content.html) 
+- Principle 5: [Scope](http://obofoundry.org/principles/fp-005-delineated-content.html)
   - IF there is significant conceptual overlap to ontologies already registered by the OBO foundry or matching labels THEN there MUST be computable linkages (one of: skos, obo:xref, owl) which are reasonably comprehensive
   - There SHOULD be a written plan (e.g ticket) for coordinating with overlapping ontologies
-- Principle 6: [Textual Definitions](http://obofoundry.org/principles/fp-006-textual-definitions.html) 
+- Principle 6: [Textual Definitions](http://obofoundry.org/principles/fp-006-textual-definitions.html)
   - The ontology SHOULD be conformant with this principle
   - All ontology root terms MUST have definitions
   - All ontology terms SHOULD have a definition

--- a/docs/ReservePrefix.md
+++ b/docs/ReservePrefix.md
@@ -6,7 +6,7 @@ title: Reserve prefix outside of OBO
 
 # My ontology is not ready for OBO Foundry, can I reserve a prefix anyway?
 
-If your ontology is not eligible for inclusion in the OBO Foundry you can not directly reserve a prefix (Ontology ID) in the OBO Foundry. 
+If your ontology is not eligible for inclusion in the OBO Foundry you can not directly reserve a prefix (Ontology ID) in the OBO Foundry.
 However, if you want to make sure that no one uses your prefix, you can [register your prefix at the Bioregistry](https://github.com/biopragmatics/bioregistry/issues/new/choose).
 The updated [OBO policy on IDs](https://obofoundry.org/id-policy) ensures that new prefix requests must not clash with existing prefixes registered at the Bioregistry.
 

--- a/docs/ReviewCriteriaPolicies.md
+++ b/docs/ReviewCriteriaPolicies.md
@@ -4,12 +4,11 @@ id: ReviewCriteriaPolicies
 title: ReviewCriteriaPolicies
 ---
 
-# Ontology Review Criteria #
+# Ontology Review Criteria
 
 This page deals with policies and guidelines for the criteria by which an ontology should be reviewed. [ReviewProcessGuidelines](/docs/ReviewProcessGuidelines.html) covers guidelines and policies for the operational aspects of ontology review.
 
-
-# Draft criteria/policies #
+# Draft criteria/policies
 
 OBO Foundry ontologies are reviewed primarily by how well they apply the currently accepted [OBO Foundry Principles](http://www.obofoundry.org/principles/fp-000-summary.html).
 

--- a/docs/ReviewManagementGuidelines.md
+++ b/docs/ReviewManagementGuidelines.md
@@ -4,6 +4,6 @@ id: ReviewManagementGuidelines
 title: ReviewManagementGuidelines
 ---
 
-# Ontology Review Management #
+# Ontology Review Management
 
 This page was originally created to cover guidelines for managing reviews. That material is not covered in the [ontology review process guidelines](/docs/ReviewProcessGuidelines.html) and the [ontology review criteria policies](/docs/ReviewCriteriaPolicies.html).

--- a/docs/ReviewProcessGuidelines.md
+++ b/docs/ReviewProcessGuidelines.md
@@ -6,30 +6,28 @@ title: ReviewProcessGuidelines
 
 This page deals with policies and guidelines for the process of ontology review, particularly operational aspects such as:
 
-  * which ontologies should be reviewed, and in what order?
-  * how should reviewers be chosen?
-  * what is the workflow for conducting a review?
-  * how will conflicts be resolved?
+- which ontologies should be reviewed, and in what order?
+- how should reviewers be chosen?
+- what is the workflow for conducting a review?
+- how will conflicts be resolved?
 
 [ReviewCriteriaPolicies](/docs/ReviewCriteriaPolicies.html) covers guidelines and policies for the criteria by which an ontology should be reviewed.
 
-# How to request an ontology review #
+# How to request an ontology review
 
-  1. Go to the OBO Foundry Operations Committee [issue tracker](https://github.com/OBOFoundry/OBOFoundry.github.io/issues).
-  2. Click on [New issue](https://github.com/OBOFoundry/OBOFoundry.github.io/issues/new/choose).
-  3. Select the "Ontology Review Request" issue template
-  4. Enter title of issue (e.g., "Review request for MyO") and any comments.
-  5. You will see a link for a self-review form. Fill this in.
-  6. Click "Submit".
+1. Go to the OBO Foundry Operations Committee [issue tracker](https://github.com/OBOFoundry/OBOFoundry.github.io/issues).
+2. Click on [New issue](https://github.com/OBOFoundry/OBOFoundry.github.io/issues/new/choose).
+3. Select the "Ontology Review Request" issue template
+4. Enter title of issue (e.g., "Review request for MyO") and any comments.
+5. You will see a link for a self-review form. Fill this in.
+6. Click "Submit".
 
-# Ontology review priority #
+# Ontology review priority
 
 Ontologies will be reviewed in the order in which the review request is received. If an ontology previously submitted a request for an OBO Foundry review (that is, before this committee was formed), then the date of the original request is used to determine priority.
 
 Any ontology group wanting a review by the Editorial WG must submit a request on the [issue tracker](https://github.com/OBOFoundry/OBOFoundry.github.io/issues)
 
-# Ontology review workflow #
+# Ontology review workflow
 
 After requesting a review, a link will be provided to perform a self-review. The self-review is then assessed by the Editorial Working Group to determine if the ontology is ready for full review. Full reviews are conducted by community experts, who provide feedback to the submitter and make recommendations for acceptance to the OBO Foundry Operations Committee. OBO Foundry ontologies are reviewed primarily by how well they apply the currently accepted [OBO Foundry Principles](http://www.obofoundry.org/principles/fp-000-summary.html).
-
-

--- a/docs/SOP.md
+++ b/docs/SOP.md
@@ -3,33 +3,37 @@ layout: doc
 id: SOP
 title: Standard Operating Procedures
 ---
+
 # Standard Operating Procedures
 
-**Description**:  
- 
+**Description**:
+
 This document contains standard operating procedures (SOPs) for the OBO Foundry Operations Committee, and is intended for internal use only.
 
 ## SOPs
+
 - [New Ontology Requests](#NOR)
 - [Changing ontology metadata in the registry](#META)
 
-<a name="NOR"></a> 
-### New Ontology Requests (NOR) 
+<a name="NOR"></a>
+
+### New Ontology Requests (NOR)
 
 1. When receiving a new ontology request (NOR), the OBO dashboard administrator should thank the submitter for their submission.
 1. The OBO dashboard administrator adds the new submission to the NOR dashboard, which is deployed at https://obofoundry.github.io/obo-nor.github.io/
 1. After the dashboard is run, the OBO dashboard administrator informs the submitter about the need to fix the issues revealed by the dashboard, noting this is not part of the review itself, just a precursor, and that upon completion, a liaison will be assigned.
 1. At the next OBO Foundry Operations Committee conference call (hereafter, "Operations call"), a liaison is selected to be responsible for the issue. This liaison becomes familiar with the new ontology and rallies the appropriate people to provide feedback.
 1. At the next Operations call after that one, the liaison presents the NOR to the OBO Foundry Operations Committee and answers questions. In most cases, the information provided will be sufficient to either grant or refuse the prefix request. In some cases, the committee may choose to postpone its decision to require some clarification and fixes from the submitter.
-The liaison MUST be present at the Operations call in order for the NOR case to be discussed. If the liaison does not participate for 2 consecutive Operations calls, the chair of the second call emails the liaison to request a statement confirming the ability to continue as liaison. If the liaison does not participate in 3 consecutive Operations calls and did not respond to the email above, a new liaison is assigned during that third call.
+   The liaison MUST be present at the Operations call in order for the NOR case to be discussed. If the liaison does not participate for 2 consecutive Operations calls, the chair of the second call emails the liaison to request a statement confirming the ability to continue as liaison. If the liaison does not participate in 3 consecutive Operations calls and did not respond to the email above, a new liaison is assigned during that third call.
 
-<a name="META"></a> 
+<a name="META"></a>
+
 ### Changing ontology metadata in the registry
 
 In general, the metadata record of an ontology in the OBO Foundry metadata registry ([example](https://github.com/OBOFoundry/OBOFoundry.github.io/blob/master/ontology/go.md)) is managed and curated by the ontology team that is responsible for the respective ontology. However, as an open data organisation, the OBO Foundry does accept proposals by any member of the community to change this metadata. Such change proposal can include fixing typos, adding a tag, adding a publication where it was missed. The following SOP exists to ensure that these changes are not performed without the knowledge of the responsible ontology team.
 
 1. Any member of the community (OBO Foundry or otherwise) may propose a change in the form of a [pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests).
-2. This pull request is reviewed by a member of the OBO Foundry operations committee and may be rejected. 
+2. This pull request is reviewed by a member of the OBO Foundry operations committee and may be rejected.
 3. The OBO Foundry operations committee member MUST then tag the listed contact person using their GitHub handle on the pull request requesting a review (initial request for feedback).
 4. After two weeks without activity, an OBO Foundry operations committee member will update the pull request and announce a prospective merge date no earlier than two weeks in the future.
 5. After at least 4 weeks have passed since the initial request for review:

--- a/docs/TableOfContents.md
+++ b/docs/TableOfContents.md
@@ -4,26 +4,24 @@ id: TableOfContents
 title: TableOfContents
 ---
 
-
 Operations Committee
 
-  * [Mission statement](/docs/MissionStatement.html)
-  * [Membership](/docs/Membership.html)
-  * [Meetings](/docs/CommitteeMeetings.html)
-  * [Policy decisions](/docs/OperationsCommitteePolicyDecisions.html)
-  * [Mailing-lists](/docs/MailingLists.html)
-  * [OBO calendar](/docs/OBOCalendar.html)
+- [Mission statement](/docs/MissionStatement.html)
+- [Membership](/docs/Membership.html)
+- [Meetings](/docs/CommitteeMeetings.html)
+- [Policy decisions](/docs/OperationsCommitteePolicyDecisions.html)
+- [Mailing-lists](/docs/MailingLists.html)
+- [OBO calendar](/docs/OBOCalendar.html)
 
 [Outreach group](/docs/OutreachWG.html)
 
 [Editorial group](/docs/EditorialWG.html)
 
-  * [Review process](/docs/ReviewProcessGuidelines.html)
-  * [Review criteria](/docs/ReviewCriteriaPolicies.html)
+- [Review process](/docs/ReviewProcessGuidelines.html)
+- [Review criteria](/docs/ReviewCriteriaPolicies.html)
 
 [Technical group](/docs/TechnicalWG.html)
 
-  * [PURL requests](/docs/Policy_for_OBO_namespace_and_associated_PURL_requests.html)
-  * [OBO PURL configuration](/docs/OBOPURLDomain.html)
-  * [Ontology tools and resources](/resources)
-
+- [PURL requests](/docs/Policy_for_OBO_namespace_and_associated_PURL_requests.html)
+- [OBO PURL configuration](/docs/OBOPURLDomain.html)
+- [Ontology tools and resources](/resources)

--- a/docs/TechnicalWG.md
+++ b/docs/TechnicalWG.md
@@ -6,7 +6,8 @@ title: OBO Foundry Technical Working Group
 
 The OBO Foundry Operations Committee Technical WG is involved in maintaining the technical infrastructure for the OBO Foundry. This includes establishment of policies to be implemented in common tools, website maintenance, etc.
 
-# Members #
+# Members
+
 See the [membership page](/docs/Membership.html) for a list of current members.
 
 <h1>Meetings</h1>

--- a/docs/TechnicalWGMeetings.md
+++ b/docs/TechnicalWGMeetings.md
@@ -4,17 +4,17 @@ id: TechnicalWGMeetings
 title: TechnicalWGMeetings
 ---
 
-# Technical working group meetings #
+# Technical working group meetings
 
-  * 20130607 - OBOFOC-TWG meeting - chair Philippe Rocca-Serra
-  * 20130517 - OBOFOC-TWG meeting - chair Colin Batchelor
-  * 20130426 - OBOFOC-TWG meeting - chair Alan Ruttenberg
-  * 20130405 - OBOFOC-TWG meeting - chair Chris Mungall
-  * [20130318 - OBOFOC-TWG meeting](https://docs.google.com/document/d/12qW0KnQQVX-hxPf93r1v_n1VFVOjb4FTbn56WaikIgs/edit) - chair Melanie Courtot
-  * [20130222 - OBOFOC-TWG meeting](https://docs.google.com/document/d/12PQ_c4dMQlP2cJxYV_QCp53sEBY342zI__VlnxZqQDM/edit) - chair Melanie Courtot
-  * 20130201 - OBOFOC-TWG meeting - chair Colin Batchelor
-  * 20130111 - OBOFOC-TWG meeting - chair Alan Ruttenberg
-  * 20121221 - OBOFOC-TWG meeting - chair Chris Mungall
-  * 20121130 - OBOFOC-TWG meeting - chair Carlo Torniai
-  * [20121109 - OBOFOC-TWG meeting](https://docs.google.com/document/d/1OxpGSNU_QiDCaRlAN9QtD3oxCXuhQap42aIP7VfM5jY/edit)
-  * [20121017 - OBOFOC-TWG meeting](https://docs.google.com/document/d/1yhwBGCVUcSV06Yz7GIv8DLWUoaxPuG0VDqRhzQZuurA/edit)
+- 20130607 - OBOFOC-TWG meeting - chair Philippe Rocca-Serra
+- 20130517 - OBOFOC-TWG meeting - chair Colin Batchelor
+- 20130426 - OBOFOC-TWG meeting - chair Alan Ruttenberg
+- 20130405 - OBOFOC-TWG meeting - chair Chris Mungall
+- [20130318 - OBOFOC-TWG meeting](https://docs.google.com/document/d/12qW0KnQQVX-hxPf93r1v_n1VFVOjb4FTbn56WaikIgs/edit) - chair Melanie Courtot
+- [20130222 - OBOFOC-TWG meeting](https://docs.google.com/document/d/12PQ_c4dMQlP2cJxYV_QCp53sEBY342zI__VlnxZqQDM/edit) - chair Melanie Courtot
+- 20130201 - OBOFOC-TWG meeting - chair Colin Batchelor
+- 20130111 - OBOFOC-TWG meeting - chair Alan Ruttenberg
+- 20121221 - OBOFOC-TWG meeting - chair Chris Mungall
+- 20121130 - OBOFOC-TWG meeting - chair Carlo Torniai
+- [20121109 - OBOFOC-TWG meeting](https://docs.google.com/document/d/1OxpGSNU_QiDCaRlAN9QtD3oxCXuhQap42aIP7VfM5jY/edit)
+- [20121017 - OBOFOC-TWG meeting](https://docs.google.com/document/d/1yhwBGCVUcSV06Yz7GIv8DLWUoaxPuG0VDqRhzQZuurA/edit)

--- a/docs/participate.md
+++ b/docs/participate.md
@@ -4,7 +4,8 @@ id: Participate
 title: How to participate in the OBO Foundry
 ---
 
-The OBO Foundry is currently a volunteer-run organization. There are many ways to get involved:  
+The OBO Foundry is currently a volunteer-run organization. There are many ways to get involved:
+
 - Submit a bug report, question, or feature request to the [OBO Foundry issue tracker](https://github.com/OBOFoundry/OBOFoundry.github.io/issues)
 - Join the [OBO-Discuss mailing list](https://groups.google.com/forum/#!forum/obo-discuss)
 - Join the [OBO-Tools mailing list](https://groups.google.com/forum/#!members/obo-tools)

--- a/docs/tasks_desiderata_wiki.md
+++ b/docs/tasks_desiderata_wiki.md
@@ -4,28 +4,25 @@ id: tasks_desiderata_wiki
 title: tasks_desiderata_wiki
 ---
 
-# Desiderata #
+# Desiderata
 
+- We should have an integrated environment with the information currently in the boo foundry website and in the OBO Foundry wiki
+- We will need to identify the content and functionalities
+  - Automatic update about OBO Foundry ontologies and their metrics (including the new assessments of OBO Foundry Principles compliancy)
+  - Bing able to link to review status and review trackers for each ontology that is under review
 
-  * We should have an integrated environment with the information currently in the boo foundry website and in the OBO Foundry wiki
-  * We will need to identify the content and functionalities
-    * Automatic update about OBO Foundry ontologies and their metrics (including the new assessments of OBO Foundry Principles compliancy)
-    * Bing able to link to review status and review trackers for each ontology that is under review
+# Tasks
 
+- Integration in one platform (OBO foundry wiki / OBO Foundry website)
 
+  - Evaluate CC wiki:
+    - Assess what should be done to use it
+    - Assess functionalitieis
 
+- Identify (talking with Alan and Chris) what has to be integrated in terms of where the current content lives
 
+- Content
 
-# Tasks #
+  - Identify what would be the content of this new integrated wiki
 
-  * Integration in one platform (OBO foundry wiki / OBO Foundry website)
-    * Evaluate CC wiki:
-      * Assess what should be done to use it
-      * Assess functionalitieis
-
-  * Identify (talking with Alan and Chris) what has to be integrated in terms of where the current content lives
-
-  * Content
-    * Identify what would be the content of this new integrated wiki
-
-  * Redesign the look and feel
+- Redesign the look and feel

--- a/faq/adding-custom-browsers.md
+++ b/faq/adding-custom-browsers.md
@@ -27,6 +27,6 @@ used to render the button), `title` and `url` (the actual link).
 
 In future we hope to enhance this:
 
- * embeddable browsers
- * embeddable search
- * automatic links to OLS and BioPortal
+- embeddable browsers
+- embeddable search
+- automatic links to OLS and BioPortal

--- a/faq/foundry-vs-format.md
+++ b/faq/foundry-vs-format.md
@@ -5,7 +5,7 @@ title: Foundry vs Format
 
 ## What is the difference between an OBO Foundry ontology and an OBO Format ontology?
 
-There has been a lot of confusion about the difference between an OBO *Foundry* ontology and OBO *Format* ontology.
+There has been a lot of confusion about the difference between an OBO _Foundry_ ontology and OBO _Format_ ontology.
 The OBO Foundry maintains a registry of ontologies.
 An OBO Foundry ontology is simply a member of this registry.
 This has nothing at all to do with the OBO format, which is a serialisation, or file format for ontologies.

--- a/faq/how-do-i-add-browser.md
+++ b/faq/how-do-i-add-browser.md
@@ -36,6 +36,6 @@ used to render the button), `title` and `url` (the actual link).
 
 In future we hope to enhance this:
 
- * embeddable browsers
- * embeddable search
- * automatic links to OLS and BioPortal
+- embeddable browsers
+- embeddable search
+- automatic links to OLS and BioPortal

--- a/faq/how-do-i-edit-content.md
+++ b/faq/how-do-i-edit-content.md
@@ -5,17 +5,17 @@ title: Edit content
 
 This FAQ is about editing the narrative content of the OBO site
 
- * To edit ontology metadata, see the FAQ <a href="{{site.baseurl}}faq/how-do-i-edit-metadata.html">How do I edit metadata</a>
- * For general contributions, see the FAQ <a href="{{site.baseurl}}faq/how-do-i-modify-website.html">How do I modify the web portal</a>
+- To edit ontology metadata, see the FAQ <a href="{{site.baseurl}}faq/how-do-i-edit-metadata.html">How do I edit metadata</a>
+- For general contributions, see the FAQ <a href="{{site.baseurl}}faq/how-do-i-modify-website.html">How do I modify the web portal</a>
 
 ## How do I edit the content of the OBO site?
 
 The procedure for editing content of the website is similar to that
 for [editing metadata files](how-do-i-edit-metadata.md):
 
- * Click the Edit button. This takes you to the GitHub page for editing content
- * Make your proposed edits
- * Save and make a Pull Request
+- Click the Edit button. This takes you to the GitHub page for editing content
+- Make your proposed edits
+- Save and make a Pull Request
 
 Note that even if you have permission to directly push to master,
 making Pull Requests (PRs) is generally a good idea.
@@ -25,8 +25,8 @@ making Pull Requests (PRs) is generally a good idea.
 Most of the content of the website is in [markdown format](http://daringfireball.net/projects/markdown/syntax). This
 is primarily:
 
- * Principles
- * The FAQ entries
+- Principles
+- The FAQ entries
 
 Most other content is metadata driven. To modify this, edit the
 metadata file itself. To change how the metadata is displayed, change
@@ -40,7 +40,7 @@ It is important that editors conform to the style guide for each page type
 
 ## Principles Styleguide
 
-Jekyll template: <a href="{{site.repo_src}}_layouts/principle.html">_layouts/principle.html</a>
+Jekyll template: <a href="{{site.repo_src}}_layouts/principle.html">\_layouts/principle.html</a>
 
 The md file should have a a yaml header like the following:
 
@@ -52,8 +52,7 @@ title: Open
 ---
 ```
 
-The value of `layout:` __must__ be `principle`
-
+The value of `layout:` **must** be `principle`
 
 Each principle should have the following sections:
 
@@ -82,7 +81,7 @@ Note that no title is necessary, as this is generated from the yaml header block
 
 ## FAQ Styleguide
 
-Jekyll template: <a href="{{site.repo_src}}_layouts/faq.html">_layouts/faq.html</a>
+Jekyll template: <a href="{{site.repo_src}}_layouts/faq.html">\_layouts/faq.html</a>
 
 The md file should have a a yaml header like the following:
 
@@ -93,9 +92,7 @@ title: Add a browser
 ---
 ```
 
-
-The value of `layout:` __must__ be `faq`
-
+The value of `layout:` **must** be `faq`
 
 A level 2 heading (`##`) should be used for each section. Level 3 headings or higher may be included.
 

--- a/faq/how-do-i-edit-metadata.md
+++ b/faq/how-do-i-edit-metadata.md
@@ -20,8 +20,8 @@ the idspace for your ontology.
 
 The markdown (`.md`) page for your ontology is in two sections:
 
- 1. The section between the `---` markers is in a format called *yaml*, and is structured metadata
- 2. The section after the markers is markdown text that can be used to customize your page
+1.  The section between the `---` markers is in a format called _yaml_, and is structured metadata
+2.  The section after the markers is markdown text that can be used to customize your page
 
 ### YAML Metadata
 
@@ -34,7 +34,7 @@ label: Cell Ontology
 title: Cell Ontology
 description: The Cell Ontology is a structured controlled vocabulary for cell types in animals.
 integration_server: http://build.berkeleybop.org/job/build-cl/
-taxon: 
+taxon:
   id: NCBITaxon:33208
   label: Metazoa
 domain: cells
@@ -50,17 +50,17 @@ products:
  - id: cl/cl-basic.obo
 ```
 
-*IMPORTANT* some properties are in flux, be warned.
+_IMPORTANT_ some properties are in flux, be warned.
 
-*TODO* link to doc for properties
+_TODO_ link to doc for properties
 
 A few key properties to be aware of:
 
- * *layout* - this is not actually metadata about the ontology but controls how the page is displayed. You should not mess with this unless you are a web style guru.
- * *id* - this should not be touched. Your ontology id is fixed in the system by OBO administrators at time of registration and should never be changed. Contact the OBO team if you have a valid reason for changing this. See [ID Policy](../id-policy.html)
- * *title* - a *short* name for your ontology - this is typically the spelling out of your ontology acronym.
- * *description* - a short one line description of your ontology. It should state concisely what the contents of the ontology are. Don't write this like a paper abstract. You can be more verbose in the custom section below
- * *tracker* - typically a github issues url
+- _layout_ - this is not actually metadata about the ontology but controls how the page is displayed. You should not mess with this unless you are a web style guru.
+- _id_ - this should not be touched. Your ontology id is fixed in the system by OBO administrators at time of registration and should never be changed. Contact the OBO team if you have a valid reason for changing this. See [ID Policy](../id-policy.html)
+- _title_ - a _short_ name for your ontology - this is typically the spelling out of your ontology acronym.
+- _description_ - a short one line description of your ontology. It should state concisely what the contents of the ontology are. Don't write this like a paper abstract. You can be more verbose in the custom section below
+- _tracker_ - typically a github issues url
 
 ### Freeform Markdown
 
@@ -85,11 +85,11 @@ their fork until approved by OBO admins.
 
 The workflow is:
 
- 1. An automated Travis job will run to validate your changes
- 2. An OBO administrator will evaluate your PR. If it failed the travis check, it will not be accepted
- 3. If the the OBO admin rejects it they will provide feedback in the comment form which you can use to make further edits
- 4. More likely, the change will be accepted by the OBO admin. They will click "merge" and the changes will be visible in a few seconds.
- 5. The OBO admin will also need to run a Make script to regenerate the main metadata file, so your changes may not be visible on the front table straight away
+1.  An automated Travis job will run to validate your changes
+2.  An OBO administrator will evaluate your PR. If it failed the travis check, it will not be accepted
+3.  If the the OBO admin rejects it they will provide feedback in the comment form which you can use to make further edits
+4.  More likely, the change will be accepted by the OBO admin. They will click "merge" and the changes will be visible in a few seconds.
+5.  The OBO admin will also need to run a Make script to regenerate the main metadata file, so your changes may not be visible on the front table straight away
 
 ## Pull Request Tutorial
 
@@ -269,8 +269,3 @@ Finally delete your branch:
 If this seems bewildering, don't worry. The PR mechanism is optional
 you can always ask OBO administrators to make any changes for you, via
 email or the tracker.
-
-
-
-
-

--- a/faq/how-do-i-modify-website.md
+++ b/faq/how-do-i-modify-website.md
@@ -23,7 +23,6 @@ required) and test changes locally.
 
 More details:
 
- * [GitHub project](https://github.com/OBOFoundry/OBOFoundry.github.io/)
- * [README.md](https://github.com/OBOFoundry/OBOFoundry.github.io/blob/master/README.md) -- how the site works
- * [README-sitedev.md](https://github.com/OBOFoundry/OBOFoundry.github.io/blob/master/README-sitedev.md) -- for site developers
-
+- [GitHub project](https://github.com/OBOFoundry/OBOFoundry.github.io/)
+- [README.md](https://github.com/OBOFoundry/OBOFoundry.github.io/blob/master/README.md) -- how the site works
+- [README-sitedev.md](https://github.com/OBOFoundry/OBOFoundry.github.io/blob/master/README-sitedev.md) -- for site developers

--- a/faq/how-do-i-register-my-ontology.md
+++ b/faq/how-do-i-register-my-ontology.md
@@ -6,8 +6,8 @@ title: Submit a new ontology
 ## How do I submit my ontology?
 
 To submit a new ontology for inclusion in the OBO Foundry, you will need to:
+
 1. Review the [OBO Foundry requirements and technical details](https://obofoundry.org/docs/Policy_for_OBO_namespace_and_associated_PURL_requests.html) document for membership expectations and submission instructions.
 2. Submit your request to our GitHub tracker, using the [New Ontology Request template](https://github.com/OBOFoundry/OBOFoundry.github.io/issues/new?assignees=&labels=new+ontology&template=new-ontology-request.md&title=). _Note: please see the [New Ontology Registration Instructions](http://obofoundry.org/docs/NewOntologyRegistrationInstructions.html) for guidance._
 3. Send an email to [obo-discuss](mailto:obo-discuss@googlegroups.com) with your request to allow community feedback (you may need to [apply to join group](https://groups.google.com/forum/#!forum/obo-discuss) first.) Be sure to include the link to the issue you created in step 2.
 4. (_Optional_): If you would like to join the obo-community Slack, please indicate this in your email.
-

--- a/faq/how-do-i-request-a-term.md
+++ b/faq/how-do-i-request-a-term.md
@@ -5,11 +5,10 @@ title: Request an ontology term
 
 ## How do I request an ontology term?
 
-Every ontology project has an issue tracker that the developers use to keep track of terms to add and problems to fix. Look for "Trackers" on the right side of the page for each ontology on this site. For example, on the [Gene Ontology page](http://obofoundry.org/ontology/go) you'll see the tracker is <https://github.com/geneontology/go-ontology/issues/>. 
+Every ontology project has an issue tracker that the developers use to keep track of terms to add and problems to fix. Look for "Trackers" on the right side of the page for each ontology on this site. For example, on the [Gene Ontology page](http://obofoundry.org/ontology/go) you'll see the tracker is <https://github.com/geneontology/go-ontology/issues/>.
 
-Before you request a new term, please search [OntoBee](https://ontobee.org) or [BioPortal](http://bioportal.bioontology.org) for the term you want and its synonyms. An OBO ontology might already include the term you want under a different name. Check the [OBO home page](http://obofoundry.org) to find appropriate ontologies. 
+Before you request a new term, please search [OntoBee](https://ontobee.org) or [BioPortal](http://bioportal.bioontology.org) for the term you want and its synonyms. An OBO ontology might already include the term you want under a different name. Check the [OBO home page](http://obofoundry.org) to find appropriate ontologies.
 
 To request a new term, you can send a new term request on the issue tracker of the appropriate ontology. For example, to request a new relation from Relations Ontology, you can post new term request on the [RO tracker](https://github.com/oborel/obo-relations/issues).
 
 When you do submit a request for a new term, please follow any term submission guidelines for the project. See the [OBO Tutorial](https://github.com/jamesaoverton/obo-tutorial/blob/master/docs/ontology-development.md#filing-effective-term-requests-and-bug-reports) for some general advice.
-

--- a/faq/index.md
+++ b/faq/index.md
@@ -4,41 +4,50 @@ title: OBO Foundry Frequently Asked Questions
 ---
 
 ### Policy
-- [What are the OBO Foundry Principles?](/principles/fp-000-summary.html) 
-- [What is the OBO ID Policy?](/id-policy.html) 
-- [My ontology is not ready for OBO Foundry, can I reserve a prefix anyway?](/docs/ReservePrefix.html) 
+
+- [What are the OBO Foundry Principles?](/principles/fp-000-summary.html)
+- [What is the OBO ID Policy?](/id-policy.html)
+- [My ontology is not ready for OBO Foundry, can I reserve a prefix anyway?](/docs/ReservePrefix.html)
 - [What's the difference between an OBO Foundry ontology and an OBO format ontology?](/faq/foundry-vs-format.html)
 
-### Citation 
-- [How do I cite the OBO Foundry?](/registry/publications.html) 
-- [How do I cite a specific ontology?](/docs/Citation.html) 
- 
-### Terms 
+### Citation
+
+- [How do I cite the OBO Foundry?](/registry/publications.html)
+- [How do I cite a specific ontology?](/docs/Citation.html)
+
+### Terms
+
 - [How do I request a new ontology term?](/faq/how-do-i-request-a-term.html)
 
-### Ontology display 
-- [How do I add a custom browser for my ontology?](/faq/how-do-i-add-browser.html) 
+### Ontology display
+
+- [How do I add a custom browser for my ontology?](/faq/how-do-i-add-browser.html)
 - [Why is there no OBO-Format file listed for my ontology?](/faq/where-is-the-obo-file.html)
 
-### Ontology metadata 
-- [How do I edit the metadata for my ontology?](/faq/how-do-i-edit-metadata.html) 
-- [What are permissible values in the metadata file, e.g. for 'publications'?](/faq/permissible-metadata-content.html) 
-- [What is the `build` object in the ontology metadata?](/faq/what-is-the-build-field.html) 
+### Ontology metadata
+
+- [How do I edit the metadata for my ontology?](/faq/how-do-i-edit-metadata.html)
+- [What are permissible values in the metadata file, e.g. for 'publications'?](/faq/permissible-metadata-content.html)
+- [What is the `build` object in the ontology metadata?](/faq/what-is-the-build-field.html)
 - [What does it mean for an ontology to be flagged as 'inactive', 'orphaned' or 'obsolete'?](/docs/OntologyStatus.html)
 
-### OBO Dashboard 
-- [What is the OBO Dashboard?](/faq/dashboard.html) 
+### OBO Dashboard
+
+- [What is the OBO Dashboard?](/faq/dashboard.html)
 - [How can I assess my ontology using the OBO Dashboard?](/faq/dashboard.html)
 
-### Guides 
-- [What tools are there for creating, editing and working with OBO ontologies?](/resources) 
-- [How should I manage my ontology using version control?](https://douroucouli.wordpress.com/2014/01/08/creating-an-ontology-project/) 
-- [How do I convert between formats (e.g. OBO to OWL format)?](http://robot.obolibrary.org/convert) 
+### Guides
+
+- [What tools are there for creating, editing and working with OBO ontologies?](/resources)
+- [How should I manage my ontology using version control?](https://douroucouli.wordpress.com/2014/01/08/creating-an-ontology-project/)
+- [How do I convert between formats (e.g. OBO to OWL format)?](http://robot.obolibrary.org/convert)
 - [How should I manage and curate my ontology throughout its lifecycle?](faq/managing-ontology.html)
 
-### Participate 
-- [How do I submit my ontology?](/faq/how-do-i-register-my-ontology.html) 
+### Participate
+
+- [How do I submit my ontology?](/faq/how-do-i-register-my-ontology.html)
 - [How can I get involved in the OBO Foundry?](/docs/participate.html)
 
 ### My question isn't listed here
+
 You can submit your question to our [issue tracker](https://github.com/OBOFoundry/OBOFoundry.github.io/issues)!

--- a/faq/permissible-metadata-content.md
+++ b/faq/permissible-metadata-content.md
@@ -8,13 +8,15 @@ This FAQ is about the content of the various fields in your ontology metadata fi
 NOTE: In the instructions below, items in angle brackets&mdash;including the brackets `<>` themselves&mdash;should be replaced by the appropriate content.
 
 ## What can I put in the 'publications' field?
-Allowed number of entries: *any*<br>
+
+Allowed number of entries: _any_<br>
 Each entry under this field should have one 'id' subfield and one 'title' subfield with content as indicated:
-- id: `<cited reference>` The cited reference must take the form of a URI that points to one of the following permitted resources: PubMed, PubMed Central, or a  Digital Object Identifier (DOI) service.
+
+- id: `<cited reference>` The cited reference must take the form of a URI that points to one of the following permitted resources: PubMed, PubMed Central, or a Digital Object Identifier (DOI) service.
 
 &emsp;&emsp;&emsp;Example URI for PubMed: https://www.ncbi.nlm.nih.gov/pubmed/27128319<br>
 &emsp;&emsp;&emsp;Example URI for PubMed Central: https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4851331<br>
-&emsp;&emsp;&emsp;Example URI for a DOI: https://doi.org/10.1371/journal.pone.0154556 
+&emsp;&emsp;&emsp;Example URI for a DOI: https://doi.org/10.1371/journal.pone.0154556
 
 <ul>Examples of other DOI services include journals, preprint servers such as arXiv, bioRxiv, medRxiv, and ChemRxiv, and alternative hosting platforms such as Zenodo and FigShare. Note, however, that the DOI link for these must be used rather than the direct link. For example, instead of a direct link to Zenodo such as https://zenodo.org/record/6685957, the equivalent DOI record https://doi.org/10.5281/zenodo.6685957 must be used. Direct links to PDFs or resources such as CEUR-WS (http://ceur-ws.org/) that do not provide DOIs are not permitted. In such cases the Zenodo platform can be used to upload content that does not have a home in any of the permitted resources.</ul>
 

--- a/faq/what-is-the-build-field.md
+++ b/faq/what-is-the-build-field.md
@@ -24,7 +24,7 @@ each ontology.
 
 The output goes here:
 
- * http://ontologies.berkeleybop.org/
+- http://ontologies.berkeleybop.org/
 
 You can choose to entirely ignore the output of this pipeline for your
 ontology. However, it provides a convenient fall-through for groups
@@ -37,36 +37,36 @@ well as additional services such as validation).
 
 The continuous integration job runs here:
 
- * http://build.berkeleybop.org/job/simple-build-obo-all/
+- http://build.berkeleybop.org/job/simple-build-obo-all/
 
 It takes as metadata input the yml file from this repository. It makes
 use of the `build` object.
 
 This job will fail if ontologies marked as `infallible` fail. To debug, the full log of the last build can be examined:
 
- * https://build.berkeleybop.org/job/simple-build-obo-all/lastBuild/consoleFull
+- https://build.berkeleybop.org/job/simple-build-obo-all/lastBuild/consoleFull
 
 (Look for the text "should not fail")
 
 ## Warning
 
-A  http://ontologies.berkeleybop.org/ URL should never be handed out directly. This service exists so that:
+A http://ontologies.berkeleybop.org/ URL should never be handed out directly. This service exists so that:
 
- * Un PURL-registered ontologies will have a fall-through
- * Registered PURL ontologies that do not want to take charge of either OBO or OWL generation will have a place to 302-redirect to
+- Un PURL-registered ontologies will have a fall-through
+- Registered PURL ontologies that do not want to take charge of either OBO or OWL generation will have a place to 302-redirect to
 
 ## What are some of the methods?
 
 The build object takes a number of different methods:
 
- * obo2owl: creates a release folder using an obo file as source
- * owl2obo: creates a release folder using an owl file as source
- * archive: copies a release folder (e.g. from an existing CI job) to the bbop ontology repository
- * vcs: does a git or svn checkout and copies the resulting folder
+- obo2owl: creates a release folder using an obo file as source
+- owl2obo: creates a release folder using an owl file as source
+- archive: copies a release folder (e.g. from an existing CI job) to the bbop ontology repository
+- vcs: does a git or svn checkout and copies the resulting folder
 
-For more details, ask a question on the tracker or see the script: 
+For more details, ask a question on the tracker or see the script:
 
- * https://github.com/owlcollab/owltools/blob/master/OWLTools-Oort/bin/build-obo-ontologies.pl
+- https://github.com/owlcollab/owltools/blob/master/OWLTools-Oort/bin/build-obo-ontologies.pl
 
 ## Assumptions
 

--- a/faq/where-is-the-obo-file.md
+++ b/faq/where-is-the-obo-file.md
@@ -3,8 +3,8 @@ layout: faq
 title: Where is the OBO file for my ontology?
 ---
 
-This registry makes a distinction between an *ontology* and the
-*products* (also known as *editions*) of that ontology.
+This registry makes a distinction between an _ontology_ and the
+_products_ (also known as _editions_) of that ontology.
 
 Products can be the ontology in a different format (e.g. obo vs owl),
 or they can be different variants (for example, subsets or
@@ -18,7 +18,6 @@ OBO Foundry administrative perspective, the "parent" is considered the
 ontology.
 
 The different products are listed as objects under the `product` key, for example:
-
 
 ```
 ---
@@ -47,10 +46,6 @@ Developers can OPTIONALLY produce ontologies in other formats. These are convent
 
 It does not matter to us if you maintain the source for your ontology
 in obo or owl or some hybrid. You have the option of either publishing
-the alternate format yourself (using a tool like ROBOT) *or* you can
+the alternate format yourself (using a tool like ROBOT) _or_ you can
 have the OBO central build pipeline do this for you. For more
 information, see the FAQ entry [What is the Build field?](what-is-the-build-field.md).
-
-
-
-

--- a/id-policy.md
+++ b/id-policy.md
@@ -13,20 +13,20 @@ In the OWL language, all elements of an ontology (including classes/terms, and t
 
 For example:
 
-* <http://purl.obolibrary.org/obo/UBERON_0000955> UBERON class PURL for 'brain'
-* <http://purl.obolibrary.org/obo/obi.owl> ontology PURL for OBI
+- <http://purl.obolibrary.org/obo/UBERON_0000955> UBERON class PURL for 'brain'
+- <http://purl.obolibrary.org/obo/obi.owl> ontology PURL for OBI
 
 Note that legacy formats such as obo-format and many bioinformatics databases require the use of short-form identifiers (e.g. GO:0008150) to identify ontology terms. In this document we provide a well-defined mapping between these short prefixed identifiers and PURLs by considering the identifiers to be [CURIE](https://en.wikipedia.org/wiki/CURIE)s.
 
-This document addresses identifiers *only* for ontology terms, and not for Dbxrefs.
+This document addresses identifiers _only_ for ontology terms, and not for Dbxrefs.
 
 ## Design goals
 
- - There must be a predictable, bidirectional mapping between OBO IDs, and OBO Foundry-compliant URIs.
- - The URIs should resolve to useful information about a term.
- - The URIs should be designed so that they can be maintained over time to keep pointing to useful information.
- - Each OBO ID is assigned to a only single term within the set of all OBO ontologies.
- - There is a 1:1 mapping of OBO IDs to Foundry-compliant URIs.
+- There must be a predictable, bidirectional mapping between OBO IDs, and OBO Foundry-compliant URIs.
+- The URIs should resolve to useful information about a term.
+- The URIs should be designed so that they can be maintained over time to keep pointing to useful information.
+- Each OBO ID is assigned to a only single term within the set of all OBO ontologies.
+- There is a 1:1 mapping of OBO IDs to Foundry-compliant URIs.
 
 ### Format of OBO-format IDs
 
@@ -85,20 +85,20 @@ A request should include information about the ontology, such as scope and maint
 
 #### Guidelines for selecting an IDSPACE
 
-* Use three or more letters; the OBO Library **does not** accept new two-letter IDSPACEs
-* Avoid the letter "O" in three-letter IDSPACES; many ontologies use "O" for "Ontology" which limits the number of combinations
-* Select a longer IDSPACE for ontologies that are more restricted in scope (e.g., species-specific phenotype ontologies)
-* Search **each** of the following registries to make sure your IDSPACE doesn't conflict with one inside or outside of the OBO Library:
-<br>&emsp; - [OBO Foundry](https://obofoundry.org) 
-<br>&emsp; - [Bioregistry](https://bioregistry.io) (or [browse here](https://bioregistry.io/registry/))
-<br>&emsp; - [BioPortal](https://bioportal.bioontology.org/) (or [browse here](https://bioportal.bioontology.org/ontologies))
+- Use three or more letters; the OBO Library **does not** accept new two-letter IDSPACEs
+- Avoid the letter "O" in three-letter IDSPACES; many ontologies use "O" for "Ontology" which limits the number of combinations
+- Select a longer IDSPACE for ontologies that are more restricted in scope (e.g., species-specific phenotype ontologies)
+- Search **each** of the following registries to make sure your IDSPACE doesn't conflict with one inside or outside of the OBO Library:
+  <br>&emsp; - [OBO Foundry](https://obofoundry.org)
+  <br>&emsp; - [Bioregistry](https://bioregistry.io) (or [browse here](https://bioregistry.io/registry/))
+  <br>&emsp; - [BioPortal](https://bioportal.bioontology.org/) (or [browse here](https://bioportal.bioontology.org/ontologies))
 
 ### Current ontology document
 
 The most current version of an ontology will be at the following URL, where "idspace" is replaced with the IDSPACE of the given ontology in lower case.
 
-* Current OWL: http://purl.obolibrary.org/obo/idspace.owl
-* Current OBO: http://purl.obolibrary.org/obo/idspace.obo
+- Current OWL: http://purl.obolibrary.org/obo/idspace.owl
+- Current OBO: http://purl.obolibrary.org/obo/idspace.obo
 
 For example, the Ontology for Biomedical Investigations has the IDSPACE "OBI", so the current version of the OWL document would be at http://purl.obolibrary.org/obo/obi.owl
 
@@ -106,7 +106,7 @@ Additionally other ontology products can be included underneath this. For exampl
 
 ## Versions of ontologies
 
-Versions are named by a date in the following format: YYYY-MM-DD. For a given version of an ontology, the ontology should be accessible at the following URL, where *idspace*; is replaced by the IDSPACE in lower case:
+Versions are named by a date in the following format: YYYY-MM-DD. For a given version of an ontology, the ontology should be accessible at the following URL, where _idspace_; is replaced by the IDSPACE in lower case:
 
 - OWL: http://purl.obolibrary.org/obo/*idspace*/YYYY-MM-DD/*idspace*.owl
 - OBO: http://purl.obolibrary.org/obo/*idspace*/YYYY-MM-DD/*idspace*.obo

--- a/index.html
+++ b/index.html
@@ -2,33 +2,52 @@
 layout: default
 title: The OBO Foundry
 ---
+
 <div class="row">
-    <h1>The Open Biological and Biomedical Ontology (OBO) Foundry</h1>
-    <h3>Community development of interoperable ontologies for the biological sciences</h3>
-    <h4>Learn about OBO best practices and community resources</h4>
-    <ul>
-        <li><a href="about-OBO-Foundry.html">More about the OBO Foundry</a></li>
-        <li><a href="principles/fp-000-summary.html">OBO Foundry principles</a></li>
-        <li><a href="https://github.com/jamesaoverton/obo-tutorial">OBO tutorial</a></li>
-        <li><a href="resources">Ontology browsers, tutorials, and tools</a></li>
-    </ul>
+  <h1>The Open Biological and Biomedical Ontology (OBO) Foundry</h1>
+  <h3>
+    Community development of interoperable ontologies for the biological
+    sciences
+  </h3>
+  <h4>Learn about OBO best practices and community resources</h4>
+  <ul>
+    <li><a href="about-OBO-Foundry.html">More about the OBO Foundry</a></li>
+    <li><a href="principles/fp-000-summary.html">OBO Foundry principles</a></li>
+    <li>
+      <a href="https://github.com/jamesaoverton/obo-tutorial">OBO tutorial</a>
+    </li>
+    <li><a href="resources">Ontology browsers, tutorials, and tools</a></li>
+  </ul>
 
-    <h4>Participate</h4>
-    <ul>
-        <li><a href="https://groups.google.com/forum/#!forum/obo-discuss">Join the OBO mailing list</a></li>
-        <li><a href="docs/OperationsCommittee.html">OBO Foundry Operations and Working Groups</a></li>
-        <li><a href="https://github.com/OBOFoundry/OBOFoundry.github.io/issues">Submit bug reports or suggestions
-            for improvement via GitHub</a></li>
-        <li><a href="faq/how-do-i-register-my-ontology.html">Submit your ontology to be considered for inclusion in
-            the OBO Foundry</a></li>
-    </ul>
+  <h4>Participate</h4>
+  <ul>
+    <li>
+      <a href="https://groups.google.com/forum/#!forum/obo-discuss"
+        >Join the OBO mailing list</a
+      >
+    </li>
+    <li>
+      <a href="docs/OperationsCommittee.html"
+        >OBO Foundry Operations and Working Groups</a
+      >
+    </li>
+    <li>
+      <a href="https://github.com/OBOFoundry/OBOFoundry.github.io/issues"
+        >Submit bug reports or suggestions for improvement via GitHub</a
+      >
+    </li>
+    <li>
+      <a href="faq/how-do-i-register-my-ontology.html"
+        >Submit your ontology to be considered for inclusion in the OBO
+        Foundry</a
+      >
+    </li>
+  </ul>
 
-    <h4>OBO Library: find, use, and contribute to community ontologies</h4>
+  <h4>OBO Library: find, use, and contribute to community ontologies</h4>
 </div>
 
 <div class="row">
-    {% include table_widget.html %}
-    <noscript>
-        {% include ontology_table.html %}
-    </noscript>
+  {% include table_widget.html %}
+  <noscript> {% include ontology_table.html %} </noscript>
 </div>

--- a/post-templates/YYYY-MM-DD-announce-new-foundry-ontology.md
+++ b/post-templates/YYYY-MM-DD-announce-new-foundry-ontology.md
@@ -1,13 +1,13 @@
 ---
 layout: post
-title:  "$OntologyName is the newest member of the OBO Foundry"
-date:   YYYY-MM-DD
+title: "$OntologyName is the newest member of the OBO Foundry"
+date: YYYY-MM-DD
 categories: update
 summary: "The OBO Foundry Operations Committee is pleased to announce the inclusion of the $OntologyName ($IDSPACE) as a full member of the the OBO Foundry."
 image: "OPTIONAL-IMAGE-URL"
 tags:
- - announce
- - foundry
+  - announce
+  - foundry
 ---
 
 $IDSPACE was reviewed by the OBO Foundry Editorial Working Group and found to perform well when measured against accepted OBO Foundry Principles. Consequently, the Editorial WG recommended that $ID be given full member status as OBO Foundry Ontologies. This decision was ratified by the OBO Foundry Operations Committee.

--- a/principles/checks/fp_001.md
+++ b/principles/checks/fp_001.md
@@ -9,17 +9,21 @@ title: Open Automated Check
 Discussion on this check can be [found here](https://github.com/OBOFoundry/OBOFoundry.github.io/issues/1019).
 
 ### Requirements
+
 1. The ontology **must** have a license both in the registry data and in the ontology file.
 2. The license **must** be the same in both files.
-3. The license *should* be one of the CC0 or CC-BY licenses.
+3. The license _should_ be one of the CC0 or CC-BY licenses.
 
 ### Fixes
 
 #### Choosing a license
+
 See [Open Recommendations](http://obofoundry.org/principles/fp-001-open.html#recommendations) for appropriate licenses.
 
 #### Adding a license to the registry data
+
 First, read the [FAQ](http://obofoundry.github.io/faq/how-do-i-edit-metadata.html) on how to edit the metadata for your ontology. Then, add the following to your [metadata file](https://github.com/OBOFoundry/OBOFoundry.github.io/tree/master/ontology) (replacing with the correct license and license label):
+
 ```
 license:
  url: http://creativecommons.org/licenses/by/4.0/
@@ -27,9 +31,11 @@ license:
 ```
 
 #### Adding a license to the ontology file
+
 See [Open Implementation](http://obofoundry.org/principles/fp-001-open.html#implementation) for details on adding license to OWL and OBO files.
 
 ### Implementation
+
 The registry data entry is validated with JSON schema using the [license schema](https://raw.githubusercontent.com/OBOFoundry/OBOFoundry.github.io/master/util/schema/license.json). The license schema ensures that a license entry is present and that the entry has a `url` and `label`. The license schema also checks that the license is one of the CC0 or CC-BY licenses. OWL API is then used to check the ontology as an `OWLOntology` object. Annotations on the ontology are retrieved and the `dcterms:license` property is found. The python script ensures that the correct `dcterms:license` property is used. The script compares this license to the registry license to ensure that they are the same.
 
 ```python

--- a/principles/checks/fp_002.md
+++ b/principles/checks/fp_002.md
@@ -9,12 +9,15 @@ title: Common Format Automated Check
 Discussion on this check can be [found here](https://github.com/OBOFoundry/OBOFoundry.github.io/issues/1018).
 
 ### Requirements
+
 1. Released ontology **must** be in RDF/XML format
 
 ### Fixes
+
 See the [Common Format Recommendations](http://obofoundry.org/principles/fp-002-format.html#recommendations). [ROBOT](http://robot.obolibrary.org/convert) offers functionality to convert a variety of formats, including OBO, to RDF/XML. Protégé allows you to save ontologies in RDF/XML, as well. The [Ontology 101 Tutorial](https://ontology101tutorial.readthedocs.io/en/latest/StartingProtege.html) has directions on starting and saving in Protégé.
 
 ### Implementation
+
 Current implementation attempts to load the ontology using OWL API. If the ontology is loaded, it is assumed that it is in a good format, although it may not be RDF/XML. For large ontologies, the ontology is a valid format (either RDF/XML or Turtle) if it can be [loaded with Jena](http://robot.obolibrary.org/query#executing-on-disk) to run the ROBOT report over.
 
 ```python

--- a/principles/checks/fp_003.md
+++ b/principles/checks/fp_003.md
@@ -9,23 +9,27 @@ title: URI Automated Check
 Discussion on this check can be [found here](https://github.com/OBOFoundry/OBOFoundry.github.io/issues/1017).
 
 ### Requirements
+
 1. All entities in the ontology namespace **must** use an underscore to separate the namespace and local ID.
-2. The local ID *should* not be semantically significant, and *should* be numeric.
+2. The local ID _should_ not be semantically significant, and _should_ be numeric.
 
 ### Fixes
+
 Edit problematic IRIs to resolve the problems. [Click here](https://ontology101tutorial.readthedocs.io/en/latest/EntitiesTab.html#renaming-an-entity) for details on editing an IRI in Protégé.
 
 The full OBO Foundry ID Policy can be found [here](http://www.obofoundry.org/id-policy). In short, all IRIs should begin with your unique OBO Foundry namespace (e.g., `http://purl.obolibrary.org/obo/OBI_`). The local ID, which comes after the unique namespace, should be numeric (e.g., `http://purl.obolibrary.org/obo/OBI_0000001`). We recommend using seven digits.
 
 #### Updating an IRI
+
 1. Add an `owl:deprecated` annotation with a boolean value of `true` to the problematic term
 2. Add `obsolete` to the beginning of the term's label to prevent duplicating labels
 3. Create a new term with a valid IRI to replace this old term
 4. Copy the old annotations (label, definition, etc., excluding the `owl:deprecated`) over to the new term
 5. Add a [`IAO:0100001` (term replaced by)](http://purl.obolibrary.org/obo/IAO_0100001) annotation to the old term with a value of the new term's IRI
-   * Make sure this is an IRI annotation by selecting "IRI Editor" when adding the annotation in Protégé
+   - Make sure this is an IRI annotation by selecting "IRI Editor" when adding the annotation in Protégé
 
 ### Implementation
+
 All entity IRIs are retrieved from the ontology, excluding annotation properties. Annotation properties may use hashtags and words due to legacy OBO conversions for subset properties. All other IRIs are checked if they are in the ontology's namespace. If the IRI begins with the ontology namespace, the next character must be an underscore. If not, this is an error. The IRI is also compared to a regex pattern to check if the local ID after the underscore is numeric. If not, this is a warning.
 
 ```python

--- a/principles/checks/fp_004.md
+++ b/principles/checks/fp_004.md
@@ -9,21 +9,26 @@ title: Versioning Automated Check
 Discussion on this check can be [found here](https://github.com/OBOFoundry/OBOFoundry.github.io/issues/1016).
 
 ### Requirements
+
 1. The released ontology **must** have a version IRI.
-2. The version IRI *should* follow a dated format (`NS/YYYY-MM-DD/ontology.owl`)
+2. The version IRI _should_ follow a dated format (`NS/YYYY-MM-DD/ontology.owl`)
 
 ### Fixes
+
 First, make sure you have a valid version IRI pattern. See [Versioning Implementation](http://obofoundry.org/principles/fp-004-versioning.html#implementation) for more details.
 
 #### Adding a Version IRI in Protégé
+
 The "Ontology Version IRI" input is located in the "Active Ontology" tab that appears when you open your ontology in Protégé.
 
 #### Adding a Version IRI with ROBOT
+
 You may use the [ROBOT annotate](http://robot.obolibrary.org/annotate) command the add a version IRI.
 
 Please be aware that the [Ontology Development Kit](https://github.com/INCATools/ontology-development-kit) comes standard with a release process that will automatically generate a dated version IRI for your ontology release.
 
 ### Implementation
+
 The version IRI is retrieved from the ontology using OWL API. For very large ontologies, the RDF/XML ontology header is parsed to find the owl:versionIRI declaration. If found, the IRI is compared to a regex pattern to determine if it is in date format. If it is not in date format, a warning is issued. If the version IRI is not present, this is an error.
 
 ```python

--- a/principles/checks/fp_005.md
+++ b/principles/checks/fp_005.md
@@ -9,15 +9,19 @@ title: Scope Automated Check
 Discussion on this check can be [found here](https://github.com/OBOFoundry/OBOFoundry.github.io/issues/1015).
 
 ### Requirements
+
 1. A scope ('domain') **must** be declared in the registry data
 
 ### Fixes
+
 First, read the [FAQ](http://obofoundry.github.io/faq/how-do-i-edit-metadata.html) on how to edit the metadata for your ontology. Then, add the following to your [metadata file](https://github.com/OBOFoundry/OBOFoundry.github.io/tree/master/ontology) (replacing with your domain):
+
 ```
 domain: experiments
 ```
 
 ### Implementation
+
 First, the registry data is checked for a 'domain' tag. If missing, that is an error. If it is present, the domain is compared to all other ontology domains. If the ontology shares a domain with one or more other ontologies, we return a list of those ontologies in an info message.
 
 ```python

--- a/principles/checks/fp_006.md
+++ b/principles/checks/fp_006.md
@@ -9,24 +9,29 @@ title: Textual Definitions Automated Check
 Discussion on this check can be [found here](https://github.com/OBOFoundry/OBOFoundry.github.io/issues/1010).
 
 ### Requirements
+
 1. Each definition **must** be unique.
 2. Each entity **must** not have more than one textual definition.
-3. Each entity *should* have a textual definition using [`IAO:0000115` (definition)](http://purl.obolibrary.org/obo/IAO_0000115).
+3. Each entity _should_ have a textual definition using [`IAO:0000115` (definition)](http://purl.obolibrary.org/obo/IAO_0000115).
 
 ### Fixes
 
 #### Uniqueness
+
 Update each duplicate definition to have some detail that differentiates one term from another.
 
 #### Multiples
+
 If a term has more than one defintion, combine the two definitions. Alternatively, change one definition to an `rdfs:comment` if it just contains further details.
 
 #### Missing Definitions
+
 Add an [`IAO:0000115` (definition)](http://purl.obolibrary.org/obo/IAO_0000115) annotation to each term that is missing a definition. For help writing good definitions, see [Textual Definitions Recommendations](http://obofoundry.org/principles/fp-006-textual-definitions.html#recommendation).
 
 For adding defintions in bulk, check out [ROBOT template](http://robot.obolibrary.org/template).
 
 ### Implementation
+
 [ROBOT report](http://robot.obolibrary.org/report) is run over the ontology. A count of violations for each of the following checks is retrieved from the report object: [duplicate definition](http://robot.obolibrary.org/report_queries/duplicate_definition), [multiple definitions](http://robot.obolibrary.org/report_queries/multiple_definitions), and [missing definition](http://robot.obolibrary.org/report_queries/missing_definition). If there are any duplicate or multiple defintions, it is an error. If there are missing definitions, it is a warning.
 
 ```python

--- a/principles/checks/fp_007.md
+++ b/principles/checks/fp_007.md
@@ -9,20 +9,24 @@ title: Relations Automated Check
 Discussion on this check can be [found here](https://github.com/OBOFoundry/OBOFoundry.github.io/issues/981).
 
 ### Requirements
+
 1. The ontology **must not** duplicate existing RO properties.
-2. The ontology *should* use existing RO properties, rather than creating new properties.
+2. The ontology _should_ use existing RO properties, rather than creating new properties.
 
 ### Fixes
 
 #### Duplicated Properties
+
 1. Add an `owl:deprecated` annotation with a boolean value of `true` to the problematic property in your ontology
 2. Add `obsolete` to the beginning of the property's label
 3. Replace all usages of that property with the duplicated RO property
 
 #### Non-RO Properties
+
 Review your non-RO properties to see if any can be replaced with an RO property using the steps above. Often, a corresponding property will not exist in RO and that is OK.
 
 ### Implementation
+
 The object and data properties from the ontology are compared to existing RO properties. If any labels match existing RO properties, but do not use the correct RO IRI, this is an error. Any non-RO properties (no label match and do not use an RO IRI) will be listed as INFO messages.
 
 ```python

--- a/principles/checks/fp_008.md
+++ b/principles/checks/fp_008.md
@@ -9,27 +9,35 @@ title: Documentation Automated Check
 Discussion on this check can be [found here](https://github.com/OBOFoundry/OBOFoundry.github.io/issues/1009).
 
 ### Requirements
+
 1. The ontology **must** have a homepage.
 2. The homepage URL **must** resolve.
 3. The ontology **must** have a description.
 
 ### Fixes
+
 First, read the [FAQ](http://obofoundry.github.io/faq/how-do-i-edit-metadata.html) on how to edit the metadata for your ontology.
 
 #### Adding or Updating a Homepage
+
 Add the following to your [metadata file](https://github.com/OBOFoundry/OBOFoundry.github.io/tree/master/ontology) (replacing with your homepage, which may just be your GitHub repository):
+
 ```
 homepage: http://obi-ontology.org
 ```
+
 If your homepage is not resolving, determine why (Is the server down? Is the URL wrong?) and update your homepage URL if needed.
 
 #### Adding a Description
+
 Add the following to your [metadata file](https://github.com/OBOFoundry/OBOFoundry.github.io/tree/master/ontology) (replacing with a short description about your ontology):
+
 ```
 description: An integrated ontology for the description of life-science and clinical investigations
 ```
 
 ### Implementation
+
 The registry data is checked for 'homepage' and 'description' entries. If either is missing, this is an error. If the homepage is present, the URL is checked to see if it resolves (does not return an HTTP status of greater than 400). If the URL does not resolve, this is also an error.
 
 ```python

--- a/principles/checks/fp_009.md
+++ b/principles/checks/fp_009.md
@@ -9,13 +9,17 @@ title: Documented Plurality of Users Automated Check
 Discussion on this check can be [found here](https://github.com/OBOFoundry/OBOFoundry.github.io/issues/1008).
 
 ### Requirements
+
 1. The ontology **must** have usages.
 
 ### Fixes
+
 First, read the [FAQ](http://obofoundry.github.io/faq/how-do-i-edit-metadata.html) on how to edit the metadata for your ontology.
 
 #### Adding Usages
+
 Determine what other groups are using your ontology and how they are using it. Then, add the following to your [metadata file](https://github.com/OBOFoundry/OBOFoundry.github.io/tree/master/ontology) (replacing with the correct group name, link, and description):
+
 ```
 usages:
 - user: http://www.informatics.jax.org/disease (link to group)
@@ -24,9 +28,11 @@ usages:
    - url: http://www.informatics.jax.org/disease/DOID:4123 (link to specific example)
      description: Human genes and mouse homology associated with nail diseases (description of specific example)
 ```
+
 You may have multiple exampels for each user, and mulitple users under the `usages` tag.
 
 ### Implementation
+
 The registry data is checked for 'usage' entries. If they are missing, this is an error.
 
 ```python

--- a/principles/checks/fp_011.md
+++ b/principles/checks/fp_011.md
@@ -9,12 +9,15 @@ title: Locus of Authority Automated Check
 Discussion on this check can be [found here](https://github.com/OBOFoundry/OBOFoundry.github.io/issues/1007).
 
 ### Requirements
+
 1. The ontology **must** have a single contact person
 
 ### Fixes
+
 First, read the [FAQ](http://obofoundry.github.io/faq/how-do-i-edit-metadata.html) on how to edit the metadata for your ontology.
 
-Next, determine who the point person for your ontology project is. This *must not* be a mailing list. If this person does not already have a GitHub account, we request that they [create one](https://github.com/join). Then, add the following to your [metadata file](https://github.com/OBOFoundry/OBOFoundry.github.io/tree/master/ontology) (replacing with the correct email, name, and GitHub username):
+Next, determine who the point person for your ontology project is. This _must not_ be a mailing list. If this person does not already have a GitHub account, we request that they [create one](https://github.com/join). Then, add the following to your [metadata file](https://github.com/OBOFoundry/OBOFoundry.github.io/tree/master/ontology) (replacing with the correct email, name, and GitHub username):
+
 ```
 contact:
  email: foo@bar.com
@@ -23,6 +26,7 @@ contact:
 ```
 
 ### Implementation
+
 The registry data entry is validated with JSON schema using the [contact schema](https://raw.githubusercontent.com/OBOFoundry/OBOFoundry.github.io/master/util/schema/contact.json). The contact schema ensures that a contact entry is present and that the entry has a name and email address.
 
 ```python

--- a/principles/checks/fp_012.md
+++ b/principles/checks/fp_012.md
@@ -9,28 +9,34 @@ title: Naming Conventions Automated Check
 Discussion on this check can be [found here](https://github.com/OBOFoundry/OBOFoundry.github.io/issues/1006).
 
 ### Requirements
+
 1. Each label **must** be unique.
 2. Each entity **must** not have more than one label.
-3. Each entity *should* have a label using `rdfs:label`.
+3. Each entity _should_ have a label using `rdfs:label`.
 
 ### Fixes
 
 #### Uniqueness
+
 Update at least one label to distinguish between the two terms. Add the original label to a `oboInOwl:hasExactSynonym` (alternatively, narrow, related, or broad) or [`IAO:0000118` (alternative term)](http://purl.obolibrary.org/obo/IAO_0000118) annotation.
 
 If the terms are exactly the same:
+
 1. Obsolete one of them by adding the `owl:deprecated` annotation property with a boolean value of `true`
 2. Add `obsolete` to the beginning of this term's label
 3. Add a [`IAO:0100001` (term replaced by)](http://purl.obolibrary.org/obo/IAO_0100001) annotation to this term pointing to the other, non-deprecated term.
-   * Make sure this is an IRI annotation by selecting "IRI Editor" when adding the annotation in Protégé
+   - Make sure this is an IRI annotation by selecting "IRI Editor" when adding the annotation in Protégé
 
 #### Multiple Labels
+
 Determine which label most accurately describes the term. Change the other label(s) to `oboInOwl:hasExactSynonym` (alternatively, narrow, related, or broad) or [`IAO:0000118` (alternative term)](http://purl.obolibrary.org/obo/IAO_0000118).
 
 #### Missing Labels
+
 Add an `rdfs:label` annotation to each term that is missing a label. For adding labels in bulk, check out [ROBOT template](http://robot.obolibrary.org/template).
 
 ### Implementation
+
 [ROBOT report](http://robot.obolibrary.org/report) is run over the ontology. A count of violations for each of the following checks is retrieved from the report object: [duplicate label](http://robot.obolibrary.org/report_queries/duplicate_label), [multiple labels](http://robot.obolibrary.org/report_queries/multiple_labels), and [missing label](http://robot.obolibrary.org/report_queries/missing_label). If there are any of these violations, it is an error.
 
 ```python

--- a/principles/checks/fp_016.md
+++ b/principles/checks/fp_016.md
@@ -9,12 +9,15 @@ title: Maintenance Automated Check
 Discussion on this check can be [found here](https://github.com/OBOFoundry/OBOFoundry.github.io/issues/1020).
 
 ### Requirements
-1. The ontology *should* be regularly updated.
+
+1. The ontology _should_ be regularly updated.
 
 ### Fixes
+
 Make sure all content in your ontology is up-to-date with scientific literature. If you make regular changes, make sure to have regular releases.
 
 ### Implementation
+
 A version IRI is retrieved from the ontology, either using OWL API or parsing RDF/XML for large ontologies. This version IRI is checked against a regex pattern to determine if it is in date format. If so, the date is retrieved. If the last version IRI date is older than three years, this is an error. If it is older than two years, this is a warning. If it is older than one year, this will be an info message.
 
 ```python

--- a/principles/checks/fp_020.md
+++ b/principles/checks/fp_020.md
@@ -9,20 +9,25 @@ title: Responsiveness Automated Check
 Discussion on this check can be [found here](https://github.com/OBOFoundry/OBOFoundry.github.io/issues/959).
 
 ### Requirements
+
 1. The ontology **must** have a tracker.
 
 ### Fixes
+
 First, read the [FAQ](http://obofoundry.github.io/faq/how-do-i-edit-metadata.html) on how to edit the metadata for your ontology.
 
 #### Adding a Tracker
+
 If you do not already have a version control repository that has an [Issues Tracker](https://help.github.com/en/github/managing-your-work-on-github/about-issues), create one. We recommend creating a [GitHub Repository](https://help.github.com/en/github/getting-started-with-github/create-a-repo). To do this, you will need to [create a GitHub account](https://github.com/join) if you do not already have one.
 
 Once you have a version control repository, add the following to your [metadata file](https://github.com/OBOFoundry/OBOFoundry.github.io/tree/master/ontology) (replacing with the link to your repository's issue tracker):
+
 ```
 tracker: https://github.com/DiseaseOntology/HumanDiseaseOntology/issues
 ```
 
 ### Implementation
+
 The registry data is checked for 'tracker' entry. If it is missing, this is an error.
 
 ```python
@@ -47,6 +52,6 @@ def is_responsive(data):
 
     if tracker is None:
         return {'status': 'ERROR', 'comment': 'Missing tracker'}
-    
+
     return {'status': 'PASS'}
 ```

--- a/principles/fp-000-summary.md
+++ b/principles/fp-000-summary.md
@@ -4,12 +4,12 @@ id: fp-000-summary
 title: Overview
 ---
 
-These principles are intended as normative for OBO Foundry ontologies, and ontologies submitted for review will be evaluated according to them. We consider these to be generally good practice, and recommend they be considered even if there are no plans to submit an ontology for review by the Foundry. Where we use capitalized words such as "MUST", and "SHOULD", they will be interpreted according to [RFC 2119: Key words for use in RFCs to Indicate Requirement Levels](https://www.ietf.org/rfc/rfc2119.html) when the principles are applied during reviews of ontologies for inclusion in the Foundry. 
+These principles are intended as normative for OBO Foundry ontologies, and ontologies submitted for review will be evaluated according to them. We consider these to be generally good practice, and recommend they be considered even if there are no plans to submit an ontology for review by the Foundry. Where we use capitalized words such as "MUST", and "SHOULD", they will be interpreted according to [RFC 2119: Key words for use in RFCs to Indicate Requirement Levels](https://www.ietf.org/rfc/rfc2119.html) when the principles are applied during reviews of ontologies for inclusion in the Foundry.
 
 There is currently an ongoing process to clarify the wording of the principles and expand on their purpose, implementation, and criteria to be used to evaluate ontologies for compliance with each principle. Please use the [issue tracker](https://github.com/OBOFoundry/OBOFoundry.github.io/issues) to let us know if there are further clarifications that you would like to see addressed for any of the principles.
 
-Quick Summary
--------------
+## Quick Summary
+
 The following summarizes each principle. See individual pages for details.
 
 P1) <b>Open</b> - The ontology MUST be openly available to be used by all without any constraint other than (a) its origin must be acknowledged and (b) it is not to be altered and subsequently redistributed in altered form under the original name or with the same identifiers.

--- a/principles/fp-001-open.md
+++ b/principles/fp-001-open.md
@@ -37,8 +37,9 @@ Note: CC-BY licenses allow others to distribute, remix, tweak, and build upon th
 #### `.owl` files
 
 1. OBO Foundry Ontologies MUST specify the reuse constraints using the following annotations in any publically released OWL version of the ontology:
-    1. dcterms:license - specifies the license - see Example 1 (below)
-    2. rdfs:comment - specifies terms of reuse - see Example 1 (below)
+
+   1. dcterms:license - specifies the license - see Example 1 (below)
+   2. rdfs:comment - specifies terms of reuse - see Example 1 (below)
 
 2. OBO Foundry Ontologies that host terms developed by an external group (but which are not part of an existing ontology) must credit the external group - see Examples (below)
 
@@ -47,8 +48,8 @@ Note: CC-BY licenses allow others to distribute, remix, tweak, and build upon th
 #### `.obo` files
 
 1. OBO Foundry Ontologies must specify the reuse constraints using the following annotations in any publically released OBO version of the ontology:
-    1. the license in a separate property annotation, which can be converted to a dc:license statement if the ontology is converted to OWL - see Example 2 (below)
-    2. the reuse constraints using a comment in the official OBO version of the ontology - see Example 2 (below)
+   1. the license in a separate property annotation, which can be converted to a dc:license statement if the ontology is converted to OWL - see Example 2 (below)
+   2. the reuse constraints using a comment in the official OBO version of the ontology - see Example 2 (below)
 
 ### For ontology re-use
 
@@ -57,13 +58,14 @@ Note: CC-BY licenses allow others to distribute, remix, tweak, and build upon th
 The attribution method for individual terms reused in another ontology (e.g., by MIREOT) is via use of their original IRI or ID - see Examples (below).
 
 1. **In OWL** - Any ontology re-using individual terms from another ontology should:
-    1. re-use the original term IRI (which for OBO Foundry ontologies is generally in the form of an OBO Foundry PURL)
-    2. use an IAO:imported from annotation <http://purl.obolibrary.org/obo/IAO_0000412> on each imported term to link back to the group (i.e. ontology) maintaining it, where more information would be available about the license
-    3. include any annotations for term or definition editors from the original ontology
+
+   1. re-use the original term IRI (which for OBO Foundry ontologies is generally in the form of an OBO Foundry PURL)
+   2. use an IAO:imported from annotation <http://purl.obolibrary.org/obo/IAO_0000412> on each imported term to link back to the group (i.e. ontology) maintaining it, where more information would be available about the license
+   3. include any annotations for term or definition editors from the original ontology
 
 2. **In OBO** - Any ontology re-using individual terms from another ontology should:
-    1. re-use the original term ID (of the form <GO:0000001>)
-    2. include any XREFs to the original term editor(s) from the original ontology
+   1. re-use the original term ID (of the form <GO:0000001>)
+   2. include any XREFs to the original term editor(s) from the original ontology
 
 #### Full ontologies
 
@@ -164,5 +166,3 @@ To suggest revisions or begin a discussion pertaining to this principle, please 
 To suggest revisions or begin a discussion pertaining to the automated validation of this principle, please [create an issue on GitHub](https://github.com/OBOFoundry/OBOFoundry.github.io/issues/new?labels=attn%3A+Technical+WG,automated+validation+of+principles&title=Principle+%231+%22Open%22+-+automated+validation+%3CENTER+ISSUE+TITLE%3E).
 
 See also [this discussion of licensing](https://github.com/OBOFoundry/Operations-Committee/issues/103) by the OBO Foundry Operations Committee focusing on Creative Commons licenses.
-
-

--- a/principles/fp-002-format.md
+++ b/principles/fp-002-format.md
@@ -45,4 +45,3 @@ The ontology MUST be available in RDF/XML format.
 To suggest revisions or begin a discussion pertaining to this principle, please [create an issue on GitHub](https://github.com/OBOFoundry/OBOFoundry.github.io/issues/new?labels=attn%3A+Editorial+WG,principles&title=Principle+%232+%22Format%22+%3CENTER+ISSUE+TITLE%3E).
 
 To suggest revisions or begin a discussion pertaining to the automated validation of this principle, please [create an issue on GitHub](https://github.com/OBOFoundry/OBOFoundry.github.io/issues/new?labels=attn%3A+Technical+WG,automated+validation+of+principles&title=Principle+%232+%22Format%22+-+automated+validation+%3CENTER+ISSUE+TITLE%3E).
-

--- a/principles/fp-003-uris.md
+++ b/principles/fp-003-uris.md
@@ -4,23 +4,19 @@ id: fp-003-uris
 title: URI/Identifier Space (principle 3)
 ---
 
-Summary
--------
+## Summary
 
 Each ontology MUST have a unique IRI in the form of an OBO Foundry persistent URL (PURL) that includes the ontology's short namespace.
 
-Purpose
--------
+## Purpose
 
 A unique namespace within the OBO Foundry Library allows the source of an element or term (e.g., class, property) from any ontology to be identified immediately by the prefix of the identifier. It also allows ontology element IRIs to be shortened to a compact URI or CURIE, which allows developers to use CURIES for working with ontologies. OWL syntax allows for ontologies and their elements to have identifiers in the form of an IRI. The OBO Foundry uses IRIs in the form of PURLs to allow an ontology and its elements to be resolvable (findable on the web). PURLs are URLs (and thus locate the resource) that are permanent or redirectable, allowing the URL to point to a new location when the resource moves. OBO Foundry PURLs use a standard format that includes the ontology namespace so that they can be easily maintained by a group of volunteers, and so ontology maintainers can update the location their PURL points to using a GitHub pull request.
 
-Recommendations and Requirements
--------
+## Recommendations and Requirements
 
 Each ontology MUST have a unique IRI in the form of an OBO Foundry permanent URL (PURL). The PURL must include the ontology namespace, which is abbreviated by a short set of letters approved by the OBO Foundry Operations Committee. Every element (class, property, etc.) created by the ontology MUST use the namespace in the identifier of each element, as specified in the OBO Foundry [ID policy](http://www.obofoundry.org/id-policy).
 
-Implementation
--------
+## Implementation
 
 ### Ontology Namespace:
 
@@ -39,14 +35,12 @@ Note: To conform with OBO Foundry [Principle 2](https://obofoundry.org/principle
 
 For guidelines on how to create IRIs for ontology elements/terms, see the OBO Foundry [ID policy](http://www.obofoundry.org/id-policy).
 
-Examples
---------
+## Examples
 
 http://purl.obolibrary.org/obo/go.owl
 http://purl.obolibrary.org/obo/pco.owl
 
-Counter Examples
---------
+## Counter Examples
 
 The following counter examples are valid ontology IRIs, but do not conform with OBO Foundry principles.
 
@@ -58,18 +52,14 @@ http://purl.org/dc/terms/
 
 http://dbpedia.org/ontology/
 
-Criteria for Review
--------
+## Criteria for Review
 
 The ontology namespace MUST be registered following the procedures outlined within the [OBO Foundry membership requirements and technical details](http://www.obofoundry.org/docs/Policy_for_OBO_namespace_and_associated_PURL_requests.html) document. In addition, the ontology IRI MUST follow the format given above.
 
 [This check is automatically validated.](checks/fp_003) The automatic check fully covers the requirements for this principle.
-
 
 ## Feedback and Discussion
 
 To suggest revisions or begin a discussion pertaining to this principle, please [create an issue on GitHub](https://github.com/OBOFoundry/OBOFoundry.github.io/issues/new?labels=attn%3A+Editorial+WG,principles&title=Principle+%233+%22URIs%22+%3CENTER+ISSUE+TITLE%3E).
 
 To suggest revisions or begin a discussion pertaining to the automated validation of this principle, please [create an issue on GitHub](https://github.com/OBOFoundry/OBOFoundry.github.io/issues/new?labels=attn%3A+Technical+WG,automated+validation+of+principles&title=Principle+%233+%22URIs%22+-+automated+validation+%3CENTER+ISSUE+TITLE%3E).
-
-

--- a/principles/fp-004-versioning.md
+++ b/principles/fp-004-versioning.md
@@ -4,18 +4,15 @@ id: fp-004-versioning
 title: Versioning (principle 4)
 ---
 
-Summary
--------
+## Summary
 
 The ontology provider has documented procedures for versioning the ontology, and different versions of ontology are marked, stored, and officially released.
 
-Purpose
--------------
+## Purpose
 
 OBO projects share their ontologies using files in OWL or OBO format (see [Principle 2](https://obofoundry.org/principles/fp-002-format.html)). Ontologies are expected to change over time as they are developed and refined (see [Principle 16](https://obofoundry.org/principles/fp-016-maintenance.html)). This will lead to a series of different files. Consumers of ontologies must be able to specify exactly which ontology files they used to encode their data or build their applications, and be able to retrieve unaltered copies of those files in perpetuity. Note that this applies only to those versions which have been officially released.
 
-Recommendations and Requirements
--------
+## Recommendations and Requirements
 
 In addition to an IRI specifying the current release (see [Principle 3](https://obofoundry.org/principles/fp-003-uris.html)), each official release MUST have a unique version IRI that resolves to the specific ontology artifact indicated. Consumers can then use the version IRI to uniquely identify which official release of the ontology they used, and to retrieve unaltered copies of the file(s). A _version IRI_ is a full path that MUST resolve to the particular version of the ontology artifact. Both the version IRI and the corresponding artifact MUST contain an identical _version identifier_ string.
 
@@ -27,14 +24,13 @@ All OBO projects MUST also have versioned PURLs that resolve to the correspondin
 
 Note that the content of official release files MUST NOT be changed. For example, if a bug is found in some official released file for some ontology, the bug MUST NOT be fixed by changing the file(s) for that official release. Instead the bug fixes should be included in a new official release, with new files, and consumers can switch to the new release.
 
-Additionally, each ontology SHOULD have an owl:versionInfo statement. When this is stated, it MUST correspond to the version Info. 
+Additionally, each ontology SHOULD have an owl:versionInfo statement. When this is stated, it MUST correspond to the version Info.
 
-Implementation
--------
+## Implementation
 
 See examples (below) for guidelines on how to specify the version within the ontology itself. If terms are imported from an external ontology, the “IAO:imported from” annotation (see [Principle 1](http://obofoundry.org/principles/fp-001-open.html)) may specify a dated version of the ontology from which they are imported.
 
-Regardless of the versioning system used for the ontology artifact, the version IRI SHOULD use an ISO-8601 dated PURL. In cases where there are multiple releases on the same day, the PURL points to the newest, and the previous release stays in the same folder or a subfolder, named in such a way as to distinguish the releases. Specifications for version IRIs are fully described in the OBO Foundry [ID policy](http://obofoundry.org/id-policy) document. In short: 
+Regardless of the versioning system used for the ontology artifact, the version IRI SHOULD use an ISO-8601 dated PURL. In cases where there are multiple releases on the same day, the PURL points to the newest, and the previous release stays in the same folder or a subfolder, named in such a way as to distinguish the releases. Specifications for version IRIs are fully described in the OBO Foundry [ID policy](http://obofoundry.org/id-policy) document. In short:
 
 For a given version of an ontology, the ontology should be accessible at the following URL, where 'idspace' is replaced by the IDSPACE in lower case:
 
@@ -47,10 +43,8 @@ An accepted alternative to the above scheme is to include /releases/ in the PURL
 
     OWL: http://purl.obolibrary.org/obo/idspace/releases/YYYY-MM-DD/idspace.owl
     OBO: http://purl.obolibrary.org/obo/idspace/releases/YYYY-MM-DD/idspace.obo
-    
 
-Examples
---------
+## Examples
 
 For an OBO format ontology use the metadata tag:
 
@@ -64,8 +58,8 @@ For an OWL format ontology, owl:versionInfo identifies the version and versionIR
 
 CHEBI is an example of an OBO ontology that uses a non-date based system system for version identifier. An example versionIRI for CHEBI is http://purl.obolibrary.org/obo/chebi/187/chebi.owl. This corresponds to a value of `187` for `data-version` in OBO format.
 
-Criteria for Review
---------
+## Criteria for Review
+
 The released ontology MUST have a version IRI. The version IRI MUST use a date format (NS/YYYY-MM-DD/ontology.owl) OR use a semantic versioning format (e.g., NS/NN.n/ontology.owl). The version IRI MUST resolve to an ontology artifact that is associated with the same version identifier as used in the version IRI.
 
 [This check is automatically validated.](checks/fp_004)

--- a/principles/fp-005-delineated-content.md
+++ b/principles/fp-005-delineated-content.md
@@ -4,40 +4,38 @@ id: fp-005-delineated-content
 title: Scope (principle 5)
 ---
 
+## NOTE
 
-NOTE
--------
 The wording of this principle is still in progress, with some issues still to be addressed (see Issues To Be Addressed below).
 
-Summary
--------
+## Summary
+
 The scope of an ontology is the extent of the domain or subject matter it intends to cover. The ontology must have a clearly specified scope and content that adheres to that scope.
 
-Purpose
--------
+## Purpose
+
 An in-scope ontology prevents overlaps between ontologies (duplication of terms), facilitates user searches for specific content, and enables quick selection of ontologies of interest, yet still allows for new terms to be created via combination of existing terms (cross-products).
 
-Recommendations and Requirements
--------
+## Recommendations and Requirements
+
 Ideally the scope should be fairly narrow. Required terms that are out of scope should be imported from the appropriate ontology.
 
-Implementation
--------
+## Implementation
+
 The domain (scope) covered by the ontology should be clearly stated. The statement should be brief and free of jargon; a few sentences should suffice. The content of the ontology should stay within the confines of the stated scope.
 
-Examples
---------
+## Examples
 
-Counter-Examples
-----------------
+## Counter-Examples
 
-Issues To Be Addressed (partial list):
--------
+## Issues To Be Addressed (partial list):
+
 1.Would like a metadata tag in the ontology itself for this. TBD.
 
 2.Possible need for controlled vocabulary for scope/domain (for example: Anatomy, Upper Level Ontology, Disease, Phenotype, Applicable taxonomy)
 
 ## Criteria for Review
+
 A scope (‘domain’) MUST be declared in the registry data, and terms from the ontology have to fall within that scope.
 
 [This check is automatically validated.](checks/fp_005)
@@ -47,5 +45,3 @@ A scope (‘domain’) MUST be declared in the registry data, and terms from the
 To suggest revisions or begin a discussion pertaining to this principle, please [create an issue on GitHub](https://github.com/OBOFoundry/OBOFoundry.github.io/issues/new?labels=attn%3A+Editorial+WG,principles&title=Principle+%235+%22Scope%22+%3CENTER+ISSUE+TITLE%3E).
 
 To suggest revisions or begin a discussion pertaining to the automated validation of this principle, please [create an issue on GitHub](https://github.com/OBOFoundry/OBOFoundry.github.io/issues/new?labels=attn%3A+Technical+WG,automated+validation+of+principles&title=Principle+%235+%22Scope%22+-+automated+validation+%3CENTER+ISSUE+TITLE%3E).
-
-

--- a/principles/fp-006-textual-definitions.md
+++ b/principles/fp-006-textual-definitions.md
@@ -4,24 +4,22 @@ id: fp-006-textual-definitions
 title: Textual Definitions (principle 6)
 ---
 
-Summary
--------
+## Summary
 
 The ontology has textual definitions for the majority of its classes and for top level terms in particular.
 
-Purpose
--------
+## Purpose
 
 A textual definition provides a human-readable understanding about what is a member of the associated class. Textual definitions are, optimally, in concordance with associated machine-readable logical definitions (the latter of which are OPTIONAL).
 
-Recommendations and Requirements
---------------
+## Recommendations and Requirements
 
 Textual definitions MUST be unique within an ontology (i.e. no two terms should share a definition). Textual definitions SHOULD follow Aristotelian form (e.g. “a B that Cs” where B is the parent and C is the differentia), where this is practical.
 
 For terms lacking textual definitions, there should be evidence of implementation of a strategy to provide definitions for all remaining undefined terms. In lieu of textual definitions, there can be elucidations when the term can not be rigorously defined. Note that textual definitions can be programmatically generated from logical definitions, if available (see [http://oro.open.ac.uk/21501/1/](http://oro.open.ac.uk/21501/1/)). In addition, [Dead Simple Ontology Design Patterns](https://github.com/INCATools/dead_simple_owl_design_patterns) (DOSDPs) can be used to generate both textual and logical definitions. DOSDPs are design specifications, written in YAML format, that specify structured text definitions and logical definitions for groups of ontology terms. These are widely used in many OBO Foundry ontologies, such as Mondo and uPheno. For some example patterns, see [Mondo patterns](https://mondo.readthedocs.io/en/latest/editors-guide/patterns/) and [uPheno patterns](https://github.com/obophenotype/upheno/tree/master/src/patterns/dosdp-patterns).
 
 Textual definitions should agree with logical definitions and vice versa. This is important for two reasons: (1) Reasoners classify terms solely based on logical definitions, while humans predominantly classify terms based on textual definitions, and mismatches between the two can cause unexpected misclassification; and (2) Curators could create incorrect annotations. An example of mismatched definitions:
+
 <pre>
 http://purl.obolibrary.org/obo/CL_0000017 spermatocyte
 
@@ -30,12 +28,15 @@ Text definition: "A male germ cell that develops from spermatogonia."
 Logical definition (that mismatches the textual def): 
 = 'male germ cell' and ('capable of' some 'spermatocyte division')
 </pre>
+
 The logical definition could be revised to:
+
 <pre>
 Logical definition (that matches the textual def): 
 = ‘male germ cell’ and (‘develops from’ some 'spermatogonium')
 </pre>
-While both logical definitions can be used to define the class, one better fits with the textual definition than the other. 
+
+While both logical definitions can be used to define the class, one better fits with the textual definition than the other.
 
 Note that it’s permissible to not to have a logical definition if the class is fuzzy or the axioms/relations can’t be composed equivalence axioms.
 
@@ -43,8 +44,7 @@ Terms often benefit from examples of usage, as well as editor notes about edge c
 
 Instances, such as organizations or geographical locations, can benefit from definitions although it is understood that definitions for instances are not required. It is recognized that OBO format (e.g., versions 1.2 and 1.4) does not allow this as an option.
 
-Implementation
---------------
+## Implementation
 
 Textual definitions should be identified using the annotation property: ‘definition’ [http://purl.obolibrary.org/obo/IAO_0000115](http://purl.obolibrary.org/obo/IAO_0000115). The source of the definition should be provided using the annotation property ‘definition source’ [http://purl.obolibrary.org/obo/IAO_0000119](http://purl.obolibrary.org/obo/IAO_0000119), or as an axiom annotation on the definition assertion.
 
@@ -72,36 +72,37 @@ name: nucleotide-excision repair complex
 def: "Any complex formed of proteins that act in nucleotide-excision repair." [PMID:10915862]
 ```
 
-Examples
---------
+## Examples
 
 <i><b>Class</b></i>: reproductive shoot system
-<br>  <i><b>Term IRI</b></i>: [http://purl.obolibrary.org/obo/PO_0025082](http://purl.obolibrary.org/obo/PO_0025082)
-<br>  <i><b>Definition</b></i>: A shoot system (PO:0009006) in the sporophytic phase that has as part at least one sporangium (PO:0025094).
-<br>  <i><b>Logical definition</b></i>:
+<br> <i><b>Term IRI</b></i>: [http://purl.obolibrary.org/obo/PO_0025082](http://purl.obolibrary.org/obo/PO_0025082)
+<br> <i><b>Definition</b></i>: A shoot system (PO:0009006) in the sporophytic phase that has as part at least one sporangium (PO:0025094).
+<br> <i><b>Logical definition</b></i>:
+
 ```
 intersectionOf: shoot system
 intersectionOf: participates_in some reproductive shoot system development stage
 ```
+
 <i><b>Class</b></i>: chromatography device
-<br>  <i><b>Term IRI</b></i>: http://purl.obolibrary.org/obo/OBI_0000048
-<br>  <i><b>Definition</b></i>: A device that facilitates the separation of mixtures. The function of a chromatography device involves passing a mixture dissolved in a "mobile phase" through a stationary phase, which separates the analyte to be measured from other molecules in the mixture and allows it to be isolated.
-<br>  <i><b>Definition source</b></i>: http://en.wikipedia.org/wiki/Chromatography
-<br>  <i><b>Logical definition</b></i>:
+<br> <i><b>Term IRI</b></i>: http://purl.obolibrary.org/obo/OBI_0000048
+<br> <i><b>Definition</b></i>: A device that facilitates the separation of mixtures. The function of a chromatography device involves passing a mixture dissolved in a "mobile phase" through a stationary phase, which separates the analyte to be measured from other molecules in the mixture and allows it to be isolated.
+<br> <i><b>Definition source</b></i>: http://en.wikipedia.org/wiki/Chromatography
+<br> <i><b>Logical definition</b></i>:
+
 ```
 intersectionOf: device
 intersectionOf: has_function some material separation function
 ```
 
-Counter-Examples
-----------------
+## Counter-Examples
 
--   No definition
--   Circular/Self-referential definition
-    “A chromatography device is a device that uses chromatography” when chromatography is not defined elsewhere
+- No definition
+- Circular/Self-referential definition
+  “A chromatography device is a device that uses chromatography” when chromatography is not defined elsewhere
 
-Criteria for Review
--------------------
+## Criteria for Review
+
 Each definition MUST be unique. Each entity MUST NOT have more than one textual definition (tagged using [IAO:0000115](http://purl.obolibrary.org/obo/IAO_0000115)). Textual definitions SHOULD be provided for most terms, and for top level terms especially.
 
 [This check is automatically validated.](checks/fp_006)
@@ -111,4 +112,3 @@ Each definition MUST be unique. Each entity MUST NOT have more than one textual 
 To suggest revisions or begin a discussion pertaining to this principle, please [create an issue on GitHub](https://github.com/OBOFoundry/OBOFoundry.github.io/issues/new?labels=attn%3A+Editorial+WG,principles&title=Principle+%236+%22Definitions%22+%3CENTER+ISSUE+TITLE%3E).
 
 To suggest revisions or begin a discussion pertaining to the automated validation of this principle, please [create an issue on GitHub](https://github.com/OBOFoundry/OBOFoundry.github.io/issues/new?labels=attn%3A+Technical+WG,automated+validation+of+principles&title=Principle+%236+%22Definitions%22+-+automated+validation+%3CENTER+ISSUE+TITLE%3E).
-

--- a/principles/fp-007-relations.md
+++ b/principles/fp-007-relations.md
@@ -4,25 +4,21 @@ id: fp-007-relations
 title: Relations (principle 7)
 ---
 
-NOTE
------
+## NOTE
 
 The content of this page is scheduled to be reviewed. Improved wording will be posted as it becomes available.
 
-Summary
--------
+## Summary
 
 Relations should be reused from the Relations Ontology (RO).
 
 [This check is automatically validated.](checks/fp_007)
 
-Purpose
--------
+## Purpose
 
 To facilitate interoperability between multiple ontologies, especially with respect to logical inference. That is, a reasoner can only detect logical inconsistencies between ontologies and infer new axioms if the ontologies use the same object properties.
 
-Recommendations and Requirements
---------------
+## Recommendations and Requirements
 
 Each OBO ontology MUST reuse existing relations (aka object properties) that have already been declared in the Relations Ontology (RO),
 rather than declaring relations that mean the same as an existing RO relation. Where it makes sense for an ontology to declare a new relation in
@@ -30,15 +26,12 @@ its own ID space and there is a RO relation that is logically a super-property o
 a sub-property of the RO relation. In such cases, it is requested that there still be coordination with RO, for example in the form of an issue
 submitted to the [RO tracker](https://github.com/oborel/obo-relations/issues).
 
-Implementation
---------------
+## Implementation
 
 Reuse means that the actual relations PURLs are used. Ontology developers should be aware that RO relations (in rare instances) can evolve over time and previous relations might become obsolete. This means developers should monitor the state of the RO relations they use.
 
-Examples
---------
+## Examples
 
-Counter-Examples
-----------------
+## Counter-Examples
 
 <Category:Principles> <Category:Accepted> <Category:Definitions>

--- a/principles/fp-008-documented.md
+++ b/principles/fp-008-documented.md
@@ -4,77 +4,71 @@ id: fp-008-documented
 title: Documentation (principle 8)
 ---
 
+## NOTE
 
-NOTE
--------
 The wording of this principle is still in progress, with some issues still to be addressed (see Issues To Be Addressed below).
 
-Summary
--------
+## Summary
+
 The owners of the ontology should strive to provide as much documentation as possible. The documentation should detail the different processes specific to an ontology life cycle and target various audiences (users or developers).
 
 [This check is automatically validated.](checks/fp_008)
 
-Purpose
--------
-Central to the issue of ontology documentation is ensuring transparency and traceability of artefact development. For each of the development steps, clear procedures should be made available. Documentation availability will be used to assess the quality of the resource. The following itemized list provides a core checklist, distinguishing  general ontology documentation (general information about the resource) and local ontology documentation (documentation at artefact level itself and representational unit level (class and relations)). Documentation assessment with the purpose of assessing Ontology soundness, will cover updates and revision to the documentation. As ontology evolve, so should the documentation, for example by including a release documentation file.
+## Purpose
 
-Examples
---------
+Central to the issue of ontology documentation is ensuring transparency and traceability of artefact development. For each of the development steps, clear procedures should be made available. Documentation availability will be used to assess the quality of the resource. The following itemized list provides a core checklist, distinguishing general ontology documentation (general information about the resource) and local ontology documentation (documentation at artefact level itself and representational unit level (class and relations)). Documentation assessment with the purpose of assessing Ontology soundness, will cover updates and revision to the documentation. As ontology evolve, so should the documentation, for example by including a release documentation file.
 
-* _Embedded or 'in-situ' documentation_:
-Namely any specific metadata available from the ontology artefact itself providing information about the resource in its entirety or parts of it.
-global ontology description (about the ontology as a whole):
- *  creator(s)
- * maintainer(s)
- * license
- * version
+## Examples
 
-* _local ontology documentation (about each term):_
-documentation for individual representational unit annotation
- * justify the different elements of class metadata
- * justify class axiomatization
-documentation about the textual definition: is it manually created or generated with software assistance by relying on patterns and class axioms.	
+- _Embedded or 'in-situ' documentation_:
+  Namely any specific metadata available from the ontology artefact itself providing information about the resource in its entirety or parts of it.
+  global ontology description (about the ontology as a whole):
+- creator(s)
+- maintainer(s)
+- license
+- version
 
-* _User documentation:_
-A documentation detailing the ontology's raison d'etre, its coverage, the use cases and query cases (including translation into  SPARQL queries) it is intended to support
-documentation about how to access the resource
-documentation about how to produce semantic web document compatible with the representation intended by the developers (OWL examples, OWL coding patterns)
- * availability of peer-reviewed publication about the resource
- * availability of training material and tutorial
- * availability of presentations (e.g. on slideshare)
- * availability of web seminars (e.g. on a youtube channel)
+- _local ontology documentation (about each term):_
+  documentation for individual representational unit annotation
+- justify the different elements of class metadata
+- justify class axiomatization
+  documentation about the textual definition: is it manually created or generated with software assistance by relying on patterns and class axioms.
 
-* _Developer documentation:_
+- _User documentation:_
+  A documentation detailing the ontology's raison d'etre, its coverage, the use cases and query cases (including translation into SPARQL queries) it is intended to support
+  documentation about how to access the resource
+  documentation about how to produce semantic web document compatible with the representation intended by the developers (OWL examples, OWL coding patterns)
+- availability of peer-reviewed publication about the resource
+- availability of training material and tutorial
+- availability of presentations (e.g. on slideshare)
+- availability of web seminars (e.g. on a youtube channel)
 
- * documentation about authors contributions
- * documentation about licensing terms, rights of use.
- * documentation about version control 
- * documentation about release process
- * documentation about changes in ontology between release version
- * continuous integration
- * documentation about the methodology used for developing the resource
- * documentation about interaction with orthogonal resources
- * documentation about resource acknowledgement
- * documentation about term submission/term requests
- * documentation about batch submission
- * documentation about term deprecation and deprecation policy (aka retirement policy)
- * documentation about conflict resolution
- * a documentation detailing the use of software agent devised or exploited to develop, maintain, enhance, perform quality control and ensure high availability of the resource
- * documentation about how the ontology is being used
+- _Developer documentation:_
 
+- documentation about authors contributions
+- documentation about licensing terms, rights of use.
+- documentation about version control
+- documentation about release process
+- documentation about changes in ontology between release version
+- continuous integration
+- documentation about the methodology used for developing the resource
+- documentation about interaction with orthogonal resources
+- documentation about resource acknowledgement
+- documentation about term submission/term requests
+- documentation about batch submission
+- documentation about term deprecation and deprecation policy (aka retirement policy)
+- documentation about conflict resolution
+- a documentation detailing the use of software agent devised or exploited to develop, maintain, enhance, perform quality control and ensure high availability of the resource
+- documentation about how the ontology is being used
 
-Issues To Be Addressed (partial list):
--------
+## Issues To Be Addressed (partial list):
+
 1. What minimal metadata is needed?
 
 2. What minimal documentation is needed?
 
 3. Clarification of the role of publications
 
-
-
 the ontology is well-documented (e.g. in a published paper describing the ontology or in manuals for developers and users)
-
 
 <Category:Principles> <Category:Accepted>

--- a/principles/fp-009-users.md
+++ b/principles/fp-009-users.md
@@ -4,28 +4,26 @@ id: fp-009-users
 title: Documented Plurality of Users (principle 9)
 ---
 
-Summary
--------
+## Summary
 
 The ontology developers should document that the ontology is used by
 multiple independent people or organizations.
 
-Purpose
--------
+## Purpose
 
 This principle aims to ensure that the ontology tackles a relevant
 scientific area and does so in a usable and sustainable fashion.
 
-Recommendations and Requirements
--------
+## Recommendations and Requirements
+
 It is important to be able to illustrate usage outside of the immediate circle of ontology developers and stakeholders. Note that the ontology can still be listed on
 the OBO Foundry website while publicising your resource in appropriate channels and searching for users with needs you can meet.
 
-Implementation
---------------
+## Implementation
 
 The ontology developers should provide links/citations to evidence of
 use (publication, external ontology; see examples below for additional types) within your ontology [metadata file](https://github.com/OBOFoundry/OBOFoundry.github.io/tree/master/ontology) (replacing with the correct group name, link, and description):
+
 ```
 usages:
 - user: http://www.informatics.jax.org/disease (link to group)
@@ -34,51 +32,48 @@ usages:
    - url: http://www.informatics.jax.org/disease/DOID:4123 (link to specific example)
      description: Human genes and mouse homology associated with nail diseases (description of specific example)
 ```
+
 You may have multiple examples for each user, and mulitple users under the `usages` tag.
 
+## Examples
 
-Examples
---------
+- Use of the target ontology's term IRIs in other ontologies. This can
+  be evidenced by linking to the other ontology that uses an ontology
+  term IRI from this ontology
 
--   Use of the target ontology's term IRIs in other ontologies. This can
-    be evidenced by linking to the other ontology that uses an ontology
-    term IRI from this ontology
+- Imports in other ontologies, again, evidenced through a link to the
+  importing ontology
 
--   Imports in other ontologies, again, evidenced through a link to the
-    importing ontology
+- A documentation page with links to databases using the ontology for
+  annotation
 
--   A documentation page with links to databases using the ontology for
-    annotation
+- Use in semantic web projects (e.g., Open PHACTS usage)
 
--   Use in semantic web projects (e.g., Open PHACTS usage)
+- Use in diverse software applications, including text mining or
+  analysis pipelines
 
--   Use in diverse software applications, including text mining or
-    analysis pipelines
+- Publications showing the ontology being used in research (evidenced
+  by citation details for the publications; if behind paywall it may
+  be necessary to provide a PDF for the paper)
 
--   Publications showing the ontology being used in research (evidenced
-    by citation details for the publications; if behind paywall it may
-    be necessary to provide a PDF for the paper)
+- Citations to the ontology publication(s); such citations are only
+  relevant if the authors indicate actual use of the cited ontology
+  within some community (mere mention of the existence is not enough
+  to warrant inclusion)
 
--   Citations to the ontology publication(s); such citations are only
-    relevant if the authors indicate actual use of the cited ontology
-    within some community (mere mention of the existence is not enough
-    to warrant inclusion)
+- Documentation of requests from multiple users, e.g., via an issue
+  tracker (provide a link to the issue tracker online)
 
--   Documentation of requests from multiple users, e.g., via an issue
-    tracker (provide a link to the issue tracker online)
+- Use of the terms from the ontology to structure or annotate
+  experimental or derived data (e.g. GOA; provide details of how to
+  review the annotations)
 
--   Use of the terms from the ontology to structure or annotate
-    experimental or derived data (e.g. GOA; provide details of how to
-    review the annotations)
-
-Counter-Examples
-----------------
+## Counter-Examples
 
 Mere mention of the existence of an ontology in a publication is not
 enough to count as evidence of usage
 
-Criteria for Review
--------------------
+## Criteria for Review
 
 An ontology that has not been used by other than the developer(s) is not
 yet ready for review. To pass review, the ontology developers must demonstrate at least three
@@ -94,4 +89,3 @@ the ontology.
 To suggest revisions or begin a discussion pertaining to this principle, please [create an issue on GitHub](https://github.com/OBOFoundry/OBOFoundry.github.io/issues/new?labels=attn%3A+Editorial+WG,principles&title=Principle+%239+%22Users%22+%3CENTER+ISSUE+TITLE%3E).
 
 To suggest revisions or begin a discussion pertaining to the automated validation of this principle, please [create an issue on GitHub](https://github.com/OBOFoundry/OBOFoundry.github.io/issues/new?labels=attn%3A+Technical+WG,automated+validation+of+principles&title=Principle+%239+%22Users%22+-+automated+validation+%3CENTER+ISSUE+TITLE%3E).
-

--- a/principles/fp-010-collaboration.md
+++ b/principles/fp-010-collaboration.md
@@ -10,24 +10,31 @@ OBO Foundry ontology development, in common with many other standards-oriented s
 activities, should be carried out in a collaborative fashion.
 
 ## Purpose
+
 The benefits of collaboration are threefold: (1) Avoid duplication of work; (2) Increase interoperability; and (3) Ensure that ontology content is both scientifically sound and meets community needs.
 
 ## Implementation
+
 ### Recommendation:
-It is expected that Foundry ontologies will collaborate with other Foundry ontologies, particularly in ensuring orthogonality of distinct ontologies, in re-using content from other ontologies in cross-product definitions where appropriate, and in establishing and evolving Foundry principles to advance the Foundry suite of ontologies to better serve the joint users. Where there are multiple ontology providers in a particular domain, they are particularly encouraged to get together and determine how the domain should be divided between the ontologies, or whether the ontologies should be merged into a single artifact. Should it be determined that there is a competing ontology in the same domain, the Foundry ontology should invite the developers of the external ontology to collaborate and should strive to negotiate an arrangement that is beneficial to both projects. If necessary, conflicts can be mediated in dedicated workshops or using the [obo-discuss mailing list](https://groups.google.com/forum/#!forum/obo-discuss) where Foundry advisors and members of the editorial board can help the parties negotiate to a mutually agreeable solution. 
+
+It is expected that Foundry ontologies will collaborate with other Foundry ontologies, particularly in ensuring orthogonality of distinct ontologies, in re-using content from other ontologies in cross-product definitions where appropriate, and in establishing and evolving Foundry principles to advance the Foundry suite of ontologies to better serve the joint users. Where there are multiple ontology providers in a particular domain, they are particularly encouraged to get together and determine how the domain should be divided between the ontologies, or whether the ontologies should be merged into a single artifact. Should it be determined that there is a competing ontology in the same domain, the Foundry ontology should invite the developers of the external ontology to collaborate and should strive to negotiate an arrangement that is beneficial to both projects. If necessary, conflicts can be mediated in dedicated workshops or using the [obo-discuss mailing list](https://groups.google.com/forum/#!forum/obo-discuss) where Foundry advisors and members of the editorial board can help the parties negotiate to a mutually agreeable solution.
 
 ### Examples:
-* _Collaborative workshop_: http://ncorwiki.buffalo.edu/index.php/Protein_Ontology_Workshop 
-* _Conflict resolution_: The Statistical Methods Ontology (STATO) and Ontology of Biological and Clinical Statistics (OBCS) both cover statistics. The developers of each have posted to the OBO Foundry discussion list to work out how to collaborate.
-* _Contribution to external ontology_: Plant Ontology (PO) curators contribute definitions to Gene Ontology (GO) for biological processes and cell components in plants. PO then uses the GO terms in their definition of corresponding structures and stages.
-* _Documentation of collaboration_: Cell Line Ontology (CLO), Cell Ontology (CL), and Ontology of Biomedical Investigations (OBI) published a paper sorting out their overlap and documented working together. Sarntivjiai et al., "CLO: The cell line ontology", J. Biomed. Sem., 2014, 5, 37. http://www.ncbi.nlm.nih.gov/pubmed/25852852
-* _Providing terms upon request_: The Disease Ontology (DO) responded to a request from the PRotein Ontology for curation of certain disease terms.
 
-### Counter-examples: 
+- _Collaborative workshop_: http://ncorwiki.buffalo.edu/index.php/Protein_Ontology_Workshop
+- _Conflict resolution_: The Statistical Methods Ontology (STATO) and Ontology of Biological and Clinical Statistics (OBCS) both cover statistics. The developers of each have posted to the OBO Foundry discussion list to work out how to collaborate.
+- _Contribution to external ontology_: Plant Ontology (PO) curators contribute definitions to Gene Ontology (GO) for biological processes and cell components in plants. PO then uses the GO terms in their definition of corresponding structures and stages.
+- _Documentation of collaboration_: Cell Line Ontology (CLO), Cell Ontology (CL), and Ontology of Biomedical Investigations (OBI) published a paper sorting out their overlap and documented working together. Sarntivjiai et al., "CLO: The cell line ontology", J. Biomed. Sem., 2014, 5, 37. http://www.ncbi.nlm.nih.gov/pubmed/25852852
+- _Providing terms upon request_: The Disease Ontology (DO) responded to a request from the PRotein Ontology for curation of certain disease terms.
+
+### Counter-examples:
+
 Interactions between ontologies developed by the same entity (person, consortium) are not evidence of collaboration.
 
 ## Criteria for Review
+
 To pass review, the ontology developers must document their attempts at an open dialog with OBO Foundry members, for example by attempting to ascertain if there are other possible ontologies in (or overlapping) the domain of interest. Such documentation can be a simple pointer to an e-mail thread on the OBO discuss list. If there are other ontologies that might need to be aligned or have boundaries determined, evidence of coordination or cooperation should be provided. Further evidence of collaboration may include examples of terms that have been provided to other ontologies in the OBO Foundry community. Finally, hosting or participating in collaborative workshops or meetings attended by OBO Foundry community members is considered evidence of collaboration.
+
 ## Feedback and Discussion
 
 To suggest revisions or begin a discussion pertaining to this principle, please [create an issue on GitHub](https://github.com/OBOFoundry/OBOFoundry.github.io/issues/new?labels=attn%3A+Editorial+WG,principles&title=Principle+%2310+%22Collaboration%22+%3CENTER+ISSUE+TITLE%3E).

--- a/principles/fp-011-locus-of-authority.md
+++ b/principles/fp-011-locus-of-authority.md
@@ -5,21 +5,24 @@ title: Locus of Authority (principle 11)
 ---
 
 ## Summary
-There should be a person who is responsible for communications between the 
-community and the ontology developers, for communicating with the Foundry on all 
-Foundry-related matters, for mediating discussions involving maintenance in the 
+
+There should be a person who is responsible for communications between the
+community and the ontology developers, for communicating with the Foundry on all
+Foundry-related matters, for mediating discussions involving maintenance in the
 light of scientific advance, and for ensuring that all user feedback is addressed.
 
 ## Purpose
+
 It is important that there is a person responsible for communication rather than a group of people or a list. Often in communications to a list, the responsibility for responding can be diffused and it is likely that in some scenarios no response will be given. It may also, from time to time, be necessary to engage in strategic communications (e.g. relating to funding or collaboration possibilities) that are not able to be made public, and these should not be conducted on public mailing lists. The designation of a contact person is not to be interpreted as a designation for credit. Note that alternative contacts can be designated in case the primary contact is unavailable. However, as for the primary contact, each alternative contact must be an individual.
 
 ## Recomendations and Requirements
+
 A primary contact person MUST be assigned.
-The name, email address and GitHub username of the contact person MUST be provided when requesting to register with [OBO](http://obofoundry.org). The contact person MUST be subscribed to obo-discuss in order to be kept abreast of community developments of relevance to 
-participating ontology projects, but the primary contact person can, of course, delegate 
-these responsibilities for the project as necessary. The email address of the person who is the locus of the 
+The name, email address and GitHub username of the contact person MUST be provided when requesting to register with [OBO](http://obofoundry.org). The contact person MUST be subscribed to obo-discuss in order to be kept abreast of community developments of relevance to
+participating ontology projects, but the primary contact person can, of course, delegate
+these responsibilities for the project as necessary. The email address of the person who is the locus of the
 authority MUST be kept up-to-date, and before that person ceases to have responsibility
-for the project, they should identify a replacement and update the metadata accordingly 
+for the project, they should identify a replacement and update the metadata accordingly
 (via the [OBO Foundry issue tracker](https://github.com/OBOFoundry/OBOFoundry.github.io/issues)) before they move on.
 
 ## Implementation
@@ -28,15 +31,14 @@ First, read the [FAQ](http://obofoundry.github.io/faq/how-do-i-edit-metadata.htm
 
 The contact email MUST NOT be a mailing list. The GitHub account MUST be for the individual designated as the locus of authority. If this person does not already have a GitHub account, we request that they [create one](https://github.com/join). Then, add the following to your [metadata file](https://github.com/OBOFoundry/OBOFoundry.github.io/tree/master/ontology) (replacing with the correct email, name, and GitHub username):
 
-`contact:
- email: foo@bar.com
- label: John Smith
- github: jsmith123`
+`contact: email: foo@bar.com label: John Smith github: jsmith123`
 
-### Examples: 
-For Mondo, the primary contact person is Nicole Vasilevsky (nicole {at} tislab.org) and her GitHub handle is: nicolevasilevsky. 
+### Examples:
 
-### Counter-Examples: 
+For Mondo, the primary contact person is Nicole Vasilevsky (nicole {at} tislab.org) and her GitHub handle is: nicolevasilevsky.
+
+### Counter-Examples:
+
 Mailing list; for ChEBI, chebi-help@ebi.ac.uk
 
 ### Criteria for Review

--- a/principles/fp-012-naming-conventions.md
+++ b/principles/fp-012-naming-conventions.md
@@ -4,34 +4,29 @@ id: fp-012-naming-conventions
 title: Naming Conventions (principle 12)
 ---
 
-NOTE
--------
+## NOTE
 
 The content of this page is scheduled to be reviewed. Improved wording will be posted as it becomes available.
 
-Details
--------
+## Details
 
 For full details, see this paper: <http://www.biomedcentral.com/1471-2105/10/125>
 
 Briefly, some important things to remember:
 
- * use rdfs:label for the primary label
- * include exactly one rdfs:label for every declared entity (e.g. class, property)
- * write labels, synonyms, etc as if writing in plain English text. ie use spaces to separate words, only capitalize proper names (e.g. Parkinson disease). Do not use CamelCase, do_not_use_underscores
- * avoid extra spaces between words, or at the beginning or end of the term label
- * spell out abbreviations. Abbreviations can be included as a separate property.
- * make the primary labels to be as unambiguous as possible. Remember, your ontology may be used in a different context than that for which it was originally intended. Remember also of course that the label should be unambiguous without looking at parent terms
- * labels should be unique within an ontology
- * use the IAO property 'obo foundry unique label' [http://purl.obolibrary.org/obo/IAO_0000589](http://purl.obolibrary.org/obo/IAO_0000589) to declare a pan-OBO unique label if required
+- use rdfs:label for the primary label
+- include exactly one rdfs:label for every declared entity (e.g. class, property)
+- write labels, synonyms, etc as if writing in plain English text. ie use spaces to separate words, only capitalize proper names (e.g. Parkinson disease). Do not use CamelCase, do_not_use_underscores
+- avoid extra spaces between words, or at the beginning or end of the term label
+- spell out abbreviations. Abbreviations can be included as a separate property.
+- make the primary labels to be as unambiguous as possible. Remember, your ontology may be used in a different context than that for which it was originally intended. Remember also of course that the label should be unambiguous without looking at parent terms
+- labels should be unique within an ontology
+- use the IAO property 'obo foundry unique label' [http://purl.obolibrary.org/obo/IAO_0000589](http://purl.obolibrary.org/obo/IAO_0000589) to declare a pan-OBO unique label if required
 
 [This check is automatically validated.](checks/fp_012)
 
+## Examples
 
-Examples
---------
-
-Counter-Examples
-----------------
+## Counter-Examples
 
 <Category:Principles> <Category:Accepted>

--- a/principles/fp-016-maintenance.md
+++ b/principles/fp-016-maintenance.md
@@ -4,29 +4,26 @@ id: fp-016-maintenance
 title: Maintenance (principle 16)
 ---
 
-NOTE
--------
+## NOTE
+
 The wording of this principle is still in progress.
 
-Summary and Purpose
--------
+## Summary and Purpose
+
 The ontology needs to reflect changes in scientific consensus to remain accurate over time.
 
 [This check is automatically validated.](checks/fp_016)
 
-Implementation
--------
+## Implementation
+
 Ideally, the maintainer of an ontology should actively monitor for any changes in scientific consensus, but at a minimum, the maintainer needs to be responsive in a timely manner (less than 3 months) to requests from the community pointing out such changes in scientific consensus. Tentatively, we consider scientific consensus to be reached if multiple publications by independent labs over a year come to the same conclusion, and there is no or limited (<10%) dissenting opinions published in the same time frame. In cases when an area remains controversial, and no consensus is reached, then it is up to the ontology maintainer to either leave out the controversial term, or pick a viewpoint for practical considerations, and note the presence of controversy in an editor note.
 
+## Examples
 
-Examples
---------
+## Counter-Examples
 
-Counter-Examples
-----------------
+## Review Criteria
 
-Review Criteria
--------
 The developers of the ontology need to include a statement specifying how they are planning to maintain the ontology. We expect that an ontology will be maintained for at least 3 years from the time of review.
 
 <Category:Principles> <Category:Accepted>

--- a/principles/fp-020-responsiveness.md
+++ b/principles/fp-020-responsiveness.md
@@ -4,26 +4,29 @@ id: fp-020-responsiveness
 title: Responsiveness (principle 20)
 ---
 
-Summary
--------
-Ontology developers MUST offer channels for community participation and SHOULD be responsive to requests. 
+## Summary
 
-Purpose
--------
-Ontology development benefits from community input, which is strongly encouraged by the OBO Foundry. Accordingly, "responsiveness" is a key quality of our general collaborative spirit. This principle is intended to ensure that channels for community input are available and that responses to input are given swiftly. 
+Ontology developers MUST offer channels for community participation and SHOULD be responsive to requests.
+
+## Purpose
+
+Ontology development benefits from community input, which is strongly encouraged by the OBO Foundry. Accordingly, "responsiveness" is a key quality of our general collaborative spirit. This principle is intended to ensure that channels for community input are available and that responses to input are given swiftly.
 
 Recommendations and Requirements
-------- 
+
+---
+
 Ontology developers MUST set up a mechanism to track community requests and suggestions (collectively, “issues”), and SHOULD aim to respond within 2-5 working days. Optional: Establish a discussion forum for more general communication with and between users.
 
 Expectations of responsiveness:
-1. Issues are contributions - and should be met by a thankful attitude. When receiving an item on your issue tracker, the first thing to do is thank the contributor, even if it cannot be addressed right away. 
-2. If an issue cannot be addressed right away, explain when you plan to address the issue. 
+
+1. Issues are contributions - and should be met by a thankful attitude. When receiving an item on your issue tracker, the first thing to do is thank the contributor, even if it cannot be addressed right away.
+2. If an issue cannot be addressed right away, explain when you plan to address the issue.
 3. Do not close issues without responding. If an issue is out of scope for a repository, recommend moving it to a different repository.
 4. It is recommended that one or more developers be designated to triage issues.
 
-Implementation
--------
+## Implementation
+
 A discussion mailing list and issue tracker are required to obtain an OBO Foundry PURL. The OBO Foundry offers the following recommendations on the responsiveness in issue trackers (GitHub is recommended).
 
 1. Specify the URL for an issue tracker (GitHub is recommended) in the ontology configuration file (YAML) that is used to display ontology details on the OBO Foundry web site.
@@ -31,26 +34,22 @@ A discussion mailing list and issue tracker are required to obtain an OBO Foundr
 
 Specification of the tracker is done using the following text (customized for your ontology) within its [metadata file](https://github.com/OBOFoundry/OBOFoundry.github.io/tree/master/ontology):
 
-`tracker: https://github.com/geneontology/go-ontology/issues/
-`
+`tracker: https://github.com/geneontology/go-ontology/issues/ `
 
-Examples
---------
+## Examples
 
-Issue tracker: https://github.com/monarch-initiative/mondo/issues  
+Issue tracker: https://github.com/monarch-initiative/mondo/issues
 
-Discussion list: mondo-users@googlegroups.com  
+Discussion list: mondo-users@googlegroups.com
 
-Collaboration of this sort can be demonstrated by having an active discussion mailing list, or responsiveness to community requests on a GitHub tracker.  
+Collaboration of this sort can be demonstrated by having an active discussion mailing list, or responsiveness to community requests on a GitHub tracker.
 
-
-Counter-Examples
-----------------
+## Counter-Examples
 
 Waiting until an issue is resolved before responding, if such resolution comes well after submission of a ticket.
 
-Criteria for Review
--------
+## Criteria for Review
+
 There is a functioning issue tracker for ontology requests specified on the OBO Foundry web site.
 
 [This check is automatically validated.](checks/fp_020)

--- a/registry/README.md
+++ b/registry/README.md
@@ -4,19 +4,17 @@ This directory contains combined metadata files derived from source in the [onto
 
 Currently:
 
- * `.yml` - YAML
- * `.jsonld` - JSON(LD)
- * `.ttl` - RDF/Turtle
+- `.yml` - YAML
+- `.jsonld` - JSON(LD)
+- `.ttl` - RDF/Turtle
 
 See the [Makefile](../Makefile) for details how these are constructed
 
 It is recommended you access all files in this repo through their PURLs. You can affix any filename to `http://purl.obolibrary.org/meta/`, e.g.
 
- * http://purl.obolibrary.org/meta/context.jsonld
- * http://purl.obolibrary.org/meta/ontologies.yml
- * http://purl.obolibrary.org/meta/ontologies.jsonld
- * http://purl.obolibrary.org/meta/obo_prefixes.ttl
+- http://purl.obolibrary.org/meta/context.jsonld
+- http://purl.obolibrary.org/meta/ontologies.yml
+- http://purl.obolibrary.org/meta/ontologies.jsonld
+- http://purl.obolibrary.org/meta/obo_prefixes.ttl
 
 https://github.com/bioregistry/bioregistry/issues/49
-
-

--- a/registry/publications.md
+++ b/registry/publications.md
@@ -9,7 +9,7 @@ title: Publications Related to the OBO Foundry
 
 [**OBO Foundry in 2021: operationalizing open data principles to evaluate ontologies**](https://academic.oup.com/database/article/doi/10.1093/database/baab069/6410158) **(2021)**.
 
-Rebecca Jackson, Nicolas Matentzoglu, James A Overton, Randi Vita, James P Balhoff, Pier Luigi Buttigieg, Seth Carbon, Melanie Courtot, Alexander D Diehl, Damion M Dooley, William D Duncan, Nomi L Harris, Melissa A Haendel, Suzanna E Lewis, Darren A Natale, David Osumi-Sutherland, Alan Ruttenberg, Lynn M Schriml, Barry Smith, Christian J Stoeckert Jr., Nicole A Vasilevsky, Ramona L Walls, Jie Zheng, Christopher J Mungall, Bjoern Peters. *Database*, Volume 2021, baab069, https://doi.org/10.1093/database/baab069
+Rebecca Jackson, Nicolas Matentzoglu, James A Overton, Randi Vita, James P Balhoff, Pier Luigi Buttigieg, Seth Carbon, Melanie Courtot, Alexander D Diehl, Damion M Dooley, William D Duncan, Nomi L Harris, Melissa A Haendel, Suzanna E Lewis, Darren A Natale, David Osumi-Sutherland, Alan Ruttenberg, Lynn M Schriml, Barry Smith, Christian J Stoeckert Jr., Nicole A Vasilevsky, Ramona L Walls, Jie Zheng, Christopher J Mungall, Bjoern Peters. _Database_, Volume 2021, baab069, https://doi.org/10.1093/database/baab069
 
 ## Other papers about the OBO Foundry
 
@@ -17,7 +17,7 @@ Rebecca Jackson, Nicolas Matentzoglu, James A Overton, Randi Vita, James P Balho
 
 Barry Smith, Michael Ashburner, Cornelius Rosse, Jonathan Bard, William Bug, Werner Ceusters, Louis J Goldberg, Karen Eilbeck, Amelia Ireland, Christopher J Mungall, The OBI Consortium, Neocles Leontis, Philippe Rocca-Serra, Alan Ruttenberg, Susanna-Assunta Sansone, Richard H Scheuermann, Nigam Shah, Patricia L Whetzel, and Suzanna Lewis
 
-*Nature Biotechnology* **25**, 1251 - 1255 (2007)
+_Nature Biotechnology_ **25**, 1251 - 1255 (2007)
 
 [Google Scholar list of papers citing The OBO Foundry](https://scholar.google.ca/scholar?cites=13806088078865650870&as_sdt=2005&sciodt=0,5&hl=en)
 

--- a/resources.md
+++ b/resources.md
@@ -2,6 +2,7 @@
 layout: doc
 title: Ontology Tools and Resources
 ---
+
 ## Ontology Browsers
 
 - [OBO Foundry](http://www.obofoundry.org/)
@@ -39,20 +40,20 @@ title: Ontology Tools and Resources
 
 ## Ontology Analysis
 
-- [OBO Dashboard](https://dashboard.obofoundry.org): An assesment of OBO Foundry ontologies' conformance to OBO Foundry principles 
+- [OBO Dashboard](https://dashboard.obofoundry.org): An assesment of OBO Foundry ontologies' conformance to OBO Foundry principles
 - [OBO Community Health Report](https://cthoyt.com/obo-community-health): A self-updating assessment of the quality of metadata, responsiveness of the maintainers, and the overall community engagement for each OBO Foundry ontology.
-- [Ontology Quality Assessment](https://cthoyt.com/oquat): A self-updating assesment of the semantic quality of OBO Foundry ontologies and beyond (using known prefixes, using standard identifiers, etc.) 
+- [Ontology Quality Assessment](https://cthoyt.com/oquat): A self-updating assesment of the semantic quality of OBO Foundry ontologies and beyond (using known prefixes, using standard identifiers, etc.)
 
 ## Relevant Publications/blogs
 
-- [**OBO Foundry in 2021: operationalizing open data principles to evaluate ontologies**](https://academic.oup.com/database/article/doi/10.1093/database/baab069/6410158) **(2021)**. Rebecca Jackson, Nicolas Matentzoglu, James A Overton, Randi Vita, James P Balhoff, Pier Luigi Buttigieg, Seth Carbon, Melanie Courtot, Alexander D Diehl, Damion M Dooley, William D Duncan, Nomi L Harris, Melissa A Haendel, Suzanna E Lewis, Darren A Natale, David Osumi-Sutherland, Alan Ruttenberg, Lynn M Schriml, Barry Smith, Christian J Stoeckert Jr., Nicole A Vasilevsky, Ramona L Walls, Jie Zheng, Christopher J Mungall, Bjoern Peters. *Database*, Volume 2021, baab069, https://doi.org/10.1093/database/baab069
+- [**OBO Foundry in 2021: operationalizing open data principles to evaluate ontologies**](https://academic.oup.com/database/article/doi/10.1093/database/baab069/6410158) **(2021)**. Rebecca Jackson, Nicolas Matentzoglu, James A Overton, Randi Vita, James P Balhoff, Pier Luigi Buttigieg, Seth Carbon, Melanie Courtot, Alexander D Diehl, Damion M Dooley, William D Duncan, Nomi L Harris, Melissa A Haendel, Suzanna E Lewis, Darren A Natale, David Osumi-Sutherland, Alan Ruttenberg, Lynn M Schriml, Barry Smith, Christian J Stoeckert Jr., Nicole A Vasilevsky, Ramona L Walls, Jie Zheng, Christopher J Mungall, Bjoern Peters. _Database_, Volume 2021, baab069, https://doi.org/10.1093/database/baab069
 - [The OBO Foundry: coordinated evolution of ontologies to support biomedical data integration](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC2814061/) (Smith et al., 2007). Nat Biotechnol 2007 Nov;25(11):1251–1255. http://dx.doi.org/10.1038/nbt1346
 - [MIRO: guidelines for minimum information for the reporting of an ontology](https://jbiomedsem.biomedcentral.com/articles/10.1186/s13326-017-0172-7) (2018). Nicolas Matentzoglu, James Malone, Chris Mungall and Robert Stevens, Journal of Biomedical Semantics 2018 9:6, https://doi.org/10.1186/s13326-017-0172-7
 - [Monkeying around with OWL](https://douroucouli.wordpress.com/): a technical blog on ontologies and ontology engineering by Chris Mungall.
 - [Feed your head](https://robertdavidstevens.wordpress.com/): a technical blog on ontologies and ontology engineering by Robert Stevens.
 - [Biomedical ontologies, data integration and annotation, British sense of humour](http://drjamesmalone.blogspot.com/): a technical blog on ontologies and ontology engineering by James Malone.
 - [What are Ontologies?](https://www.ontotext.com/knowledgehub/fundamentals/what-are-ontologies/)
-- [Semantic Web for the Working Ontologist](http://workingontologist.org/), Second Edition by Dean Allemang and James Hendler 
+- [Semantic Web for the Working Ontologist](http://workingontologist.org/), Second Edition by Dean Allemang and James Hendler
 - [Linked Data Patterns: A pattern catalogue for modelling, publishing, and consuming Linked Data](http://patterns.dataincubator.org/book/) by Leigh Dodds and Ian Davis
 - [Learning SPARQL](http://www.learningsparql.com/) by Bob DuCharme
 - [Guidelines for writing definitions in ontologies](https://philpapers.org/archive/SEPGFW.pdf) by Selja Seppälä, Alan Ruttenberg and Barry Smith


### PR DESCRIPTION
This PR runs `npx prettier --write .` to reformat HTML and markdown in a principled, deterministic way. This will make it easier to make updates that have smaller diffs, such as #2042. It adds a note on how to do this in the README-sitedev.md

It also adds a `.prettierignore` file that lists some file types and directories to ignore.

This PR **does not** change how anything looks on the website. However, in 3 cases (see 5ec2d01) it fixes some invalid HTML.