### PR TITLE
Amendments to Ontology Acceptance section (details about communicating ontology acceptance, some minor wording/punctuation improvements)

### DIFF
--- a/docs/SOP.md
+++ b/docs/SOP.md
@@ -45,13 +45,13 @@ Are axioms generally highly complex? If so, we should review a handful to ensure
 6. Responsiveness to fixing changes. A willingness to fix any identified issues during the review must be demonstrated. Issues expected to be addressed should be added using GitHub checklist syntax (`- [ ] TODO`) in the GitHub issue. The time limit for addressing these is 2 months; a longer period should be requested if needed.
 
 <a name="OAE"></a> 
-### Ontology Acceptance Email 
+### Ontology Acceptance Notification 
 
-Once a new ontology has been accepted, the following should be used as a template plate for letting them know and what are the next steps they should take.
+Once a new ontology has been accepted, the following should be used as a template for letting them know that, and informing them about the next steps they should take.
 
-"Thank you again for your ontology submission to the OBO Foundry. We are happy to inform you that your ontology (YOURID) has been accepted following discussion in the OBO Operations Committee meeting, DD-MM-YYYY. Before we can add it to the OBO ontology registry you need to complete the following steps.
+"Thank you again for your ontology submission to the OBO Foundry. We are happy to inform you that your ontology (YOURID) has been accepted following discussion in the OBO Operations Committee meeting, YYYY-MM-DD. Before we can add it to the OBO ontology registry you need to complete the following steps.
 
-Create a metadata record for your ontology to be included in the registry
+Create a metadata record for your ontology to be included in the registry:
 1. Create a new file in this directory,  https://github.com/OBOFoundry/OBOFoundry.github.io/tree/master/ontology, called YOURID.md (there is an “Add file” button in the top right).
 2. Obtain the already curated metadata that relates to your ontology from https://github.com/OBOFoundry/obo-nor.github.io/blob/master/dashboard-config.yml (you'll need to scroll down to locate yours; it will have your prefix in the " - id:" field.) 
 3. Create a pull request to add the metadata record. This pull request should include a link to this issue (the New Ontology Request issue).
@@ -60,7 +60,7 @@ Here is an example record for the PATO ontology: https://github.com/OBOFoundry/O
 
 Your metadata will be reviewed and merged by a member of the OBO Foundry Operations Committee. Permissable content for fields is being documented [here](https://obofoundry.org/faq/permissible-metadata-content.html).
 
-Create a PURL registry entry for your ontology.
+Create a PURL registry entry for your ontology:
 1. Go to https://github.com/OBOFoundry/purl.obolibrary.org/tree/master/config, click “Add file” and add a file named YOURID.yml.
 2. Add the desired configuration.
 3. Make a pull request with a link to this issue

--- a/docs/SOP.md
+++ b/docs/SOP.md
@@ -50,7 +50,7 @@ Are axioms generally highly complex? If so, we should review a handful to ensure
 Once a new ontology has been accepted, the following should be used as a template for letting the ontology owner know that, and informing them about the next steps they should take.
 
 The ontology owner should be notified in the ticket and also by email (they were required to supply their email address as part of their new ontology request),
-ccing obo-discuss & obo-operations.
+ccing obo-discuss & obo-operations-committee.
 
 "Thank you again for your ontology submission to the OBO Foundry. We are happy to inform you that your ontology (YOURID) has been accepted following discussion in the OBO Operations Committee meeting, YYYY-MM-DD. Before we can add it to the OBO ontology registry you need to complete the following steps.
 

--- a/docs/SOP.md
+++ b/docs/SOP.md
@@ -47,12 +47,15 @@ Are axioms generally highly complex? If so, we should review a handful to ensure
 <a name="OAE"></a> 
 ### Ontology Acceptance Notification 
 
-Once a new ontology has been accepted, the following should be used as a template for letting them know that, and informing them about the next steps they should take.
+Once a new ontology has been accepted, the following should be used as a template for letting the ontology owner know that, and informing them about the next steps they should take.
+
+The ontology owner should be notified in the ticket and also by email (they were required to supply their email address as part of their new ontology request),
+ccing obo-discuss & obo-operations.
 
 "Thank you again for your ontology submission to the OBO Foundry. We are happy to inform you that your ontology (YOURID) has been accepted following discussion in the OBO Operations Committee meeting, YYYY-MM-DD. Before we can add it to the OBO ontology registry you need to complete the following steps.
 
 Create a metadata record for your ontology to be included in the registry:
-1. Create a new file in this directory,  https://github.com/OBOFoundry/OBOFoundry.github.io/tree/master/ontology, called YOURID.md (there is an “Add file” button in the top right).
+1. Create a new file in https://github.com/OBOFoundry/OBOFoundry.github.io/tree/master/ontology, called YOURID.md (there is an “Add file” button in the top right).
 2. Obtain the already curated metadata that relates to your ontology from https://github.com/OBOFoundry/obo-nor.github.io/blob/master/dashboard-config.yml (you'll need to scroll down to locate yours; it will have your prefix in the " - id:" field.) 
 3. Create a pull request to add the metadata record. This pull request should include a link to this issue (the New Ontology Request issue).
 
@@ -60,7 +63,7 @@ Here is an example record for the PATO ontology: https://github.com/OBOFoundry/O
 
 Your metadata will be reviewed and merged by a member of the OBO Foundry Operations Committee. Permissable content for fields is being documented [here](https://obofoundry.org/faq/permissible-metadata-content.html).
 
-Create a PURL registry entry for your ontology:
+To create a PURL registry entry for your ontology:
 1. Go to https://github.com/OBOFoundry/purl.obolibrary.org/tree/master/config, click “Add file” and add a file named YOURID.yml.
 2. Add the desired configuration.
 3. Make a pull request with a link to this issue

--- a/docs/SOP.md
+++ b/docs/SOP.md
@@ -61,7 +61,7 @@ Create a metadata record for your ontology to be included in the registry:
 
 Here is an example record for the PATO ontology: https://github.com/OBOFoundry/OBOFoundry.github.io/blob/master/ontology/pato.md?plain=1
 
-Your metadata will be reviewed and merged by a member of the OBO Foundry Operations Committee. Permissable content for fields is being documented [here](https://obofoundry.org/faq/permissible-metadata-content.html).
+Your metadata will be reviewed and merged by a member of the OBO Foundry Operations Committee. Permissible content for fields is being documented [here](https://obofoundry.org/faq/permissible-metadata-content.html).
 
 To create a PURL registry entry for your ontology:
 1. Go to https://github.com/OBOFoundry/purl.obolibrary.org/tree/master/config, click “Add file” and add a file named YOURID.yml.


### PR DESCRIPTION
- Fixed "template plate" typo
- Changed "Email" to "Notification", since I assume we're putting that message in the GH issue (since in many cases, including this one, we don't know the ontology submitter's email address -- yes, I could probably dig it up somehow, but I don't have it to hand)
- If you're suggesting a date format, don't suggest DD-MM-YYYY!