### PR TITLE
Add badge for preferred citations

### DIFF
--- a/_layouts/ontology_detail.html
+++ b/_layouts/ontology_detail.html
@@ -93,6 +93,9 @@ page.preferredPrefix | upcase %} {% if upperPrefix != page.preferredPrefix %}
         {% for p in page.publications %}
         <div class="list-group-item">
           <a href="{{p.id}}">{{p.title}}</a>
+          {% if p.preferred %}
+          <span class="badge">Preferred</span>
+          {% endif %}
         </div>
         {% endfor %}
       </div>

--- a/ontology/eco.md
+++ b/ontology/eco.md
@@ -17,7 +17,7 @@ description: An ontology for experimental and other evidence statements.
 domain: investigations
 funded_by:
 - http://www.nsf.gov/awardsearch/showAward?AWD_ID=1458400
-homepage: http://www.evidenceontology.org
+homepage: https://github.com/evidenceontology/evidenceontology/
 jobs:
 - id: https://travis-ci.org/evidenceontology/evidenceontology
   type: travis-ci
@@ -63,5 +63,7 @@ ECO was originally created around the year 2000 to support gene product annotati
 
 ***
 For **advice on requesting new terms**, please see **[the Evidence & Conclusion Ontology wiki](https://github.com/evidenceontology/evidenceontology/wiki/New-term-request-how-to)**.
+
+For **further information** visit the **[Evidence & Conclusion Ontology website](http://www.evidenceontology.org/)**.
 
 This work is made possible by **[award number 1458400](http://www.nsf.gov/awardsearch/showAward?AWD_ID=1458400)** from the **US National Science Foundation's Division of Biological Infrastructure**.

--- a/ontology/eco.md
+++ b/ontology/eco.md
@@ -17,7 +17,7 @@ description: An ontology for experimental and other evidence statements.
 domain: investigations
 funded_by:
 - http://www.nsf.gov/awardsearch/showAward?AWD_ID=1458400
-homepage: https://github.com/evidenceontology/evidenceontology/
+homepage: http://www.evidenceontology.org
 jobs:
 - id: https://travis-ci.org/evidenceontology/evidenceontology
   type: travis-ci
@@ -31,6 +31,7 @@ products:
 publications:
 - id: https://www.ncbi.nlm.nih.gov/pubmed/30407590
   title: 'ECO, the Evidence & Conclusion Ontology: community standard for evidence information.'
+  preferred: true
 - id: https://www.ncbi.nlm.nih.gov/pubmed/25052702
   title: Standardized description of scientific evidence using the Evidence Ontology (ECO)
 repository: https://github.com/evidenceontology/evidenceontology
@@ -62,9 +63,5 @@ ECO was originally created around the year 2000 to support gene product annotati
 
 ***
 For **advice on requesting new terms**, please see **[the Evidence & Conclusion Ontology wiki](https://github.com/evidenceontology/evidenceontology/wiki/New-term-request-how-to)**.
-
-For **further information** visit the **[Evidence & Conclusion Ontology website](http://www.evidenceontology.org/)**.
-
-Please **cite** the following paper: [Giglio M, Tauber R, Nadendla S, Munro J, Olley D, Ball S, Mitraka E, Schriml LM, Gaudet P, Hobbs ET, Erill I, Siegele DA, Hu JC, Mungall C, Chibucos MC. **ECO, the Evidence & Conclusion Ontology: community standard for evidence information**. Nucleic Acids Res. 2019 Jan 8;47(D1):D1186-D1194.](https://www.ncbi.nlm.nih.gov/pubmed/30407590)
 
 This work is made possible by **[award number 1458400](http://www.nsf.gov/awardsearch/showAward?AWD_ID=1458400)** from the **US National Science Foundation's Division of Biological Infrastructure**.

--- a/ontology/fbbt.md
+++ b/ontology/fbbt.md
@@ -37,6 +37,7 @@ products:
 publications:
 - id: https://www.ncbi.nlm.nih.gov/pubmed/24139062
   title: The Drosophila anatomy ontology
+  preferred: true
 - id: https://www.ncbi.nlm.nih.gov/pubmed/22402613
   title: A strategy for building neuroanatomy ontologies
 - id: https://www.ncbi.nlm.nih.gov/pubmed/22180411
@@ -65,8 +66,3 @@ usages:
   user: http://flybase.org
 activity_status: active
 ---
-
-An ontology representing the gross anatomy of Drosophila melanogaster.
-
-FBbt can be cited as:
-_Costa M., Reeve S., Grumbling G., Osumi-Sutherland D._ (2013) The Drosophila anatomy ontology. [Journal of Biomedical Semantics __4__(32).](https://doi.org/10.1186/2041-1480-4-32)

--- a/tests/test_integrity.py
+++ b/tests/test_integrity.py
@@ -84,6 +84,15 @@ class TestIntegrity(unittest.TestCase):
     def test_publications(self):
         """Test publications information."""
         for ontology, data in sorted(self.ontologies.items()):
+            self.assertIn(
+                sum(
+                    publication.get("preferred", False)
+                    for publication in data.get("publications", [])
+                ),
+                {0, 1},
+                msg=f"Only one publication can be marked as preferred for {ontology}.",
+            )
+
             for i, publication in enumerate(data.get("publications", [])):
                 identifier = publication["id"]
                 if ontology == "agro" and identifier.startswith("http://ceur-ws.org/"):

--- a/util/schema/registry_schema.json
+++ b/util/schema/registry_schema.json
@@ -341,6 +341,9 @@
           },
           "title": {
             "type": "string"
+          },
+          "preferred": {
+            "type": "boolean"
           }
         },
         "required": [


### PR DESCRIPTION
This PR adds a "preferred" citation field as suggested in https://github.com/OBOFoundry/OBOFoundry.github.io/pull/2063#issuecomment-1231327188 and adds a nice display badge to match it so we can remove more redundant information from ECO and FBbt. It adds a test to make sure at most only one citation is marked as preferred.

This PR also removes some redundant information from ECO and FBbt that does not affect the overall meaning of the page.

<img width="1341" alt="Screen Shot 2022-08-30 at 11 15 20" src="https://user-images.githubusercontent.com/5069736/187401225-9b789e3c-bc2f-46b8-8c15-00d609e1274d.png">
