### PR TITLE
Fix typo in JSON schema

### DIFF
--- a/util/schema/registry_schema.json
+++ b/util/schema/registry_schema.json
@@ -142,7 +142,7 @@
         },
         "required": [
           "title",
-          "url"
+          "id"
         ]
       }
     },


### PR DESCRIPTION
This updates the required parts of `funded_by`, which was wrong, and for some reason hadn't caused issues before but now it is.