### PR TITLE
Add 404 page with case insensitivity hack

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,28 @@
+---
+permalink: /404.html
+layout: default
+title: 404
+---
+
+<h1>404 - Page not found!</h1>
+<p>We're sorry, we can't find the page you requested, please check the URL and try again or <a href="/">go back to the homepage</a></p>
+
+<script>
+  /*
+  * This script simulates case-insensitivity by taking the given
+  * URL, casting it to lower case, and then redirecting the user
+  * to the lower-case-URL. This is a hack, as it's not currently
+  * possible to enforce case-insensitivity on GitHub pages.
+  *
+  * In the worst case, this script may cause the 404 page to be
+  * loaded twice. Suppose a user went to homepage/NonExistent.html,
+  * leading them to this page; this script would redirect them to
+  * homepage/nonexistent.html which would again lead to this page.
+  */
+  window.onload = () => {
+    givenURL = window.location.href;
+    if (givenURL != givenURL.toLowerCase()) {
+      location.replace(givenURL.toLowerCase());
+    }
+  }
+</script>


### PR DESCRIPTION
This PR adds a `404.html` page, which in itself will dictate how navigation to URLs of non-existent resources are handled. As of right now, if a user tries to go to a non-existent webpage, they'll see the GitHub Pages default 404 page. If this PR is merged, this file will now be what the user sees instead.

That said, this adds a hacky script to simulate case-insensitive URLs as requested in #1728. In general, case-insensitivity in URLs is not possible in GitHub pages since they run on Linux servers where case matters. To work around this, the 404 page will now take the given URL, cast it to an all lowercase URL, and then redirect the user to the all lower case URL if they don't match, simulating case insensitivity. 

I want to highlight that _**this is a hack**_. Without access to the web server's `.htaccess` file (or whatever equivalent server configuration file), I don't think you can do redirects "the right way." Also, as mentioned in the comment, this code may cause the 404 page to be loaded twice. Suppose a user went to `homepage/NonExistent.html`, leading them to the 404 page, the script would redirect them to `homepage/nonexistent.html` which would again lead them to the 404 page. This hack also means that you have to make sure every page's file name is all lowercase from now on because this script will not work for pages that are called something like `MixedCase.md`.

Alternatively, there is a gem that handles redirects in Jekyll, but I think to use it, you'd have to add a redirect entry on every ontology page for every permutation of the ontology's name (e.g., for chebi, you'd have to make an entry for CHEBI, cHEBI, chEBI, cheBI, etc) to simulate true case insensitivity.

If you want to test this locally, try going to `localhost:5000/ontology/CHEBI` (or whatever address you have pointed at your local setup) and see that it redirects you to `localhost:5000/ontology/chebi`. If you're on Windows like me, the `ontology/CHEBI` URL won't be a problem because Windows apparently _**doesn't**_ care about case. To test this, I put the following line right above `window.onload() = () => {` :

```javascript
console.log("Hey! I'm at ", window.location.href);
```

I then went to `localhost:5000/aSdF` and saw the following output in the JavaScript console:
```
> Hey! I'm at localhost:5000/aSdF
. . .
> Hey! I'm at localhost:5000/asdf
```

Again, this implementation is a hack so consider if supporting case-insensitive URLs is more important than having clean, professional looking code.