### PR TITLE
Add automated check for OBO Library PURL configuration

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -8,6 +8,7 @@ version = 0.0.1-dev
 [options]
 install_requires =
     pyyaml
+    requests
 
 # Random options
 zip_safe = false

--- a/tests/test_integrity.py
+++ b/tests/test_integrity.py
@@ -6,6 +6,7 @@ from io import StringIO
 from pathlib import Path
 from typing import Set
 
+import requests
 import yaml
 
 from obofoundry.standardize_metadata import ModifiedDumper
@@ -214,6 +215,50 @@ class TestIntegrity(unittest.TestCase):
                     _string_norm(description),
                     _string_norm(long_description),
                     msg=f"Effectively the same description was reused in the short and long-form field for {prefix}",
+                )
+
+    def test_has_purl_config(self):
+        """Tests that OBO PURL configuration is available."""
+        #: A begrudging list of exceptions that are currently missing configuration.
+        #: DO NOT EVER AMMEND THIS LIST.
+        exceptions = {
+            "bootstrep",
+            "cmf",
+            "dinto",
+            "epo",
+            "ev",
+            "gro",
+            "habronattus",
+            "lipro",
+            "loggerhead",
+            "mao",
+            "mfo",
+            "mirnao",
+            "nif_cell",
+            "nif_dysfunction",
+            "nif_grossanatomy",
+            "pao",
+            "pd_st",
+            "pgdso",
+            "plo",
+            "propreo",
+            "sopharm",
+            "tahe",
+            "tahh",
+            "vsao",
+            "ypo",
+            "zea",
+        }
+        for prefix in self.ontologies:
+            if prefix in exceptions:
+                continue
+            with self.subTest(prefix=prefix):
+                url = f"https://raw.githubusercontent.com/OBOFoundry/purl.obolibrary.org/master/config/{prefix}.yml"
+                res = requests.get(url)
+                self.assertEqual(
+                    200,
+                    res.status_code,
+                    msg=f"PURL configuration is missing for {prefix}",
                 )
 
 

--- a/tests/test_integrity.py
+++ b/tests/test_integrity.py
@@ -249,8 +249,8 @@ class TestIntegrity(unittest.TestCase):
             "ypo",
             "zea",
         }
-        for prefix in self.ontologies:
-            if prefix in exceptions:
+        for prefix, record in self.ontologies.items():
+            if prefix in exceptions or self.skip_inactive(record):
                 continue
             with self.subTest(prefix=prefix):
                 url = f"https://raw.githubusercontent.com/OBOFoundry/purl.obolibrary.org/master/config/{prefix}.yml"

--- a/tests/test_integrity.py
+++ b/tests/test_integrity.py
@@ -219,38 +219,8 @@ class TestIntegrity(unittest.TestCase):
 
     def test_has_purl_config(self):
         """Tests that OBO PURL configuration is available."""
-        #: A begrudging list of exceptions that are currently missing configuration.
-        #: DO NOT EVER AMMEND THIS LIST.
-        exceptions = {
-            "bootstrep",
-            "cmf",
-            "dinto",
-            "epo",
-            "ev",
-            "gro",
-            "habronattus",
-            "lipro",
-            "loggerhead",
-            "mao",
-            "mfo",
-            "mirnao",
-            "nif_cell",
-            "nif_dysfunction",
-            "nif_grossanatomy",
-            "pao",
-            "pd_st",
-            "pgdso",
-            "plo",
-            "propreo",
-            "sopharm",
-            "tahe",
-            "tahh",
-            "vsao",
-            "ypo",
-            "zea",
-        }
         for prefix, record in self.ontologies.items():
-            if prefix in exceptions or self.skip_inactive(record):
+            if self.skip_inactive(record):
                 continue
             with self.subTest(prefix=prefix):
                 url = f"https://raw.githubusercontent.com/OBOFoundry/purl.obolibrary.org/master/config/{prefix}.yml"


### PR DESCRIPTION
As mentioned in https://github.com/OBOFoundry/OBOFoundry.github.io/pull/1958#issuecomment-1249287870, all new ontologies should have a working configuration on the OBO Library PURL service at https://github.com/OBOFoundry/purl.obolibrary.org before merging any new ontology metadata files.

This PR adds this check, which formats the prefix for the ontology into the appropriate URL and checks if it can be retrieved with a HTTP 200.

## Blocked by

- [x] @sabrinatoro you should create an appropriate configuration, noted in https://github.com/OBOFoundry/purl.obolibrary.org/issues/869