### PR TITLE
Improve summary page

### DIFF
--- a/_layouts/ontology_detail.html
+++ b/_layouts/ontology_detail.html
@@ -319,7 +319,7 @@ page.preferredPrefix | upcase %} {% if upperPrefix != page.preferredPrefix %}
             <dd>{% endif %}</dd>
         </dl>
 
-        <div class="btn-group" role="group" aria-label="Source">
+        <div class="btn-group pull-right" role="group" aria-label="Source">
             <a
                     href="https://github.com/OBOFoundry/OBOFoundry.github.io/blob/master/ontology/{{page.id}}.md"
             >

--- a/_layouts/ontology_detail.html
+++ b/_layouts/ontology_detail.html
@@ -50,46 +50,9 @@ page.preferredPrefix | upcase %} {% if upperPrefix != page.preferredPrefix %}
 
 <div class="row">
   <div class="col-md-8" style="padding-left: 0">
-    {% assign stripped_content_size = content | strip | size %} {% if
-    stripped_content_size > 0 %}
-    <div class="panel panel-default">
-      <div class="panel-body">{{ content }}</div>
-    </div>
-    {% endif %}
+    {% assign stripped_content_size = content | strip | size %}
 
     <div class="panel panel-default">
-      <div class="panel-heading">
-        <h3 class="panel-title">Badges and Buttons</h3>
-      </div>
-      {% if page.repository and page.repository contains "https://github.com/"
-      %}
-      <div class="panel-body">
-        <a href="{{ page.repository }}">
-          <img
-            alt="GitHub Repo stars"
-            src="https://img.shields.io/github/stars/{{ page.repository | remove: 'https://github.com/' }}"
-          />
-          <img
-            alt="GitHub contributors"
-            src="https://img.shields.io/github/contributors/{{ page.repository | remove: 'https://github.com/' }}"
-          />
-          <img
-            alt="GitHub last commit"
-            src="https://img.shields.io/github/last-commit/{{ page.repository | remove: 'https://github.com/' }}"
-          />
-          <!--<img alt="GitHub issues" src="https://img.shields.io/github/issues/{{ page.repository | remove: 'https://github.com/' }}" />-->
-        </a>
-      </div>
-      {% endif %} {% if page.twitter %}
-      <div class="panel-body">
-        <a href="https://twitter.com/{{ page.twitter }}">
-          <img
-            alt="Twitter Follow"
-            src="https://img.shields.io/twitter/follow/{{ page.twitter }}?style=social"
-          />
-        </a>
-      </div>
-      {% endif %}
       <div class="panel-body">
         <!-- TODO: each ontology should configure which browsers to be exposed in -->
         <a href="https://ontobee.org/browser/index.php?o={{page.id}}">
@@ -116,6 +79,9 @@ page.preferredPrefix | upcase %} {% if upperPrefix != page.preferredPrefix %}
           <button type="button" class="btn btn-default">Bioregistry</button>
         </a>
       </div>
+      {% if stripped_content_size > 0 %}
+      <div class="panel-body">{{ content }}</div>
+      {% endif %}
     </div>
 
     <div class="panel panel-default">
@@ -305,8 +271,50 @@ page.preferredPrefix | upcase %} {% if upperPrefix != page.preferredPrefix %}
         <a href="{{p.id}}">{{p.type}}</a>
         {% endif %}
       </dd>
-      {% endfor %} {% endif %} {% if page.review.date and page.review.document
-      %}
+      {% endfor %} {% endif %} {% if page.twitter %}
+      <dt>Twitter</dt>
+      <dd>
+        <a
+          href="https://twitter.com/{{ page.twitter }}"
+          style="padding: 0.5em 0"
+        >
+          <img
+            alt="Twitter Follow"
+            src="https://img.shields.io/twitter/follow/{{ page.twitter }}?style=social"
+          />
+        </a>
+      </dd>
+      {% endif %} {% if page.repository and page.repository contains
+      "https://github.com/" %}
+      <dt>Stars</dt>
+      <dd>
+        <a href="{{ page.repository }}">
+          <img
+            alt="GitHub Repo stars"
+            src="https://img.shields.io/github/stars/{{ page.repository | remove: 'https://github.com/' }}"
+          />
+        </a>
+      </dd>
+      <dt>Contributors</dt>
+      <dd>
+        <a href="{{ page.repository }}">
+          <img
+            alt="GitHub contributors"
+            src="https://img.shields.io/github/contributors/{{ page.repository | remove: 'https://github.com/' }}"
+          />
+        </a>
+      </dd>
+      <dt>Last Commit</dt>
+      <dd>
+        <a href="{{ page.repository }}">
+          <img
+            alt="GitHub last commit"
+            src="https://img.shields.io/github/last-commit/{{ page.repository | remove: 'https://github.com/' }}"
+          />
+        </a>
+        <!--<img alt="GitHub issues" src="https://img.shields.io/github/issues/{{ page.repository | remove: 'https://github.com/' }}" />-->
+      </dd>
+      {% endif %} {% if page.review.date and page.review.document %}
       <dt>OBO Review</dt>
       <dd>
         {{page.review.date}}

--- a/_layouts/ontology_detail.html
+++ b/_layouts/ontology_detail.html
@@ -3,371 +3,369 @@ layout: default
 ---
 
 <div class="row">
-    <h1>
-        {% if page.depicted_by %}
-        <img alt="logo" src="{{page.depicted_by}}" style="max-height: 1em"/>
-        {% endif %} {{ page.title }}
-    </h1>
-    <p>{{page.description}}</p>
+  <h1>
+    {% if page.depicted_by %}
+    <img alt="logo" src="{{page.depicted_by}}" style="max-height: 1em" />
+    {% endif %} {{ page.title }}
+  </h1>
+  <p>{{page.description}}</p>
 </div>
 
 {% if page.is_obsolete %}
 <div>
-    <div class="alert alert-danger" role="alert">
-        This ontology is deprecated!
-    </div>
-    {% for repl in page.replaced_by %}
-    <div class="alert alert-info" role="alert">
-        Consider using: <a href="{{repl}}.html">{{repl}}</a>
-    </div>
-    {% endfor %}
+  <div class="alert alert-danger" role="alert">
+    This ontology is deprecated!
+  </div>
+  {% for repl in page.replaced_by %}
+  <div class="alert alert-info" role="alert">
+    Consider using: <a href="{{repl}}.html">{{repl}}</a>
+  </div>
+  {% endfor %}
 </div>
 {% endif %} {% if page.activity_status == "inactive" %}{% unless
 page.is_obsolete %}
 <div>
-    <div class="alert alert-warning" role="alert">
-        This ontology is inactive. For more information see
-        <a href="/docs/OntologyStatus.html">here</a>.
-    </div>
+  <div class="alert alert-warning" role="alert">
+    This ontology is inactive. For more information see
+    <a href="/docs/OntologyStatus.html">here</a>.
+  </div>
 </div>
 {% endunless %}{% endif %} {% if page.activity_status == "orphaned" %}{% unless
 page.is_obsolete %}
 <div>
-    <div class="alert alert-warning" role="alert">
-        This ontology is orphaned. For more information see
-        <a href="/docs/OntologyStatus.html">here</a>.
-    </div>
+  <div class="alert alert-warning" role="alert">
+    This ontology is orphaned. For more information see
+    <a href="/docs/OntologyStatus.html">here</a>.
+  </div>
 </div>
 {% endunless %}{% endif %} {% if page.preferredPrefix %} {% assign upperPrefix =
 page.preferredPrefix | upcase %} {% if upperPrefix != page.preferredPrefix %}
 <div>
-    <div class="alert alert-info" role="alert">
-        This ontology uses a mixed-case prefix. Identifiers and URIs should use: "{{
-        page.preferredPrefix }}".
-    </div>
+  <div class="alert alert-info" role="alert">
+    This ontology uses a mixed-case prefix. Identifiers and URIs should use: "{{
+    page.preferredPrefix }}".
+  </div>
 </div>
 {% endif %} {% endif %}
 
 <div class="row">
-    <div class="col-md-8" style="padding-left: 0">
-        {% assign stripped_content_size = content | strip | size %}
-        {% if stripped_content_size > 0 %}
-        <div class="panel panel-default">
-            <div class="panel-body">
-                {{ content }}
-            </div>
-        </div>
-        {% endif %}
+  <div class="col-md-8" style="padding-left: 0">
+    {% assign stripped_content_size = content | strip | size %} {% if
+    stripped_content_size > 0 %}
+    <div class="panel panel-default">
+      <div class="panel-body">{{ content }}</div>
+    </div>
+    {% endif %}
 
-        <div class="panel panel-default">
-            <div class="panel-heading">
-                <h3 class="panel-title">Badges and Buttons</h3>
-            </div>
-            {% if page.repository and page.repository contains "https://github.com/" %}
-            <div class="panel-body">
-                <a href="{{ page.repository }}">
-                    <img
-                            alt="GitHub Repo stars"
-                            src="https://img.shields.io/github/stars/{{ page.repository | remove: 'https://github.com/' }}"
-                    />
-                    <img
-                            alt="GitHub contributors"
-                            src="https://img.shields.io/github/contributors/{{ page.repository | remove: 'https://github.com/' }}"
-                    />
-                    <img
-                            alt="GitHub last commit"
-                            src="https://img.shields.io/github/last-commit/{{ page.repository | remove: 'https://github.com/' }}"
-                    />
-                    <!--<img alt="GitHub issues" src="https://img.shields.io/github/issues/{{ page.repository | remove: 'https://github.com/' }}" />-->
-                </a>
-            </div>
-            {% endif %}
-            {% if page.twitter %}
-            <div class="panel-body">
-                <a href="https://twitter.com/{{ page.twitter }}">
-                    <img
-                            alt="Twitter Follow"
-                            src="https://img.shields.io/twitter/follow/{{ page.twitter }}?style=social"
-                    />
-                </a>
-            </div>
-            {% endif %}
-            <div class="panel-body">
-                <!-- TODO: each ontology should configure which browsers to be exposed in -->
-                <a href="https://ontobee.org/browser/index.php?o={{page.id}}">
-                    <button type="button" class="btn btn-default">OntoBee</button>
-                </a>
-                {% if page.aberowl_id %}
-                <a href="http://aber-owl.net/ontology/{{page.aberowl_id | upcase}}">
-                    <button type="button" class="btn btn-default">AberOWL</button>
-                </a>
-                {% else %}
-                <a href="http://aber-owl.net/ontology/{{page.id | upcase}}">
-                    <button type="button" class="btn btn-default">AberOWL</button>
-                </a>
-                {% endif %}
-                <a href="http://www.ebi.ac.uk/ols/ontologies/{{page.id}}">
-                    <button type="button" class="btn btn-default">OLS</button>
-                </a>
-                {% for b in page.browsers %}
-                <a href="{{b.url}}">
-                    <button type="button" class="btn btn-default">{{b.label}}</button>
-                </a>
-                {% endfor %}
-                <a href="https://bioregistry.io/metaregistry/obofoundry/{{page.id}}">
-                    <button type="button" class="btn btn-default">Bioregistry</button>
-                </a>
-            </div>
-        </div>
-
-        <div class="panel panel-default">
-            <div class="panel-heading">
-                <h3 class="panel-title">Products</h3>
-            </div>
-            <table class="table table-striped">
-                <tbody>
-                {% for p in page.products %}
-                <tr>
-                    <td>
-                        <a href="http://purl.obolibrary.org/obo/{{p.id}}">{{p.id}}</a>
-                    </td>
-                    <td>{{p.title}}</td>
-                    <td>
-                        {{p.description}} {% if p.page %}
-                        <a href="{{p.page}}"> [page]</a>
-                        {% endif %}
-                    </td>
-                </tr>
-                {% endfor %}
-                </tbody>
-            </table>
-        </div>
-        {% if page.usages %}
-        <div class="panel panel-default">
-            <div class="panel-heading">
-                <h3 class="panel-title">Usages</h3>
-            </div>
-            <div class="list-group">
-                {% for p in page.usages %}
-                <div class="list-group-item">
-                    <dl class="dl-horizontal" style="margin-bottom: 0">
-                        <dt>User</dt>
-                        <dd><a href="{{p.user}}">{{p.user}}</a></dd>
-                        <dt>Description</dt>
-                        <dd>{{p.description}}</dd>
-                        {% if p.type %}
-                        <dt>Type</dt>
-                        <dd>{{p.type}}</dd>
-                        {% endif %} {% if p.seeAlso %}
-                        <dt>See also</dt>
-                        <dd><a href="{{p.seeAlso}}">{{p.seeAlso}}</a></dd>
-                        {% endif %} {% if p.examples %}
-                        <dt>Examples</dt>
-                        {% for example in p.examples %}
-                        <dd><a href="{{example.url}}">{{example.description}}</a></dd>
-                        {% endfor %} {% endif %} {% if p.publications %}
-                        <dt>Publications</dt>
-                        <dd>
-                            <ul style="padding-left: 20px">
-                                {% for publication in p.publications %}
-                                <li><a href="{{publication.id}}">{{publication.title}}</a></li>
-                                {% endfor %}
-                            </ul>
-                        </dd>
-                        {% endif %}
-                    </dl>
-                </div>
-                {% endfor %}
-            </div>
-        </div>
+    <div class="panel panel-default">
+      <div class="panel-heading">
+        <h3 class="panel-title">Badges and Buttons</h3>
+      </div>
+      {% if page.repository and page.repository contains "https://github.com/"
+      %}
+      <div class="panel-body">
+        <a href="{{ page.repository }}">
+          <img
+            alt="GitHub Repo stars"
+            src="https://img.shields.io/github/stars/{{ page.repository | remove: 'https://github.com/' }}"
+          />
+          <img
+            alt="GitHub contributors"
+            src="https://img.shields.io/github/contributors/{{ page.repository | remove: 'https://github.com/' }}"
+          />
+          <img
+            alt="GitHub last commit"
+            src="https://img.shields.io/github/last-commit/{{ page.repository | remove: 'https://github.com/' }}"
+          />
+          <!--<img alt="GitHub issues" src="https://img.shields.io/github/issues/{{ page.repository | remove: 'https://github.com/' }}" />-->
+        </a>
+      </div>
+      {% endif %} {% if page.twitter %}
+      <div class="panel-body">
+        <a href="https://twitter.com/{{ page.twitter }}">
+          <img
+            alt="Twitter Follow"
+            src="https://img.shields.io/twitter/follow/{{ page.twitter }}?style=social"
+          />
+        </a>
+      </div>
+      {% endif %}
+      <div class="panel-body">
+        <!-- TODO: each ontology should configure which browsers to be exposed in -->
+        <a href="https://ontobee.org/browser/index.php?o={{page.id}}">
+          <button type="button" class="btn btn-default">OntoBee</button>
+        </a>
+        {% if page.aberowl_id %}
+        <a href="http://aber-owl.net/ontology/{{page.aberowl_id | upcase}}">
+          <button type="button" class="btn btn-default">AberOWL</button>
+        </a>
+        {% else %}
+        <a href="http://aber-owl.net/ontology/{{page.id | upcase}}">
+          <button type="button" class="btn btn-default">AberOWL</button>
+        </a>
         {% endif %}
+        <a href="http://www.ebi.ac.uk/ols/ontologies/{{page.id}}">
+          <button type="button" class="btn btn-default">OLS</button>
+        </a>
+        {% for b in page.browsers %}
+        <a href="{{b.url}}">
+          <button type="button" class="btn btn-default">{{b.label}}</button>
+        </a>
+        {% endfor %}
+        <a href="https://bioregistry.io/metaregistry/obofoundry/{{page.id}}">
+          <button type="button" class="btn btn-default">Bioregistry</button>
+        </a>
+      </div>
     </div>
 
-    <div class="col-md-4" style="padding-right: 0">
-        <dl class="dl-horizontal" style="margin-left: 0">
-            <dt>
-                ID Space
-                <span data-toggle="tooltip" title="ID prefix" data-html="true"> </span>
-            </dt>
+    <div class="panel panel-default">
+      <div class="panel-heading">
+        <h3 class="panel-title">Products</h3>
+      </div>
+      <table class="table table-striped">
+        <tbody>
+          {% for p in page.products %}
+          <tr>
+            <td>
+              <a href="http://purl.obolibrary.org/obo/{{p.id}}">{{p.id}}</a>
+            </td>
+            <td>{{p.title}}</td>
+            <td>
+              {{p.description}} {% if p.page %}
+              <a href="{{p.page}}"> [page]</a>
+              {% endif %}
+            </td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+    {% if page.usages %}
+    <div class="panel panel-default">
+      <div class="panel-heading">
+        <h3 class="panel-title">Usages</h3>
+      </div>
+      <div class="list-group">
+        {% for p in page.usages %}
+        <div class="list-group-item">
+          <dl class="dl-horizontal" style="margin-bottom: 0">
+            <dt>User</dt>
+            <dd><a href="{{p.user}}">{{p.user}}</a></dd>
+            <dt>Description</dt>
+            <dd>{{p.description}}</dd>
+            {% if p.type %}
+            <dt>Type</dt>
+            <dd>{{p.type}}</dd>
+            {% endif %} {% if p.seeAlso %}
+            <dt>See also</dt>
+            <dd><a href="{{p.seeAlso}}">{{p.seeAlso}}</a></dd>
+            {% endif %} {% if p.examples %}
+            <dt>Examples</dt>
+            {% for example in p.examples %}
+            <dd><a href="{{example.url}}">{{example.description}}</a></dd>
+            {% endfor %} {% endif %} {% if p.publications %}
+            <dt>Publications</dt>
             <dd>
-                <a href="http://purl.obolibrary.org/obo/{{page.id}}/">{{page.id}}</a>
-            </dd>
-
-            <dt>PURL</dt>
-            <dd>
-                <a href="http://purl.obolibrary.org/obo/{{page.id}}.owl"
-                >http://purl.obolibrary.org/obo/{{page.id}}.owl</a
-                >
-            </dd>
-
-            <dt>License</dt>
-            <dd>
-                {% if page.license %}
-                <a href="{{page.license.url}}">{{page.license.label}}</a>
-                {% if page.license.alert %}
-                <div class="alert alert-danger" role="alert">
-          <span
-                  class="glyphicon glyphicon-exclamation-sign"
-                  aria-hidden="true"
-          ></span>
-                    <span class="sr-only">Warning:</span>
-                    {{page.license.alert}}
-                </div>
-                {% endif %} {% else %}
-                <div class="alert alert-danger" role="alert">
-          <span
-                  class="glyphicon glyphicon-exclamation-sign"
-                  aria-hidden="true"
-          ></span>
-                    <span class="sr-only">Warning:</span>
-                    Not entered
-                </div>
-                {% endif %}
-            </dd>
-
-            <dt>Homepage</dt>
-            <dd>
-                <a href="{{page.homepage}}">{{page.homepage}}</a>
-            </dd>
-            {% for p in page.page %}
-            <dd>
-                <a href="{{p}}">{{p}}</a>
-            </dd>
-            {% endfor %} {% if page.biosharing %}
-            <dd>
-                <a href="{{page.biosharing}}">{{page.biosharing}}</a>
+              <ul style="padding-left: 20px">
+                {% for publication in p.publications %}
+                <li><a href="{{publication.id}}">{{publication.title}}</a></li>
+                {% endfor %}
+              </ul>
             </dd>
             {% endif %}
-
-            <dt>Contact</dt>
-            <dd>
-                <a href="mailto:{{page.contact.email}}">{{page.contact.label}}</a>
-            </dd>
-
-            <dt>Trackers</dt>
-            <dd>
-                <a href="{{page.tracker}}">{{page.tracker}}</a>
-            </dd>
-
-            <dt>Domain</dt>
-            <dd>
-                <a href="/domain/{{page.domain}}.html">{{page.domain}}</a>
-            </dd>
-
-            {% if page.mailing_list %}
-            <dt>Mail List</dt>
-            <dd>
-                <a href="{{page.mailing_list}}">{{page.mailing_list}}</a>
-            </dd>
-            {% endif %} {% if page.taxon %}
-            <dt>Taxon</dt>
-            <dd>
-                <a href="http://amigo.geneontology.org/amigo/term/{{page.taxon.id}}"
-                >{{page.taxon.label}}</a
-                >
-            </dd>
-            {% endif %} {% if page.exampleClass %}
-            <dt>Example</dt>
-            <dd>
-                <a href="http://purl.obolibrary.org/obo/{{page.exampleClass}}"
-                >{{page.exampleClass}}</a
-                >
-            </dd>
-            {% endif %} {% if page.publications %}
-            <dt>Cite</dt>
-            {% for p in page.publications %}
-            <dd>
-                <small><a href="{{p.id}}">{{p.title}}</a></small>
-            </dd>
-            {% endfor %} {% endif %} {% if page.funded_by %}
-            <dt>Funding</dt>
-            {% for x in page.funded_by %}
-            <dd>{{x}}</dd>
-            {% endfor %} {% endif %} {% if page.used_by %}
-            <dt>Used by</dt>
-            {% for x in page.used_by %}
-            <dd>
-                <a href="{{x.url}}">{{x.label}}</a>
-            </dd>
-            {% endfor %} {% endif %} {% if page.dependencies %}
-            <dt>Dependencies</dt>
-            {% for x in page.dependencies %}
-            <dd>
-                <a href="{{x.id}}">{{x.id}}</a>
-            </dd>
-            {% endfor %} {% endif %} {% if page.jobs %}
-            <dt>Jobs</dt>
-            {% for p in page.jobs %}
-            <dd>
-                {% if p.type == "travis-cl" or p.id contains "travis" %}
-                <a href="{{p.id}}">
-                    <img alt="Build Status" src="{{p.id}}.svg?branch=master"/>
-                </a>
-                {% else %}
-                <a href="{{p.id}}">{{p.type}}</a>
-                {% endif %}
-            </dd>
-            {% endfor %} {% endif %} {% if page.review.date and page.review.document
-            %}
-            <dt>OBO Review</dt>
-            <dd>
-                {{page.review.date}}
-                <a href="{{page.review.document.link}}"
-                >{{page.review.document.label}}</a
-                >
-            </dd>
-            <dd>{% endif %}</dd>
-        </dl>
-
-        <div class="btn-group pull-right" role="group" aria-label="Source">
-            <a
-                    href="https://github.com/OBOFoundry/OBOFoundry.github.io/blob/master/ontology/{{page.id}}.md"
-            >
-                <button
-                        type="button"
-                        data-toggle="tooltip"
-                        title="See FAQ entry: How is metadata stored?"
-                        data-html="true"
-                        class="btn btn-default"
-                >
-                    View
-                </button>
-            </a>
-            <a
-                    href="https://github.com/OBOFoundry/OBOFoundry.github.io/edit/master/ontology/{{page.id}}.md"
-            >
-                <button
-                        type="button"
-                        data-toggle="tooltip"
-                        title="See FAQ entry: How I do edit my metadata?"
-                        data-html="true"
-                        class="btn btn-default"
-                >
-                    Edit
-                </button>
-            </a>
-            <a
-                    href="https://github.com/OBOFoundry/purl.obolibrary.org/blob/master/config/{{page.id}}.yml"
-            >
-                <button
-                        type="button"
-                        data-toggle="tooltip"
-                        title="See FAQ entry: How I do edit my PURL?"
-                        data-html="true"
-                        class="btn btn-default"
-                >
-                    PURL
-                </button>
-            </a>
-            <div>
-                Generated by:
-                <a href="{{site.repo_src}}_layouts/ontology_detail.html"
-                >_layouts/ontology_detail.html</a
-                ><br/>
-                See
-                <a href="/faq/how-do-i-edit-metadata.html">metadata guide</a>
-            </div>
-            <!-- <button type="button" class="btn btn-default">Help</button> -->
+          </dl>
         </div>
+        {% endfor %}
+      </div>
     </div>
+    {% endif %}
+  </div>
+
+  <div class="col-md-4" style="padding-right: 0">
+    <dl class="dl-horizontal" style="margin-left: 0">
+      <dt>
+        ID Space
+        <span data-toggle="tooltip" title="ID prefix" data-html="true"> </span>
+      </dt>
+      <dd>
+        <a href="http://purl.obolibrary.org/obo/{{page.id}}/">{{page.id}}</a>
+      </dd>
+
+      <dt>PURL</dt>
+      <dd>
+        <a href="http://purl.obolibrary.org/obo/{{page.id}}.owl"
+          >http://purl.obolibrary.org/obo/{{page.id}}.owl</a
+        >
+      </dd>
+
+      <dt>License</dt>
+      <dd>
+        {% if page.license %}
+        <a href="{{page.license.url}}">{{page.license.label}}</a>
+        {% if page.license.alert %}
+        <div class="alert alert-danger" role="alert">
+          <span
+            class="glyphicon glyphicon-exclamation-sign"
+            aria-hidden="true"
+          ></span>
+          <span class="sr-only">Warning:</span>
+          {{page.license.alert}}
+        </div>
+        {% endif %} {% else %}
+        <div class="alert alert-danger" role="alert">
+          <span
+            class="glyphicon glyphicon-exclamation-sign"
+            aria-hidden="true"
+          ></span>
+          <span class="sr-only">Warning:</span>
+          Not entered
+        </div>
+        {% endif %}
+      </dd>
+
+      <dt>Homepage</dt>
+      <dd>
+        <a href="{{page.homepage}}">{{page.homepage}}</a>
+      </dd>
+      {% for p in page.page %}
+      <dd>
+        <a href="{{p}}">{{p}}</a>
+      </dd>
+      {% endfor %} {% if page.biosharing %}
+      <dd>
+        <a href="{{page.biosharing}}">{{page.biosharing}}</a>
+      </dd>
+      {% endif %}
+
+      <dt>Contact</dt>
+      <dd>
+        <a href="mailto:{{page.contact.email}}">{{page.contact.label}}</a>
+      </dd>
+
+      <dt>Trackers</dt>
+      <dd>
+        <a href="{{page.tracker}}">{{page.tracker}}</a>
+      </dd>
+
+      <dt>Domain</dt>
+      <dd>
+        <a href="/domain/{{page.domain}}.html">{{page.domain}}</a>
+      </dd>
+
+      {% if page.mailing_list %}
+      <dt>Mail List</dt>
+      <dd>
+        <a href="{{page.mailing_list}}">{{page.mailing_list}}</a>
+      </dd>
+      {% endif %} {% if page.taxon %}
+      <dt>Taxon</dt>
+      <dd>
+        <a href="http://amigo.geneontology.org/amigo/term/{{page.taxon.id}}"
+          >{{page.taxon.label}}</a
+        >
+      </dd>
+      {% endif %} {% if page.exampleClass %}
+      <dt>Example</dt>
+      <dd>
+        <a href="http://purl.obolibrary.org/obo/{{page.exampleClass}}"
+          >{{page.exampleClass}}</a
+        >
+      </dd>
+      {% endif %} {% if page.publications %}
+      <dt>Cite</dt>
+      {% for p in page.publications %}
+      <dd>
+        <small><a href="{{p.id}}">{{p.title}}</a></small>
+      </dd>
+      {% endfor %} {% endif %} {% if page.funded_by %}
+      <dt>Funding</dt>
+      {% for x in page.funded_by %}
+      <dd>{{x}}</dd>
+      {% endfor %} {% endif %} {% if page.used_by %}
+      <dt>Used by</dt>
+      {% for x in page.used_by %}
+      <dd>
+        <a href="{{x.url}}">{{x.label}}</a>
+      </dd>
+      {% endfor %} {% endif %} {% if page.dependencies %}
+      <dt>Dependencies</dt>
+      {% for x in page.dependencies %}
+      <dd>
+        <a href="{{x.id}}">{{x.id}}</a>
+      </dd>
+      {% endfor %} {% endif %} {% if page.jobs %}
+      <dt>Jobs</dt>
+      {% for p in page.jobs %}
+      <dd>
+        {% if p.type == "travis-cl" or p.id contains "travis" %}
+        <a href="{{p.id}}">
+          <img alt="Build Status" src="{{p.id}}.svg?branch=master" />
+        </a>
+        {% else %}
+        <a href="{{p.id}}">{{p.type}}</a>
+        {% endif %}
+      </dd>
+      {% endfor %} {% endif %} {% if page.review.date and page.review.document
+      %}
+      <dt>OBO Review</dt>
+      <dd>
+        {{page.review.date}}
+        <a href="{{page.review.document.link}}"
+          >{{page.review.document.label}}</a
+        >
+      </dd>
+      <dd>{% endif %}</dd>
+    </dl>
+
+    <div class="btn-group pull-right" role="group" aria-label="Source">
+      <a
+        href="https://github.com/OBOFoundry/OBOFoundry.github.io/blob/master/ontology/{{page.id}}.md"
+      >
+        <button
+          type="button"
+          data-toggle="tooltip"
+          title="See FAQ entry: How is metadata stored?"
+          data-html="true"
+          class="btn btn-default"
+        >
+          View
+        </button>
+      </a>
+      <a
+        href="https://github.com/OBOFoundry/OBOFoundry.github.io/edit/master/ontology/{{page.id}}.md"
+      >
+        <button
+          type="button"
+          data-toggle="tooltip"
+          title="See FAQ entry: How I do edit my metadata?"
+          data-html="true"
+          class="btn btn-default"
+        >
+          Edit
+        </button>
+      </a>
+      <a
+        href="https://github.com/OBOFoundry/purl.obolibrary.org/blob/master/config/{{page.id}}.yml"
+      >
+        <button
+          type="button"
+          data-toggle="tooltip"
+          title="See FAQ entry: How I do edit my PURL?"
+          data-html="true"
+          class="btn btn-default"
+        >
+          PURL
+        </button>
+      </a>
+      <div>
+        Generated by:
+        <a href="{{site.repo_src}}_layouts/ontology_detail.html"
+          >_layouts/ontology_detail.html</a
+        ><br />
+        See
+        <a href="/faq/how-do-i-edit-metadata.html">metadata guide</a>
+      </div>
+      <!-- <button type="button" class="btn btn-default">Help</button> -->
+    </div>
+  </div>
 </div>

--- a/_layouts/ontology_detail.html
+++ b/_layouts/ontology_detail.html
@@ -12,7 +12,7 @@ layout: default
 </div>
 
 {% if page.is_obsolete %}
-<div>
+<div class="row">
   <div class="alert alert-danger" role="alert">
     This ontology is deprecated!
   </div>
@@ -24,7 +24,7 @@ layout: default
 </div>
 {% endif %} {% if page.activity_status == "inactive" %}{% unless
 page.is_obsolete %}
-<div>
+<div class="row">
   <div class="alert alert-warning" role="alert">
     This ontology is inactive. For more information see
     <a href="/docs/OntologyStatus.html">here</a>.
@@ -32,7 +32,7 @@ page.is_obsolete %}
 </div>
 {% endunless %}{% endif %} {% if page.activity_status == "orphaned" %}{% unless
 page.is_obsolete %}
-<div>
+<div class="row">
   <div class="alert alert-warning" role="alert">
     This ontology is orphaned. For more information see
     <a href="/docs/OntologyStatus.html">here</a>.
@@ -40,7 +40,7 @@ page.is_obsolete %}
 </div>
 {% endunless %}{% endif %} {% if page.preferredPrefix %} {% assign upperPrefix =
 page.preferredPrefix | upcase %} {% if upperPrefix != page.preferredPrefix %}
-<div>
+<div class="row">
   <div class="alert alert-info" role="alert">
     This ontology uses a mixed-case prefix. Identifiers and URIs should use: "{{
     page.preferredPrefix }}".

--- a/_layouts/ontology_detail.html
+++ b/_layouts/ontology_detail.html
@@ -3,352 +3,370 @@ layout: default
 ---
 
 <div class="row">
-  <h1>
-    {% if page.depicted_by %}
-    <img alt="logo" src="{{page.depicted_by}}" style="max-height: 1em" />
-    {% endif %} {{ page.title }}
-  </h1>
-  <p>{{page.description}}</p>
-  {% if page.repository %} {% if page.repository contains "https://github.com/"
-  %}
-  <p>
-    <a href="{{ page.repository }}">
-      <img
-        alt="GitHub Repo stars"
-        src="https://img.shields.io/github/stars/{{ page.repository | remove: 'https://github.com/' }}"
-      />
-      <img
-        alt="GitHub contributors"
-        src="https://img.shields.io/github/contributors/{{ page.repository | remove: 'https://github.com/' }}"
-      />
-      <img
-        alt="GitHub last commit"
-        src="https://img.shields.io/github/last-commit/{{ page.repository | remove: 'https://github.com/' }}"
-      />
-      <!--<img alt="GitHub issues" src="https://img.shields.io/github/issues/{{ page.repository | remove: 'https://github.com/' }}" />-->
-    </a>
-  </p>
-  {% endif %} {% endif %} {% if page.twitter %}
-  <a href="https://twitter.com/{{ page.twitter }}">
-    <img
-      alt="Twitter Follow"
-      src="https://img.shields.io/twitter/follow/{{ page.twitter }}?style=social"
-    />
-  </a>
-  {% endif %}
+    <h1>
+        {% if page.depicted_by %}
+        <img alt="logo" src="{{page.depicted_by}}" style="max-height: 1em"/>
+        {% endif %} {{ page.title }}
+    </h1>
+    <p>{{page.description}}</p>
 </div>
 
 {% if page.is_obsolete %}
 <div>
-  <div class="alert alert-danger" role="alert">
-    This ontology is deprecated!
-  </div>
-  {% for repl in page.replaced_by %}
-  <div class="alert alert-info" role="alert">
-    Consider using: <a href="{{repl}}.html">{{repl}}</a>
-  </div>
-  {% endfor %}
+    <div class="alert alert-danger" role="alert">
+        This ontology is deprecated!
+    </div>
+    {% for repl in page.replaced_by %}
+    <div class="alert alert-info" role="alert">
+        Consider using: <a href="{{repl}}.html">{{repl}}</a>
+    </div>
+    {% endfor %}
 </div>
 {% endif %} {% if page.activity_status == "inactive" %}{% unless
 page.is_obsolete %}
 <div>
-  <div class="alert alert-warning" role="alert">
-    This ontology is inactive. For more information see
-    <a href="/docs/OntologyStatus.html">here</a>.
-  </div>
+    <div class="alert alert-warning" role="alert">
+        This ontology is inactive. For more information see
+        <a href="/docs/OntologyStatus.html">here</a>.
+    </div>
 </div>
 {% endunless %}{% endif %} {% if page.activity_status == "orphaned" %}{% unless
 page.is_obsolete %}
 <div>
-  <div class="alert alert-warning" role="alert">
-    This ontology is orphaned. For more information see
-    <a href="/docs/OntologyStatus.html">here</a>.
-  </div>
+    <div class="alert alert-warning" role="alert">
+        This ontology is orphaned. For more information see
+        <a href="/docs/OntologyStatus.html">here</a>.
+    </div>
 </div>
 {% endunless %}{% endif %} {% if page.preferredPrefix %} {% assign upperPrefix =
 page.preferredPrefix | upcase %} {% if upperPrefix != page.preferredPrefix %}
 <div>
-  <div class="alert alert-info" role="alert">
-    This ontology uses a mixed-case prefix. Identifiers and URIs should use: "{{
-    page.preferredPrefix }}".
-  </div>
+    <div class="alert alert-info" role="alert">
+        This ontology uses a mixed-case prefix. Identifiers and URIs should use: "{{
+        page.preferredPrefix }}".
+    </div>
 </div>
 {% endif %} {% endif %}
 
 <div class="row">
-  <div class="col-md-8" style="padding-left: 0">
-    <!-- TODO: each ontology should configure which browsers to be exposed in -->
-    <a href="https://ontobee.org/browser/index.php?o={{page.id}}">
-      <button type="button" class="btn btn-default">OntoBee</button>
-    </a>
-    {% if page.aberowl_id %}
-    <a href="http://aber-owl.net/ontology/{{page.aberowl_id | upcase}}">
-      <button type="button" class="btn btn-default">AberOWL</button>
-    </a>
-    {% else %}
-    <a href="http://aber-owl.net/ontology/{{page.id | upcase}}">
-      <button type="button" class="btn btn-default">AberOWL</button>
-    </a>
-    {% endif %}
-    <a href="http://www.ebi.ac.uk/ols/ontologies/{{page.id}}">
-      <button type="button" class="btn btn-default">OLS</button>
-    </a>
-    {% for b in page.browsers %}
-    <a href="{{b.url}}">
-      <button type="button" class="btn btn-default">{{b.label}}</button>
-    </a>
-    {% endfor %}
-    <a href="https://bioregistry.io/metaregistry/obofoundry/{{page.id}}">
-      <button type="button" class="btn btn-default">Bioregistry</button>
-    </a>
-
-    {{ content }}
-
-    <div>
-      <h2>Products</h2>
-      <table class="table">
-        <tbody>
-          {% for p in page.products %}
-          <tr>
-            <td>
-              <a href="http://purl.obolibrary.org/obo/{{p.id}}">{{p.id}}</a>
-            </td>
-            <td>{{p.title}}</td>
-            <td>
-              {{p.description}} {% if p.page %}
-              <a href="{{p.page}}"> [page]</a>
-              {% endif %}
-            </td>
-          </tr>
-          {% endfor %}
-        </tbody>
-      </table>
-    </div>
-    {% if page.usages %}
-    <div>
-      <h2>Usages</h2>
-      {% for p in page.usages %}
-      <dl class="dl-horizontal">
-        <dt>User</dt>
-        <dd><a href="{{p.user}}">{{p.user}}</a></dd>
-        <dt>Description</dt>
-        <dd>{{p.description}}</dd>
-        {% if p.type %}
-        <dt>Type</dt>
-        <dd>{{p.type}}</dd>
-        {% endif %} {% if p.seeAlso %}
-        <dt>See also</dt>
-        <dd><a href="{{p.seeAlso}}">{{p.seeAlso}}</a></dd>
-        {% endif %} {% if p.examples %}
-        <dt>Examples</dt>
-        <dd>
-          <ul style="padding-left: 20px">
-            {% for example in p.examples %}
-            <li><a href="{{example.url}}">{{example.description}}</a></li>
-            {% endfor %}
-          </ul>
-        </dd>
-        {% endif %} {% if p.publications %}
-        <dt>Publications</dt>
-        <dd>
-          <ul style="padding-left: 20px">
-            {% for publication in p.publications %}
-            <li><a href="{{publication.id}}">{{publication.title}}</a></li>
-            {% endfor %}
-          </ul>
-        </dd>
-        {% endif %}
-      </dl>
-      {% endfor %}
-    </div>
-    {% endif %}
-  </div>
-
-  <div class="col-md-4" style="padding-right: 0">
-    <dl class="dl-horizontal" style="margin-left: 0">
-      <dt>
-        ID Space
-        <span data-toggle="tooltip" title="ID prefix" data-html="true"> </span>
-      </dt>
-      <dd>
-        <a href="http://purl.obolibrary.org/obo/{{page.id}}/">{{page.id}}</a>
-      </dd>
-
-      <dt>PURL</dt>
-      <dd>
-        <a href="http://purl.obolibrary.org/obo/{{page.id}}.owl"
-          >http://purl.obolibrary.org/obo/{{page.id}}.owl</a
-        >
-      </dd>
-
-      <dt>License</dt>
-      <dd>
-        {% if page.license %}
-        <a href="{{page.license.url}}">{{page.license.label}}</a>
-        {% if page.license.alert %}
-        <div class="alert alert-danger" role="alert">
-          <span
-            class="glyphicon glyphicon-exclamation-sign"
-            aria-hidden="true"
-          ></span>
-          <span class="sr-only">Warning:</span>
-          {{page.license.alert}}
-        </div>
-        {% endif %} {% else %}
-        <div class="alert alert-danger" role="alert">
-          <span
-            class="glyphicon glyphicon-exclamation-sign"
-            aria-hidden="true"
-          ></span>
-          <span class="sr-only">Warning:</span>
-          Not entered
+    <div class="col-md-8" style="padding-left: 0">
+        {% if content | strip %}
+        <div class="panel panel-default">
+            <div class="panel-body">
+                {{ content }}
+            </div>
         </div>
         {% endif %}
-      </dd>
 
-      <dt>Homepage</dt>
-      <dd>
-        <a href="{{page.homepage}}">{{page.homepage}}</a>
-      </dd>
-      {% for p in page.page %}
-      <dd>
-        <a href="{{p}}">{{p}}</a>
-      </dd>
-      {% endfor %} {% if page.biosharing %}
-      <dd>
-        <a href="{{page.biosharing}}">{{page.biosharing}}</a>
-      </dd>
-      {% endif %}
+        <div class="panel panel-default">
+            <div class="panel-heading">
+                <h3 class="panel-title">Badges and Buttons</h3>
+            </div>
+            {% if page.repository and page.repository contains "https://github.com/" %}
+            <div class="panel-body">
+                <a href="{{ page.repository }}">
+                    <img
+                            alt="GitHub Repo stars"
+                            src="https://img.shields.io/github/stars/{{ page.repository | remove: 'https://github.com/' }}"
+                    />
+                    <img
+                            alt="GitHub contributors"
+                            src="https://img.shields.io/github/contributors/{{ page.repository | remove: 'https://github.com/' }}"
+                    />
+                    <img
+                            alt="GitHub last commit"
+                            src="https://img.shields.io/github/last-commit/{{ page.repository | remove: 'https://github.com/' }}"
+                    />
+                    <!--<img alt="GitHub issues" src="https://img.shields.io/github/issues/{{ page.repository | remove: 'https://github.com/' }}" />-->
+                </a>
+            </div>
+            {% endif %}
+            {% if page.twitter %}
+            <div class="panel-body">
+                <a href="https://twitter.com/{{ page.twitter }}">
+                    <img
+                            alt="Twitter Follow"
+                            src="https://img.shields.io/twitter/follow/{{ page.twitter }}?style=social"
+                    />
+                </a>
+            </div>
+            {% endif %}
+            <div class="panel-body">
+                <!-- TODO: each ontology should configure which browsers to be exposed in -->
+                <a href="https://ontobee.org/browser/index.php?o={{page.id}}">
+                    <button type="button" class="btn btn-default">OntoBee</button>
+                </a>
+                {% if page.aberowl_id %}
+                <a href="http://aber-owl.net/ontology/{{page.aberowl_id | upcase}}">
+                    <button type="button" class="btn btn-default">AberOWL</button>
+                </a>
+                {% else %}
+                <a href="http://aber-owl.net/ontology/{{page.id | upcase}}">
+                    <button type="button" class="btn btn-default">AberOWL</button>
+                </a>
+                {% endif %}
+                <a href="http://www.ebi.ac.uk/ols/ontologies/{{page.id}}">
+                    <button type="button" class="btn btn-default">OLS</button>
+                </a>
+                {% for b in page.browsers %}
+                <a href="{{b.url}}">
+                    <button type="button" class="btn btn-default">{{b.label}}</button>
+                </a>
+                {% endfor %}
+                <a href="https://bioregistry.io/metaregistry/obofoundry/{{page.id}}">
+                    <button type="button" class="btn btn-default">Bioregistry</button>
+                </a>
+            </div>
+        </div>
 
-      <dt>Contact</dt>
-      <dd>
-        <a href="mailto:{{page.contact.email}}">{{page.contact.label}}</a>
-      </dd>
-
-      <dt>Trackers</dt>
-      <dd>
-        <a href="{{page.tracker}}">{{page.tracker}}</a>
-      </dd>
-
-      <dt>Domain</dt>
-      <dd>
-        <a href="/domain/{{page.domain}}.html">{{page.domain}}</a>
-      </dd>
-
-      {% if page.mailing_list %}
-      <dt>Mail List</dt>
-      <dd>
-        <a href="{{page.mailing_list}}">{{page.mailing_list}}</a>
-      </dd>
-      {% endif %} {% if page.taxon %}
-      <dt>Taxon</dt>
-      <dd>
-        <a href="http://amigo.geneontology.org/amigo/term/{{page.taxon.id}}"
-          >{{page.taxon.label}}</a
-        >
-      </dd>
-      {% endif %} {% if page.exampleClass %}
-      <dt>Example</dt>
-      <dd>
-        <a href="http://purl.obolibrary.org/obo/{{page.exampleClass}}"
-          >{{page.exampleClass}}</a
-        >
-      </dd>
-      {% endif %} {% if page.publications %}
-      <dt>Cite</dt>
-      {% for p in page.publications %}
-      <dd>
-        <small><a href="{{p.id}}">{{p.title}}</a></small>
-      </dd>
-      {% endfor %} {% endif %} {% if page.funded_by %}
-      <dt>Funding</dt>
-      {% for x in page.funded_by %}
-      <dd>{{x}}</dd>
-      {% endfor %} {% endif %} {% if page.used_by %}
-      <dt>Used by</dt>
-      {% for x in page.used_by %}
-      <dd>
-        <a href="{{x.url}}">{{x.label}}</a>
-      </dd>
-      {% endfor %} {% endif %} {% if page.dependencies %}
-      <dt>Dependencies</dt>
-      {% for x in page.dependencies %}
-      <dd>
-        <a href="{{x.id}}">{{x.id}}</a>
-      </dd>
-      {% endfor %} {% endif %} {% if page.jobs %}
-      <dt>Jobs</dt>
-      {% for p in page.jobs %}
-      <dd>
-        {% if p.type == "travis-cl" or p.id contains "travis" %}
-        <a href="{{p.id}}">
-          <img alt="Build Status" src="{{p.id}}.svg?branch=master" />
-        </a>
-        {% else %}
-        <a href="{{p.id}}">{{p.type}}</a>
+        <div class="panel panel-default">
+            <div class="panel-heading">
+                <h3 class="panel-title">Products</h3>
+            </div>
+            <table class="table table-striped">
+                <tbody>
+                {% for p in page.products %}
+                <tr>
+                    <td>
+                        <a href="http://purl.obolibrary.org/obo/{{p.id}}">{{p.id}}</a>
+                    </td>
+                    <td>{{p.title}}</td>
+                    <td>
+                        {{p.description}} {% if p.page %}
+                        <a href="{{p.page}}"> [page]</a>
+                        {% endif %}
+                    </td>
+                </tr>
+                {% endfor %}
+                </tbody>
+            </table>
+        </div>
+        {% if page.usages %}
+        <div class="panel panel-default">
+            <div class="panel-heading">
+                <h3 class="panel-title">Usages</h3>
+            </div>
+            <div class="list-group">
+                {% for p in page.usages %}
+                <div class="list-group-item">
+                    <dl class="dl-horizontal" style="margin-bottom: 0">
+                        <dt>User</dt>
+                        <dd><a href="{{p.user}}">{{p.user}}</a></dd>
+                        <dt>Description</dt>
+                        <dd>{{p.description}}</dd>
+                        {% if p.type %}
+                        <dt>Type</dt>
+                        <dd>{{p.type}}</dd>
+                        {% endif %} {% if p.seeAlso %}
+                        <dt>See also</dt>
+                        <dd><a href="{{p.seeAlso}}">{{p.seeAlso}}</a></dd>
+                        {% endif %} {% if p.examples %}
+                        <dt>Examples</dt>
+                        {% for example in p.examples %}
+                        <dd><a href="{{example.url}}">{{example.description}}</a></dd>
+                        {% endfor %} {% endif %} {% if p.publications %}
+                        <dt>Publications</dt>
+                        <dd>
+                            <ul style="padding-left: 20px">
+                                {% for publication in p.publications %}
+                                <li><a href="{{publication.id}}">{{publication.title}}</a></li>
+                                {% endfor %}
+                            </ul>
+                        </dd>
+                        {% endif %}
+                    </dl>
+                </div>
+                {% endfor %}
+            </div>
+        </div>
         {% endif %}
-      </dd>
-      {% endfor %} {% endif %} {% if page.review.date and page.review.document
-      %}
-      <dt>OBO Review</dt>
-      <dd>
-        {{page.review.date}}
-        <a href="{{page.review.document.link}}"
-          >{{page.review.document.label}}</a
-        >
-      </dd>
-      <dd>{% endif %}</dd>
-    </dl>
-
-    <div class="btn-group" role="group" aria-label="Source">
-      <a
-        href="https://github.com/OBOFoundry/OBOFoundry.github.io/blob/master/ontology/{{page.id}}.md"
-      >
-        <button
-          type="button"
-          data-toggle="tooltip"
-          title="See FAQ entry: How is metadata stored?"
-          data-html="true"
-          class="btn btn-default"
-        >
-          View
-        </button>
-      </a>
-      <a
-        href="https://github.com/OBOFoundry/OBOFoundry.github.io/edit/master/ontology/{{page.id}}.md"
-      >
-        <button
-          type="button"
-          data-toggle="tooltip"
-          title="See FAQ entry: How I do edit my metadata?"
-          data-html="true"
-          class="btn btn-default"
-        >
-          Edit
-        </button>
-      </a>
-      <a
-        href="https://github.com/OBOFoundry/purl.obolibrary.org/blob/master/config/{{page.id}}.yml"
-      >
-        <button
-          type="button"
-          data-toggle="tooltip"
-          title="See FAQ entry: How I do edit my PURL?"
-          data-html="true"
-          class="btn btn-default"
-        >
-          PURL
-        </button>
-      </a>
-      <div>
-        Generated by:
-        <a href="{{site.repo_src}}_layouts/ontology_detail.html"
-          >_layouts/ontology_detail.html</a
-        ><br />
-        See
-        <a href="/faq/how-do-i-edit-metadata.html">metadata guide</a>
-      </div>
-      <!-- <button type="button" class="btn btn-default">Help</button> -->
     </div>
-  </div>
+
+    <div class="col-md-4" style="padding-right: 0">
+        <dl class="dl-horizontal" style="margin-left: 0">
+            <dt>
+                ID Space
+                <span data-toggle="tooltip" title="ID prefix" data-html="true"> </span>
+            </dt>
+            <dd>
+                <a href="http://purl.obolibrary.org/obo/{{page.id}}/">{{page.id}}</a>
+            </dd>
+
+            <dt>PURL</dt>
+            <dd>
+                <a href="http://purl.obolibrary.org/obo/{{page.id}}.owl"
+                >http://purl.obolibrary.org/obo/{{page.id}}.owl</a
+                >
+            </dd>
+
+            <dt>License</dt>
+            <dd>
+                {% if page.license %}
+                <a href="{{page.license.url}}">{{page.license.label}}</a>
+                {% if page.license.alert %}
+                <div class="alert alert-danger" role="alert">
+          <span
+                  class="glyphicon glyphicon-exclamation-sign"
+                  aria-hidden="true"
+          ></span>
+                    <span class="sr-only">Warning:</span>
+                    {{page.license.alert}}
+                </div>
+                {% endif %} {% else %}
+                <div class="alert alert-danger" role="alert">
+          <span
+                  class="glyphicon glyphicon-exclamation-sign"
+                  aria-hidden="true"
+          ></span>
+                    <span class="sr-only">Warning:</span>
+                    Not entered
+                </div>
+                {% endif %}
+            </dd>
+
+            <dt>Homepage</dt>
+            <dd>
+                <a href="{{page.homepage}}">{{page.homepage}}</a>
+            </dd>
+            {% for p in page.page %}
+            <dd>
+                <a href="{{p}}">{{p}}</a>
+            </dd>
+            {% endfor %} {% if page.biosharing %}
+            <dd>
+                <a href="{{page.biosharing}}">{{page.biosharing}}</a>
+            </dd>
+            {% endif %}
+
+            <dt>Contact</dt>
+            <dd>
+                <a href="mailto:{{page.contact.email}}">{{page.contact.label}}</a>
+            </dd>
+
+            <dt>Trackers</dt>
+            <dd>
+                <a href="{{page.tracker}}">{{page.tracker}}</a>
+            </dd>
+
+            <dt>Domain</dt>
+            <dd>
+                <a href="/domain/{{page.domain}}.html">{{page.domain}}</a>
+            </dd>
+
+            {% if page.mailing_list %}
+            <dt>Mail List</dt>
+            <dd>
+                <a href="{{page.mailing_list}}">{{page.mailing_list}}</a>
+            </dd>
+            {% endif %} {% if page.taxon %}
+            <dt>Taxon</dt>
+            <dd>
+                <a href="http://amigo.geneontology.org/amigo/term/{{page.taxon.id}}"
+                >{{page.taxon.label}}</a
+                >
+            </dd>
+            {% endif %} {% if page.exampleClass %}
+            <dt>Example</dt>
+            <dd>
+                <a href="http://purl.obolibrary.org/obo/{{page.exampleClass}}"
+                >{{page.exampleClass}}</a
+                >
+            </dd>
+            {% endif %} {% if page.publications %}
+            <dt>Cite</dt>
+            {% for p in page.publications %}
+            <dd>
+                <small><a href="{{p.id}}">{{p.title}}</a></small>
+            </dd>
+            {% endfor %} {% endif %} {% if page.funded_by %}
+            <dt>Funding</dt>
+            {% for x in page.funded_by %}
+            <dd>{{x}}</dd>
+            {% endfor %} {% endif %} {% if page.used_by %}
+            <dt>Used by</dt>
+            {% for x in page.used_by %}
+            <dd>
+                <a href="{{x.url}}">{{x.label}}</a>
+            </dd>
+            {% endfor %} {% endif %} {% if page.dependencies %}
+            <dt>Dependencies</dt>
+            {% for x in page.dependencies %}
+            <dd>
+                <a href="{{x.id}}">{{x.id}}</a>
+            </dd>
+            {% endfor %} {% endif %} {% if page.jobs %}
+            <dt>Jobs</dt>
+            {% for p in page.jobs %}
+            <dd>
+                {% if p.type == "travis-cl" or p.id contains "travis" %}
+                <a href="{{p.id}}">
+                    <img alt="Build Status" src="{{p.id}}.svg?branch=master"/>
+                </a>
+                {% else %}
+                <a href="{{p.id}}">{{p.type}}</a>
+                {% endif %}
+            </dd>
+            {% endfor %} {% endif %} {% if page.review.date and page.review.document
+            %}
+            <dt>OBO Review</dt>
+            <dd>
+                {{page.review.date}}
+                <a href="{{page.review.document.link}}"
+                >{{page.review.document.label}}</a
+                >
+            </dd>
+            <dd>{% endif %}</dd>
+        </dl>
+
+        <div class="btn-group" role="group" aria-label="Source">
+            <a
+                    href="https://github.com/OBOFoundry/OBOFoundry.github.io/blob/master/ontology/{{page.id}}.md"
+            >
+                <button
+                        type="button"
+                        data-toggle="tooltip"
+                        title="See FAQ entry: How is metadata stored?"
+                        data-html="true"
+                        class="btn btn-default"
+                >
+                    View
+                </button>
+            </a>
+            <a
+                    href="https://github.com/OBOFoundry/OBOFoundry.github.io/edit/master/ontology/{{page.id}}.md"
+            >
+                <button
+                        type="button"
+                        data-toggle="tooltip"
+                        title="See FAQ entry: How I do edit my metadata?"
+                        data-html="true"
+                        class="btn btn-default"
+                >
+                    Edit
+                </button>
+            </a>
+            <a
+                    href="https://github.com/OBOFoundry/purl.obolibrary.org/blob/master/config/{{page.id}}.yml"
+            >
+                <button
+                        type="button"
+                        data-toggle="tooltip"
+                        title="See FAQ entry: How I do edit my PURL?"
+                        data-html="true"
+                        class="btn btn-default"
+                >
+                    PURL
+                </button>
+            </a>
+            <div>
+                Generated by:
+                <a href="{{site.repo_src}}_layouts/ontology_detail.html"
+                >_layouts/ontology_detail.html</a
+                ><br/>
+                See
+                <a href="/faq/how-do-i-edit-metadata.html">metadata guide</a>
+            </div>
+            <!-- <button type="button" class="btn btn-default">Help</button> -->
+        </div>
+    </div>
 </div>

--- a/_layouts/ontology_detail.html
+++ b/_layouts/ontology_detail.html
@@ -50,7 +50,8 @@ page.preferredPrefix | upcase %} {% if upperPrefix != page.preferredPrefix %}
 
 <div class="row">
     <div class="col-md-8" style="padding-left: 0">
-        {% if content | strip %}
+        {% assign stripped_content_size = content | strip | size %}
+        {% if stripped_content_size > 0 %}
         <div class="panel panel-default">
             <div class="panel-body">
                 {{ content }}

--- a/ontology/mondo.md
+++ b/ontology/mondo.md
@@ -52,6 +52,7 @@ taxon:
   id: NCBITaxon:33208
   label: Metazoa
 tracker: https://github.com/monarch-initiative/mondo/issues
+twitter: MonarchInit
 usages:
 - description: Mondo is used by the Monarch Initiative for disease annotations.
   examples:

--- a/registry/publications.md
+++ b/registry/publications.md
@@ -9,7 +9,7 @@ title: Publications Related to the OBO Foundry
 
 [**OBO Foundry in 2021: operationalizing open data principles to evaluate ontologies**](https://academic.oup.com/database/article/doi/10.1093/database/baab069/6410158) **(2021)**.
 
-Rebecca Jackson, Nicolas Matentzoglu, James A Overton, Randi Vita, James P Balhoff, Pier Luigi Buttigieg, Seth Carbon, Melanie Courtot, Alexander D Diehl, Damion M Dooley, William D Duncan, Nomi L Harris, Melissa A Haendel, Suzanna E Lewis, Darren A Natale, David Osumi-Sutherland, Alan Ruttenberg, Lynn M Schriml, Barry Smith, Christian J Stoeckert Jr., Nicole A Vasilevsky, Ramona L Walls, Jie Zheng, Christopher J Mungall, Bjoern Peters. *Database*, Volume 2021, baab069, https://doi.org/10.1093/database/baab069
+Rebecca Jackson, Nicolas Matentzoglu, James A Overton, Randi Vita, James P Balhoff, Pier Luigi Buttigieg, Seth Carbon, Melanie Courtot, Alexander D Diehl, Damion M Dooley, William D Duncan, Nomi L Harris, Melissa A Haendel, Suzanna E Lewis, Darren A Natale, David Osumi-Sutherland, Alan Ruttenberg, Lynn M Schriml, Barry Smith, Christian J Stoeckert Jr., Nicole A Vasilevsky, Ramona L Walls, Jie Zheng, Christopher J Mungall, Bjoern Peters. _Database_, Volume 2021, baab069, https://doi.org/10.1093/database/baab069
 
 ## Other papers about the OBO Foundry
 
@@ -17,7 +17,7 @@ Rebecca Jackson, Nicolas Matentzoglu, James A Overton, Randi Vita, James P Balho
 
 Barry Smith, Michael Ashburner, Cornelius Rosse, Jonathan Bard, William Bug, Werner Ceusters, Louis J Goldberg, Karen Eilbeck, Amelia Ireland, Christopher J Mungall, The OBI Consortium, Neocles Leontis, Philippe Rocca-Serra, Alan Ruttenberg, Susanna-Assunta Sansone, Richard H Scheuermann, Nigam Shah, Patricia L Whetzel, and Suzanna Lewis
 
-*Nature Biotechnology* **25**, 1251 - 1255 (2007)
+_Nature Biotechnology_ **25**, 1251 - 1255 (2007)
 
 [Google Scholar list of papers citing The OBO Foundry](https://scholar.google.ca/scholar?cites=13806088078865650870&as_sdt=2005&sciodt=0,5&hl=en)
 


### PR DESCRIPTION
This PR updates the layout of the summary page, which has been irking people quite a bit lately. It moves the twitter and social buttons into the right panel while better styling the out-link buttons

<img width="1586" alt="Screen Shot 2022-08-28 at 14 32 44" src="https://user-images.githubusercontent.com/5069736/187074278-04602e0d-12e2-4b69-a871-5806a629bfbc.png">

<img width="1586" alt="Screen Shot 2022-08-28 at 14 32 40" src="https://user-images.githubusercontent.com/5069736/187074288-45700116-b29d-49c4-ae2e-e53a38d46689.png">

<img width="1586" alt="Screen Shot 2022-08-28 at 14 34 18" src="https://user-images.githubusercontent.com/5069736/187074339-b2f0e64b-82fc-46af-bb51-cc1c969f51e6.png">

