### PR TITLE
Curate domains for all remaining ontologies

### DIFF
--- a/ontology/aao.md
+++ b/ontology/aao.md
@@ -5,6 +5,7 @@ title: Amphibian gross anatomy
 contact:
   email: david.c.blackburn@gmail.com
   label: David Blackburn
+domain: anatomy and development
 homepage: http://github.com/seger/aao
 is_obsolete: true
 replaced_by: uberon

--- a/ontology/adw.md
+++ b/ontology/adw.md
@@ -5,6 +5,7 @@ title: Animal natural history and life history
 contact:
   email: adw_geeks@umich.edu
   label: Animal Diversity Web technical staff
+domain: organisms
 homepage: http://www.animaldiversity.org
 is_obsolete: true
 activity_status: inactive

--- a/ontology/ato.md
+++ b/ontology/ato.md
@@ -5,6 +5,7 @@ title: Amphibian taxonomy
 contact:
   email: david.c.blackburn@gmail.com
   label: David Blackburn
+domain: organisms
 homepage: http://www.amphibanat.org
 is_obsolete: true
 taxon:

--- a/ontology/bcgo.md
+++ b/ontology/bcgo.md
@@ -8,6 +8,7 @@ contact:
   label: Jie Zheng
   orcid: 0000-0002-2999-0103
 description: An application ontology built for beta cell genomics studies.
+domain: anatomy and development
 homepage: https://github.com/obi-bcgo/bcgo
 in_foundry: false
 is_obsolete: true

--- a/ontology/bootstrep.md
+++ b/ontology/bootstrep.md
@@ -5,6 +5,7 @@ title: Gene Regulation Ontology
 contact:
   email: vlee@ebi.ac.uk
   label: Vivian Lee
+domain: chemistry and biochemistry
 homepage: http://www.ebi.ac.uk/Rebholz-srv/GRO/GRO.html
 is_obsolete: true
 replaced_by: molecular_function

--- a/ontology/cmf.md
+++ b/ontology/cmf.md
@@ -6,6 +6,7 @@ contact:
   email: engelsta@ohsu.edu
   label: Mark Engelstad
   orcid: 0000-0001-5889-4463
+domain: health
 homepage: https://code.google.com/p/craniomaxillofacial-ontology/
 is_obsolete: true
 activity_status: inactive

--- a/ontology/dc_cl.md
+++ b/ontology/dc_cl.md
@@ -6,6 +6,7 @@ contact:
   email: Lindsay.Cowell@utsouthwestern.edu
   label: Lindsay Cowell
   orcid: 0000-0003-1617-8244
+domain: anatomy and development
 homepage: http://www.dukeontologygroup.org/Projects.html
 is_obsolete: true
 replaced_by: cl

--- a/ontology/ehda.md
+++ b/ontology/ehda.md
@@ -5,6 +5,7 @@ title: Human developmental anatomy, timed version
 contact:
   email: J.Bard@ed.ac.uk
   label: Jonathan Bard
+domain: anatomy and development
 homepage: http://genex.hgu.mrc.ac.uk/
 is_obsolete: true
 replaced_by: ehdaa2

--- a/ontology/ehdaa.md
+++ b/ontology/ehdaa.md
@@ -5,6 +5,7 @@ title: Human developmental anatomy, abstract version
 contact:
   email: J.Bard@ed.ac.uk
   label: Jonathan Bard
+domain: anatomy and development
 homepage: null
 is_obsolete: true
 replaced_by: ehdaa2

--- a/ontology/epo.md
+++ b/ontology/epo.md
@@ -6,6 +6,7 @@ build:
   method: owl2obo
   source_url: http://purl.obolibrary.org/obo/epo.owl
 description: An ontology designed to support the semantic annotation of epidemiology resources
+domain: health
 homepage: https://code.google.com/p/epidemiology-ontology/
 in_foundry: false
 is_obsolete: true

--- a/ontology/ev.md
+++ b/ontology/ev.md
@@ -5,6 +5,7 @@ title: eVOC (Expressed Sequence Annotation for Humans)
 contact:
   email: evoc@sanbi.ac.za
   label: eVOC mailing list
+domain: chemistry and biochemistry
 homepage: http://www.evocontology.org/
 is_obsolete: true
 activity_status: inactive

--- a/ontology/ev.md
+++ b/ontology/ev.md
@@ -5,7 +5,7 @@ title: eVOC (Expressed Sequence Annotation for Humans)
 contact:
   email: evoc@sanbi.ac.za
   label: eVOC mailing list
-domain: chemistry and biochemistry
+domain: anatomy and development
 homepage: http://www.evocontology.org/
 is_obsolete: true
 activity_status: inactive

--- a/ontology/fix.md
+++ b/ontology/fix.md
@@ -11,6 +11,7 @@ contact:
   email: null
   label: chEBI
 description: An ontology of physico-chemical methods and properties.
+domain: chemistry and biochemistry
 homepage: http://www.ebi.ac.uk/chebi
 in_foundry: false
 products:

--- a/ontology/gro.md
+++ b/ontology/gro.md
@@ -5,6 +5,7 @@ title: Cereal Plant Gross Anatomy
 contact:
   email: po-discuss@plantontology.org
   label: Plant Ontology Administrators
+domain: anatomy and development
 homepage: http://www.gramene.org/plant_ontology/
 is_obsolete: true
 activity_status: inactive

--- a/ontology/habronattus.md
+++ b/ontology/habronattus.md
@@ -6,6 +6,7 @@ contact:
   email: peteremidford@yahoo.com
   label: Peter Midford
   orcid: 0000-0001-6512-3296
+domain: organisms
 homepage: http://www.mesquiteproject.org/ontology/Habronattus/index.html
 is_obsolete: true
 activity_status: inactive

--- a/ontology/iev.md
+++ b/ontology/iev.md
@@ -6,6 +6,7 @@ build:
   insert_ontology_id: true
   method: obo2owl
   source_url: http://download.baderlab.org/INOH/ontologies/EventOntology_172.obo
+domain: chemistry and biochemistry
 homepage: http://www.inoh.org
 is_obsolete: true
 activity_status: inactive

--- a/ontology/imr.md
+++ b/ontology/imr.md
@@ -9,6 +9,7 @@ build:
 contact:
   email: curator@inoh.org
   label: INOH curators
+domain: chemistry and biochemistry
 homepage: http://www.inoh.org
 is_obsolete: true
 activity_status: inactive

--- a/ontology/ipr.md
+++ b/ontology/ipr.md
@@ -5,6 +5,7 @@ title: Protein Domains
 contact:
   email: interhelp@ebi.ac.uk
   label: InterPro Help
+domain: chemistry and biochemistry
 homepage: http://www.ebi.ac.uk/interpro/index.html
 is_obsolete: true
 activity_status: inactive

--- a/ontology/loggerhead.md
+++ b/ontology/loggerhead.md
@@ -6,6 +6,7 @@ contact:
   email: peteremidford@yahoo.com
   label: Peter Midford
   orcid: 0000-0001-6512-3296
+domain: organisms
 homepage: http://www.mesquiteproject.org/ontology/Loggerhead/index.html
 is_obsolete: true
 activity_status: inactive

--- a/ontology/mao.md
+++ b/ontology/mao.md
@@ -5,6 +5,7 @@ title: Multiple alignment
 contact:
   email: julie@igbmc.u-strasbg.fr
   label: Julie Thompson
+domain: chemistry and biochemistry
 homepage: http://www-igbmc.u-strasbg.fr/BioInfo/MAO/mao.html
 is_obsolete: true
 activity_status: inactive

--- a/ontology/mat.md
+++ b/ontology/mat.md
@@ -5,6 +5,7 @@ title: Minimal anatomical terminology
 contact:
   email: j.bard@ed.ac.uk
   label: Jonathan Bard
+domain: anatomy and development
 homepage: null
 is_obsolete: true
 activity_status: inactive

--- a/ontology/mirnao.md
+++ b/ontology/mirnao.md
@@ -6,6 +6,7 @@ contact:
   email: topalis@imbb.forth.gr
   label: Pantelis Topalis
 description: An application ontology for use with miRNA databases.
+domain: chemistry and biochemistry
 homepage: http://code.google.com/p/mirna-ontology/
 is_obsolete: true
 license:

--- a/ontology/nif_cell.md
+++ b/ontology/nif_cell.md
@@ -6,6 +6,7 @@ contact:
   email: smtifahim@gmail.com
   label: Fahim Imam
 description: Neuronal cell types
+domain: anatomy and development
 homepage: http://neuinfo.org/
 is_obsolete: true
 replaced_by: cl

--- a/ontology/nif_dysfunction.md
+++ b/ontology/nif_dysfunction.md
@@ -5,6 +5,7 @@ title: NIF Dysfunction
 contact:
   email: smtifahim@gmail.com
   label: Fahim Imam
+domain: health
 homepage: http://neuinfo.org/
 is_obsolete: true
 replaced_by: doid

--- a/ontology/nif_grossanatomy.md
+++ b/ontology/nif_grossanatomy.md
@@ -5,6 +5,7 @@ title: NIF Gross Anatomy
 contact:
   email: smtifahim@gmail.com
   label: Fahim Imam
+domain: anatomy and development
 homepage: http://neuinfo.org/
 is_obsolete: true
 replaced_by: uberon

--- a/ontology/obo_rel.md
+++ b/ontology/obo_rel.md
@@ -6,6 +6,7 @@ contact:
   email: cjmungall@lbl.gov
   label: Chris Mungall
   orcid: 0000-0002-6601-2165
+domain: upper
 homepage: http://www.obofoundry.org/ro
 is_obsolete: true
 replaced_by: ro

--- a/ontology/ogi.md
+++ b/ontology/ogi.md
@@ -8,7 +8,7 @@ contact:
   label: Asiyah Yu Lin
   orcid: 0000-0002-5379-5359
 description: An ontology that formalizes the genomic element by defining an upper class genetic interval
-domain: investigations
+domain: chemistry and biochemistry
 homepage: https://code.google.com/p/ontology-for-genetic-interval/
 is_obsolete: true
 products:

--- a/ontology/ogi.md
+++ b/ontology/ogi.md
@@ -8,6 +8,7 @@ contact:
   label: Asiyah Yu Lin
   orcid: 0000-0002-5379-5359
 description: An ontology that formalizes the genomic element by defining an upper class genetic interval
+domain: investigations
 homepage: https://code.google.com/p/ontology-for-genetic-interval/
 is_obsolete: true
 products:

--- a/ontology/pao.md
+++ b/ontology/pao.md
@@ -7,6 +7,7 @@ contact:
   github: jaiswalp
   label: Pankaj Jaiswal
   orcid: 0000-0002-1005-8383
+domain: anatomy and development
 homepage: http://www.plantontology.org
 is_obsolete: true
 taxon:

--- a/ontology/pd_st.md
+++ b/ontology/pd_st.md
@@ -5,6 +5,7 @@ title: Platynereis stage ontology
 contact:
   email: henrich@embl.de
   label: Thorsten Heinrich
+domain: anatomy and development
 homepage: http://4dx.embl.de/platy
 is_obsolete: true
 replaced_by: pdumdv

--- a/ontology/pgdso.md
+++ b/ontology/pgdso.md
@@ -5,6 +5,7 @@ title: Plant Growth and Development Stage
 contact:
   email: po-discuss@plantontology.org
   label: Plant Ontology Administrators
+domain: anatomy and development
 homepage: http://www.plantontology.org
 is_obsolete: true
 taxon:

--- a/ontology/plo.md
+++ b/ontology/plo.md
@@ -5,6 +5,7 @@ title: Plasmodium life cycle
 contact:
   email: mb4@sanger.ac.uk
   label: Matt Berriman
+domain: anatomy and development
 homepage: http://www.sanger.ac.uk/Users/mb4/PLO/
 is_obsolete: true
 activity_status: inactive

--- a/ontology/propreo.md
+++ b/ontology/propreo.md
@@ -5,6 +5,7 @@ title: Proteomics data and process provenance
 contact:
   email: satya30@uga.edu
   label: Satya S. Sahoo
+domain: chemistry and biochemistry
 homepage: http://lsdis.cs.uga.edu/projects/glycomics/propreo/
 is_obsolete: true
 activity_status: inactive

--- a/ontology/rex.md
+++ b/ontology/rex.md
@@ -7,6 +7,7 @@ build:
   method: obo2owl
   source_url: http://obo.cvs.sourceforge.net/*checkout*/obo/obo/ontology/physicochemical/rex.obo
 description: An ontology of physico-chemical processes, i.e. physico-chemical changes occurring in course of time.
+domain: chemistry and biochemistry
 products:
 - id: rex.owl
 activity_status: orphaned

--- a/ontology/sao.md
+++ b/ontology/sao.md
@@ -5,6 +5,7 @@ title: Subcellular anatomy ontology
 contact:
   email: slarson@ncmir.ucsd.edu
   label: Stephen Larson
+domain: anatomy and development
 homepage: http://ccdb.ucsd.edu/CCDBWebSite/sao.html
 is_obsolete: true
 replaced_by: go

--- a/ontology/sopharm.md
+++ b/ontology/sopharm.md
@@ -5,6 +5,7 @@ title: Suggested Ontology for Pharmacogenomics
 contact:
   email: Adrien.Coulet@loria.fr
   label: Adrien Coulet
+domain: chemistry and biochemistry
 homepage: http://www.loria.fr/~coulet/sopharm2.0_description.php
 is_obsolete: true
 taxon:

--- a/ontology/tahe.md
+++ b/ontology/tahe.md
@@ -5,6 +5,7 @@ title: Terminology of Anatomy of Human Embryology
 contact:
   email: pierre.sprumont@unifr.ch
   label: Pierre Sprumont
+domain: anatomy and development
 homepage: null
 is_obsolete: true
 taxon:

--- a/ontology/tahh.md
+++ b/ontology/tahh.md
@@ -5,6 +5,7 @@ title: Terminology of Anatomy of Human Histology
 contact:
   email: pierre.sprumont@unifr.ch
   label: Pierre Sprumont
+domain: health
 homepage: null
 is_obsolete: true
 taxon:

--- a/ontology/vario.md
+++ b/ontology/vario.md
@@ -9,6 +9,7 @@ contact:
   email: mauno.vihinen@med.lu.se
   label: Mauno Vihinen
 description: Variation Ontology, VariO, is an ontology for standardized, systematic description of effects, consequences and mechanisms of variations.
+domain: biological systems
 homepage: http://variationontology.org
 preferredPrefix: VariO
 products:

--- a/ontology/vhog.md
+++ b/ontology/vhog.md
@@ -3,6 +3,7 @@ layout: ontology_detail
 id: vhog
 title: Vertebrate Homologous Ontology Group Ontology
 depicted_by: http://bgee.org/img/logo/bgee13_logo.png
+domain: anatomy and development
 is_obsolete: true
 products:
 - id: vhog.owl

--- a/ontology/ypo.md
+++ b/ontology/ypo.md
@@ -6,6 +6,7 @@ contact:
   email: cherry@genome.stanford.edu
   label: Mike Cherry
   orcid: 0000-0001-9163-5180
+domain: phenotype
 homepage: http://www.yeastgenome.org/
 is_obsolete: true
 replaced_by: apo

--- a/ontology/zea.md
+++ b/ontology/zea.md
@@ -6,6 +6,7 @@ contact:
   email: Leszek@missouri.edu
   label: Leszek Vincent
   orcid: 0000-0002-9316-2919
+domain: anatomy and development
 homepage: http://www.maizemap.org/
 is_obsolete: true
 taxon:

--- a/src/obofoundry/utils.py
+++ b/src/obofoundry/utils.py
@@ -1,0 +1,31 @@
+"""Test data integrity, beyond what's possible with the JSON schema."""
+
+from pathlib import Path
+
+import yaml
+
+__all__ = [
+    "get_data",
+    "ONTOLOGY_DIRECTORY",
+]
+
+HERE = Path(__file__).parent.resolve()
+ROOT = HERE.parent.parent.resolve()
+ONTOLOGY_DIRECTORY = ROOT.joinpath("ontology").resolve()
+
+
+def get_data():
+    """Get ontology data."""
+    ontologies = {}
+    for path in ONTOLOGY_DIRECTORY.glob("*.md"):
+        with open(path) as file:
+            lines = [line.rstrip("\n") for line in file]
+
+        assert lines[0] == "---"
+        idx = min(i for i, line in enumerate(lines[1:], start=1) if line == "---")
+
+        # Load the data like it is YAML
+        data = yaml.safe_load("\n".join(lines[1:idx]))
+        data["long_description"] = "".join(lines[idx:])
+        ontologies[data["id"]] = data
+    return ontologies

--- a/tests/test_integrity.py
+++ b/tests/test_integrity.py
@@ -10,10 +10,10 @@ import requests
 import yaml
 
 from obofoundry.standardize_metadata import ModifiedDumper
+from obofoundry.utils import ONTOLOGY_DIRECTORY, get_data
 
 HERE = Path(__file__).parent.resolve()
 ROOT = HERE.parent
-ONTOLOGY_DIRECTORY = ROOT.joinpath("ontology").resolve()
 SCHEMA_PATH = ROOT.joinpath("util", "schema", "registry_schema.json")
 
 PUBMED_PREFIX = "https://www.ncbi.nlm.nih.gov/pubmed/"
@@ -23,23 +23,6 @@ MEDRXIV_PREFIX = "https://www.medrxiv.org/content/"
 ZENODO_PREFIX = "https://zenodo.org/record/"
 DOI_PREFIX = "https://doi.org/"
 CHEMRXIV_DOI_PREFIX = "https://doi.org/10.26434/chemrxiv"
-
-
-def get_data():
-    """Get ontology data."""
-    ontologies = {}
-    for path in ONTOLOGY_DIRECTORY.glob("*.md"):
-        with open(path) as file:
-            lines = [line.rstrip("\n") for line in file]
-
-        assert lines[0] == "---"
-        idx = min(i for i, line in enumerate(lines[1:], start=1) if line == "---")
-
-        # Load the data like it is YAML
-        data = yaml.safe_load("\n".join(lines[1:idx]))
-        data["long_description"] = "".join(lines[idx:])
-        ontologies[data["id"]] = data
-    return ontologies
 
 
 class TestIntegrity(unittest.TestCase):


### PR DESCRIPTION
It took about 25 minutes to go through and give a good shot at annotating all of the remaining ontologies that didn't have one. I just read through the descriptions, some of them that had replacement annotations were even easier since I could just grab the domain from the updated one.

By definition all of the remaining ontologies are orphaned, deprecated, or obsolete, so there is no bureaucratic need to ask anyone if we can update these metadata, but any suggestions are welcome.