### PR TITLE
Don't filter ontologies with no domain when not grouping by domain

### DIFF
--- a/_includes/js/custom.js
+++ b/_includes/js/custom.js
@@ -404,10 +404,22 @@ jQuery(document).ready(function() {
      */
     function apply_all_filters(data) {
         let selectedDomain = $("#dd-domains").children("option:selected").val();
-        let res = data["ontologies"].filter(x => x["domain"] !== undefined);
-        let dt = res.filter(x => x["domain"].includes(selectedDomain));
-        let dt2 = Search($("#searchVal"), dt);
-        applyFilters(dt2)
+        if (selectedDomain) {
+            /**
+             * Filter out ontologies with no `domain` attribute and apply
+             * the rest of the user-supplied filters to the data.
+             */
+            let res = data["ontologies"].filter(x => x["domain"] !== undefined);
+            let dt = res.filter(x => x["domain"].includes(selectedDomain));
+            let dt2 = Search($("#searchVal"), dt);
+            applyFilters(dt2)
+        } else {
+            /**
+             * If no filters are supplied, just send back the raw data,
+             * including ontologies that don't have a `domain` attribute.
+             */
+            applyFilters(data["ontologies"]);
+        }
     }
 // obtain json data using fetch
     fetch('/registry/ontologies.jsonld')


### PR DESCRIPTION
With these changes, the homepage will show ontologies that don't have a domain if the "Group by Domain" checkbox is unchecked. I believe this is what the reporter of #2107 wants.

Something to think about: Do you want to put a "No Domain" grouping when looking at ontologies grouped by domain? This will be a little bit more work but if it's something that would be helpful to your users, I'd be happy to take a shot at it. 