### PR TITLE
Map operations committee metadata to wikidata and github

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -150,6 +150,7 @@ tox:
 
 # Use SPARQL queries to Wikidata to enrich the
 # OBO operations committee metadata file
+.PHONY: update-operations-metadata
 update-operations-metadata:
 	python -m obofoundry update-operations-metadata
 

--- a/Makefile
+++ b/Makefile
@@ -144,6 +144,15 @@ prettify: $(ONTS)
 tox:
 	tox -e py
 
+##########################
+## Metadata Maintenance ##
+##########################
+
+# Use SPARQL queries to Wikidata to enrich the
+# OBO operations committee metadata file
+update-operations-metadata:
+	python -m obofoundry update-operations-metadata
+
 ### OBO Dashboard
 
 # This is the Jenkins job

--- a/_data/operations.yml
+++ b/_data/operations.yml
@@ -93,19 +93,24 @@ members:
   wikidata: Q54303418
 - affiliation: Kansas State University, Manhattan, KS
   country: USA
+  github: handemcginty
   groups:
   - editorial
   - outreach
-  name: "Hande K\xFC\xE7\xFCk McGinty"
+  name: Hande Küçük McGinty
   orcid: 0000-0002-9025-5538
+  wikidata: Q107527234
 - affiliation: La Jolla Institute for Immunology, La Jolla, CA
   country: USA
+  github: hectorguzor
   groups:
   - outreach
   name: Hector Guzman-Orozco
   orcid: 0000-0003-3430-8997
+  wikidata: Q114354576
 - affiliation: Knocean Inc., Toronto
   country: Canada
+  github: jamesaoverton
   groups:
   - technical
   link: http://james.overton.ca/
@@ -159,6 +164,7 @@ members:
   wikidata: Q28368079
 - affiliation: Semanticly, Athens
   country: Greece
+  github: matentzn
   groups:
   - technical
   name: Nico Matentzoglu
@@ -175,6 +181,7 @@ members:
   wikidata: Q42763131
 - affiliation: Lawrence Berkeley National Laboratory, Berkeley, CA
   country: USA
+  github: nlharris
   groups:
   - outreach
   - technical
@@ -210,6 +217,7 @@ members:
   wikidata: Q63240627
 - affiliation: La Jolla Institute for Immunology, La Jolla, CA
   country: USA
+  github: rvita
   groups:
   - outreach
   name: Randi Vita
@@ -225,6 +233,7 @@ members:
   wikidata: Q59539088
 - affiliation: J. Craig Venter Institute, La Jolla, CA
   country: USA
+  github: scheuerm
   groups:
   - outreach
   link: https://www.jcvi.org/about/rscheuermann
@@ -233,6 +242,7 @@ members:
   wikidata: Q30508615
 - affiliation: Lawrence Berkeley National Laboratory, Berkeley, CA
   country: USA
+  github: kltm
   groups:
   - technical
   name: Seth Carbon

--- a/_data/operations.yml
+++ b/_data/operations.yml
@@ -190,6 +190,7 @@ members:
   wikidata: Q58106602
 - affiliation: University of Oxford e-Research Centre, Department of Engineering Science, Oxford
   country: UK
+  github: proccaserra
   groups:
   - outreach
   link: https://eng.ox.ac.uk/people/philippe-rocca-serra/

--- a/_data/operations.yml
+++ b/_data/operations.yml
@@ -1,74 +1,96 @@
 members:
 - affiliation: University at Buffalo, Buffalo
   country: USA
+  github: alanruttenberg
   groups:
   - outreach
   link: http://sciencecommons.org/about/whoweare/ruttenberg/
   name: Alan Ruttenberg
   orcid: 0000-0002-1604-3078
+  wikidata: Q30508557
 - affiliation: University at Buffalo, Buffalo, NY
   country: USA
+  github: addiehl
   groups:
   - technical
   name: Alexander Diehl
   orcid: 0000-0001-9990-8331
+  wikidata: Q47502183
 - affiliation: University at Buffalo, Buffalo, NY
   country: USA
+  github: phismith
   groups:
   - outreach
   name: Barry Smith
   orcid: 0000-0003-1384-116X
+  wikidata: Q809101
 - affiliation: University of Florida, Gainseville, FL
   country: USA
+  github: wdduncan
   groups:
   - editorial
   name: Bill Duncan
   orcid: 0000-0001-9625-1899
+  wikidata: Q89881908
 - affiliation: University of Florida, Gainseville, FL
   country: USA
+  github: hoganwr
   groups:
   - editorial
   name: Bill Hogan
   orcid: 0000-0002-9881-1017
+  wikidata: Q56590169
 - affiliation: La Jolla Institute for Immunology, La Jolla, CA
   country: USA
+  github: bpeters42
   groups:
   - editorial
   name: Bjoern Peters
   orcid: 0000-0002-8457-6693
+  wikidata: Q60541156
 - affiliation: Lawrence Berkeley National Laboratory, Berkeley, CA
   country: USA
+  github: cmungall
   groups:
   - technical
   link: https://github.com/cmungall/
   name: Chris Mungall
   orcid: 0000-0002-6601-2165
+  wikidata: Q20746118
 - affiliation: University of Pennsylvania, Philadelphia, PA
   country: USA
+  github: cstoeckert
   groups:
   - outreach
   - editorial
   name: Chris Stoeckert
   orcid: 0000-0002-5714-991X
+  wikidata: Q67220657
 - affiliation: Centre for Infectious Disease Genomics and One Health, Simon Fraser University, BC
   country: Canada
+  github: ddooley
   groups:
   - outreach
   name: Damion Dooley
   orcid: 0000-0002-8844-9165
+  wikidata: Q91868864
 - affiliation: Georgetown University Medical Center, Washington DC
   country: USA
+  github: nataled
   groups:
   - editorial
   link: http://pir.georgetown.edu/pirwww/aboutpir/natalebio.shtml
   name: Darren Natale
   orcid: 0000-0001-5809-9523
+  wikidata: Q99552327
 - affiliation: EMBL-EBI, Cambridge
   country: UK
+  github: dosumis
   groups:
   - outreach
   name: David Osumi-Sutherland
   orcid: 0000-0002-7073-9172
+  wikidata: Q54303418
 - affiliation: Kansas State University, Manhattan, KS
   country: USA
   groups:
@@ -89,54 +111,68 @@ members:
   link: http://james.overton.ca/
   name: James A. Overton
   orcid: 0000-0001-5139-5557
+  wikidata: Q106221456
 - affiliation: University of Pennsylvania, Philadelphia, PA
   country: USA
+  github: zhengj2007
   groups:
   - outreach
   - technical
   link: http://cbil.upenn.edu/profile-staff_bio/39
   name: Jie Zheng
   orcid: 0000-0002-2999-0103
+  wikidata: Q90780528
 - affiliation: RENCI, University of North Carolina, Chapel Hill, NC
   country: USA
+  github: balhoff
   groups:
   - technical
   name: Jim Balhoff
   orcid: 0000-0002-8688-6599
+  wikidata: Q37649212
 - affiliation: University of Maryland School of Medicine, Baltimore, MD
   country: USA
+  github: lschriml
   groups:
   - editorial
   - outreach
   link: http://www.medschool.umaryland.edu/profiles/Schriml-Lynn/
   name: Lynn Schriml
   orcid: 0000-0001-8910-9851
+  wikidata: Q28913673
 - affiliation: Unversity of Colorado Anschutz Medical Campus, Auroa, CO
   country: USA
+  github: mbrush
   groups:
   - technical
   name: Matt Brush
   orcid: 0000-0002-1048-5019
+  wikidata: Q88110949
 - affiliation: Unversity of Colorado Anschutz Medical Campus, Auroa, CO
   country: USA
+  github: mellybelly
   groups:
   - outreach
   link: https://www.ohsu.edu/people/melissa-haendel/AFE044BDE8046E5D6FBDA51F448BDE2A
   name: Melissa Haendel
   orcid: 0000-0001-9114-8737
+  wikidata: Q28368079
 - affiliation: Semanticly, Athens
   country: Greece
   groups:
   - technical
   name: Nico Matentzoglu
   orcid: 0000-0002-7356-1779
+  wikidata: Q60972192
 - affiliation: Unversity of Colorado Anschutz Medical Campus, Auroa, CO
   country: USA
+  github: nicolevasilevsky
   groups:
   - editorial
   - outreach
   name: Nicole Vasilevsky
   orcid: 0000-0001-5208-3432
+  wikidata: Q42763131
 - affiliation: Lawrence Berkeley National Laboratory, Berkeley, CA
   country: USA
   groups:
@@ -144,6 +180,7 @@ members:
   - technical
   name: Nomi Harris
   orcid: 0000-0001-6315-3707
+  wikidata: Q58106602
 - affiliation: University of Oxford e-Research Centre, Department of Engineering Science, Oxford
   country: UK
   groups:
@@ -151,33 +188,41 @@ members:
   link: https://eng.ox.ac.uk/people/philippe-rocca-serra/
   name: Philippe Rocca-Serra
   orcid: 0000-0001-9853-5668
+  wikidata: Q28364404
 - affiliation: Alfred Wegener Institute, Helmholtz Centre for Polar and Marine Research, Bremerhaven
   country: Germany
+  github: pbuttigieg
   groups:
   - editorial
   - outreach
   name: Pier Luigi Buttigieg
   orcid: 0000-0002-4366-3088
+  wikidata: Q41566750
 - affiliation: CyVerse, University of Arizona, Tucson, AZ
   country: USA
+  github: ramonawalls
   groups:
   - technical
   - editorial
   link: http://www.cyverse.org/ramona-walls
   name: Ramona Walls
   orcid: 0000-0001-8815-0078
+  wikidata: Q63240627
 - affiliation: La Jolla Institute for Immunology, La Jolla, CA
   country: USA
   groups:
   - outreach
   name: Randi Vita
   orcid: 0000-0001-8957-7612
+  wikidata: Q58116889
 - affiliation: Intelligent Medical Objects (IMO), Rosemont, IL
   country: USA
+  github: beckyjackson
   groups:
   - technical
   name: Rebecca Jackson
   orcid: 0000-0003-4871-5569
+  wikidata: Q59539088
 - affiliation: J. Craig Venter Institute, La Jolla, CA
   country: USA
   groups:
@@ -185,15 +230,19 @@ members:
   link: https://www.jcvi.org/about/rscheuermann
   name: Richard Scheuermann
   orcid: 0000-0003-1355-892X
+  wikidata: Q30508615
 - affiliation: Lawrence Berkeley National Laboratory, Berkeley, CA
   country: USA
   groups:
   - technical
   name: Seth Carbon
   orcid: 0000-0001-8244-1536
+  wikidata: Q57081961
 - affiliation: European Bioinformatics Institute, Cambridge
   country: UK
+  github: shawntanzk
   groups:
   - technical
   name: Shawn Tan
   orcid: 0000-0001-7258-9596
+  wikidata: Q57023310

--- a/docs/EditorialWG.md
+++ b/docs/EditorialWG.md
@@ -43,6 +43,7 @@ Membership in the OBO Foundry Editorial WG is open to all members of the OBO Fou
 <tr>
     <th role="columnheader">Name</th>
     <th role="columnheader">ORCID</th>
+    <th role="columnheader">GitHub</th>
     <th role="columnheader">Affiliation</th>
     <th role="columnheader">Country</th>
 </tr>
@@ -53,6 +54,7 @@ Membership in the OBO Foundry Editorial WG is open to all members of the OBO Fou
 <tr>
     <td>{% if member.link %}<a href="{{ member.link }}">{{ member.name }}</a>{% else %}{{ member.name }}{% endif %}</td>
     <td><a href="https://orcid.org/{{ member.orcid }}">{{ member.orcid }}</a></td>
+    <td><a href="https://github.com/{{ member.github }}">{{ member.github }}</a></td>
     <td>{{ member.affiliation }}</td>
     <td>{{ member.country }}</td>
 </tr>

--- a/docs/Membership.md
+++ b/docs/Membership.md
@@ -31,7 +31,7 @@ There are currently three working groups. Each page lists their respective membe
     <td>{% if member.link %}<a href="{{ member.link }}">{{ member.name }}</a>{% else %}{{ member.name }}{% endif %}</td>
     <td><a href="https://orcid.org/{{ member.orcid }}">{{ member.orcid }}</a></td>
     <td><a href="https://github.com/{{ member.github }}">{{ member.github }}</a></td>
-    <td><a href="https://bioregistry.io/wikidata:{{ member.wikidata }}">{{ member.wikidata }}</a></td>
+    <td><a href="https://www.wikidata.org/wiki/{{ member.wikidata }}">{{ member.wikidata }}</a></td>
     <td>{{ member.affiliation }}</td>
     <td>{{ member.country }} </td>
     <td>{{ member.groups | join: ", " }}</td>

--- a/docs/Membership.md
+++ b/docs/Membership.md
@@ -17,6 +17,8 @@ There are currently three working groups. Each page lists their respective membe
 <tr>
     <th role="columnheader">Name</th>
     <th role="columnheader">ORCID</th>
+    <th role="columnheader">GitHub</th>
+    <th role="columnheader">Wikidata</th>
     <th role="columnheader">Affiliation</th>
     <th role="columnheader">Country</th>
     <th role="columnheader">Groups</th>
@@ -28,6 +30,8 @@ There are currently three working groups. Each page lists their respective membe
 <tr>
     <td>{% if member.link %}<a href="{{ member.link }}">{{ member.name }}</a>{% else %}{{ member.name }}{% endif %}</td>
     <td><a href="https://orcid.org/{{ member.orcid }}">{{ member.orcid }}</a></td>
+    <td><a href="https://github.com/{{ member.github }}">{{ member.github }}</a></td>
+    <td><a href="https://bioregistry.io/wikidata:{{ member.wikidata }}">{{ member.wikidata }}</a></td>
     <td>{{ member.affiliation }}</td>
     <td>{{ member.country }} </td>
     <td>{{ member.groups | join: ", " }}</td>

--- a/docs/Membership.md
+++ b/docs/Membership.md
@@ -18,7 +18,6 @@ There are currently three working groups. Each page lists their respective membe
     <th role="columnheader">Name</th>
     <th role="columnheader">ORCID</th>
     <th role="columnheader">GitHub</th>
-    <th role="columnheader">Wikidata</th>
     <th role="columnheader">Affiliation</th>
     <th role="columnheader">Country</th>
     <th role="columnheader">Groups</th>
@@ -31,7 +30,6 @@ There are currently three working groups. Each page lists their respective membe
     <td>{% if member.link %}<a href="{{ member.link }}">{{ member.name }}</a>{% else %}{{ member.name }}{% endif %}</td>
     <td><a href="https://orcid.org/{{ member.orcid }}">{{ member.orcid }}</a></td>
     <td><a href="https://github.com/{{ member.github }}">{{ member.github }}</a></td>
-    <td><a href="https://www.wikidata.org/wiki/{{ member.wikidata }}">{{ member.wikidata }}</a></td>
     <td>{{ member.affiliation }}</td>
     <td>{{ member.country }} </td>
     <td>{{ member.groups | join: ", " }}</td>

--- a/docs/OutreachWG.md
+++ b/docs/OutreachWG.md
@@ -19,6 +19,7 @@ The mailing list for the OBO Foundry Outreach Working Group is <a href='mailto:o
 <tr>
     <th role="columnheader">Name</th>
     <th role="columnheader">ORCID</th>
+    <th role="columnheader">GitHub</th>
     <th role="columnheader">Affiliation</th>
     <th role="columnheader">Country</th>
 </tr>
@@ -29,6 +30,7 @@ The mailing list for the OBO Foundry Outreach Working Group is <a href='mailto:o
 <tr>
     <td>{% if member.link %}<a href="{{ member.link }}">{{ member.name }}</a>{% else %}{{ member.name }}{% endif %}</td>
     <td><a href="https://orcid.org/{{ member.orcid }}">{{ member.orcid }}</a></td>
+    <td><a href="https://github.com/{{ member.github }}">{{ member.github }}</a></td>
     <td>{{ member.affiliation }}</td>
     <td>{{ member.country }}</td>
 </tr>

--- a/docs/TechnicalWG.md
+++ b/docs/TechnicalWG.md
@@ -23,6 +23,7 @@ The mailing list for the OBO Foundry Technical Working Group is <a href='mailto:
 <tr>
     <th role="columnheader">Name</th>
     <th role="columnheader">ORCID</th>
+    <th role="columnheader">GitHub</th>
     <th role="columnheader">Affiliation</th>
     <th role="columnheader">Country</th>
 </tr>
@@ -33,6 +34,7 @@ The mailing list for the OBO Foundry Technical Working Group is <a href='mailto:
 <tr>
     <td>{% if member.link %}<a href="{{ member.link }}">{{ member.name }}</a>{% else %}{{ member.name }}{% endif %}</td>
     <td><a href="https://orcid.org/{{ member.orcid }}">{{ member.orcid }}</a></td>
+    <td><a href="https://github.com/{{ member.github }}">{{ member.github }}</a></td>
     <td>{{ member.affiliation }}</td>
     <td>{{ member.country }}</td>
 </tr>

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,3 +27,7 @@ where = src
 [options.extras_require]
 tests =
     pytest
+
+[options.entry_points]
+console_scripts =
+    obofoundry = obofoundry.cli:main

--- a/src/obofoundry/__main__.py
+++ b/src/obofoundry/__main__.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+
+"""Entrypoint module, in case you use `python -m obofoundry`.
+
+Why does this file exist, and why ``__main__``? For more info, read:
+- https://www.python.org/dev/peps/pep-0338/
+- https://docs.python.org/3/using/cmdline.html#cmdoption-m
+"""
+
+from .cli import main
+
+if __name__ == '__main__':
+    main()

--- a/src/obofoundry/cli.py
+++ b/src/obofoundry/cli.py
@@ -1,0 +1,30 @@
+"""Command line interface for :mod:`obofoundry`.
+
+Why does this file exist, and why not put this in ``__main__``? You might be tempted to import things from ``__main__``
+later, but that will cause problems--the code will get executed twice:
+
+- When you run ``python3 -m obofoundry`` python will execute``__main__.py`` as a script.
+  That means there won't be any ``obofoundry.__main__`` in ``sys.modules``.
+- When you import __main__ it will get executed again (as a module) because
+  there's no ``obofoundry.__main__`` in ``sys.modules``.
+
+.. seealso:: https://click.palletsprojects.com/en/8.0.x/setuptools/
+"""
+
+import click
+from . import update_operations_metadata
+
+__all__ = [
+    "main",
+]
+
+
+@click.group()
+def main():
+    """CLI for the OBO Foundry."""
+
+
+main.add_command(update_operations_metadata.main)
+
+if __name__ == '__main__':
+    main()

--- a/src/obofoundry/constants.py
+++ b/src/obofoundry/constants.py
@@ -1,0 +1,9 @@
+"""Constants for the OBO Foundry."""
+
+import pathlib
+
+HERE = pathlib.Path(__file__).parent.resolve()
+ROOT = HERE.parent.parent.resolve()
+ONTOLOGY_DIRECTORY = ROOT.joinpath("ontology")
+DATA_DIRECTORY = ROOT.joinpath("_data")
+OPS_PATH = DATA_DIRECTORY.joinpath("operations.yml")

--- a/src/obofoundry/constants.py
+++ b/src/obofoundry/constants.py
@@ -6,4 +6,5 @@ HERE = pathlib.Path(__file__).parent.resolve()
 ROOT = HERE.parent.parent.resolve()
 ONTOLOGY_DIRECTORY = ROOT.joinpath("ontology")
 DATA_DIRECTORY = ROOT.joinpath("_data")
-OPS_PATH = DATA_DIRECTORY.joinpath("operations.yml")
+#: Path to the file containing metadata about members of the OBO Operations Committee
+OPERATIONS_METADATA_PATH = DATA_DIRECTORY.joinpath("operations.yml")

--- a/src/obofoundry/standardize_metadata.py
+++ b/src/obofoundry/standardize_metadata.py
@@ -14,7 +14,7 @@ from operator import itemgetter
 import yaml
 from yaml import MappingNode, SafeDumper, ScalarNode
 
-from obofoundry.constants import ONTOLOGY_DIRECTORY, DATA_DIRECTORY
+from obofoundry.constants import DATA_DIRECTORY, ONTOLOGY_DIRECTORY
 
 
 def sort_key(kv):

--- a/src/obofoundry/standardize_metadata.py
+++ b/src/obofoundry/standardize_metadata.py
@@ -14,10 +14,7 @@ from operator import itemgetter
 import yaml
 from yaml import MappingNode, SafeDumper, ScalarNode
 
-HERE = pathlib.Path(__file__).parent.resolve()
-ROOT = HERE.parent.parent.resolve()
-ONTOLOGY_DIRECTORY = ROOT.joinpath("ontology")
-DATA_DIRECTORY = ROOT.joinpath("_data")
+from obofoundry.constants import ONTOLOGY_DIRECTORY, DATA_DIRECTORY
 
 
 def sort_key(kv):

--- a/src/obofoundry/update_operations_metadata.py
+++ b/src/obofoundry/update_operations_metadata.py
@@ -7,7 +7,7 @@ import requests
 import yaml
 from tqdm import tqdm
 
-from obofoundry.constants import OPS_PATH
+from obofoundry.constants import OPERATIONS_METADATA_PATH
 
 #: WikiData SPARQL endpoint. See https://www.wikidata.org/wiki/Wikidata:SPARQL_query_service#Interfacing
 WIKIDATA_SPARQL = "https://query.wikidata.org/bigdata/namespace/wdq/sparql"
@@ -27,7 +27,7 @@ def query_wikidata(query: str):
 @click.command(name="update-operations-metadata")
 def main():
     """Update the operations committee members metadata file by querying Wikidata."""
-    operations_metadata = yaml.safe_load(OPS_PATH.read_text())
+    operations_metadata = yaml.safe_load(OPERATIONS_METADATA_PATH.read_text())
     for member in tqdm(operations_metadata["members"]):
         orcid = member["orcid"]
         if "wikidata" not in member or "github" not in member:
@@ -51,7 +51,7 @@ def main():
                 github = res[0].get("github")
                 if github:
                     member["github"] = github["value"]
-            OPS_PATH.write_text(
+            OPERATIONS_METADATA_PATH.write_text(
                 yaml.safe_dump(
                     operations_metadata,
                     sort_keys=True,

--- a/src/obofoundry/update_operations_metadata.py
+++ b/src/obofoundry/update_operations_metadata.py
@@ -24,8 +24,9 @@ def query_wikidata(query: str):
     return res_json["results"]["bindings"]
 
 
-@click.command()
+@click.command(name="update-operations-metadata")
 def main():
+    """Update the operations committee members metadata file by querying Wikidata."""
     operations_metadata = yaml.safe_load(OPS_PATH.read_text())
     for member in tqdm(operations_metadata["members"]):
         orcid = member["orcid"]

--- a/src/obofoundry/update_operations_metadata.py
+++ b/src/obofoundry/update_operations_metadata.py
@@ -1,0 +1,52 @@
+"""Run this script to update the operations metadata."""
+
+from obofoundry.constants import OPS_PATH
+from obofoundry.utils import load_ops
+import click
+import yaml
+import requests
+from textwrap import dedent
+
+#: WikiData SPARQL endpoint. See https://www.wikidata.org/wiki/Wikidata:SPARQL_query_service#Interfacing
+WIKIDATA_SPARQL = "https://query.wikidata.org/bigdata/namespace/wdq/sparql"
+
+
+def query_wikidata(query: str):
+    """Query the Wikidata SPARQL endpoint and return JSON."""
+    res = requests.get(
+        WIKIDATA_SPARQL,
+        params={"query": query, "format": "json"},
+    )
+    res.raise_for_status()
+    res_json = res.json()
+    return res_json["results"]["bindings"]
+
+
+@click.command()
+def main():
+    operations_metadata = yaml.safe_load(OPS_PATH.read_text())
+    for member in operations_metadata["members"]:
+        orcid = member["orcid"]
+        if "wikidata" not in member:
+            print(orcid, "missing ORCID")
+            q = dedent(f"""\
+                SELECT DISTINCT ?item ?github 
+                WHERE 
+                {{
+                    ?item wdt:P496 "{orcid}" .
+                    OPTIONAL {{ ?item wdt:P2037 ?github }} .
+                }}
+                LIMIT 1
+                """)
+            print(f"running query:\n{q}")
+            res = query_wikidata(q)
+            if res:
+                member["wikidata"] = res[0]["item"]["value"].removeprefix("http://www.wikidata.org/entity/")
+                github = res[0].get("github")
+                if github:
+                    member["github"] = github["value"]
+            OPS_PATH.write_text(yaml.safe_dump(operations_metadata, sort_keys=True, width=float("inf")))
+
+
+if __name__ == '__main__':
+    main()

--- a/src/obofoundry/update_operations_metadata.py
+++ b/src/obofoundry/update_operations_metadata.py
@@ -1,11 +1,13 @@
 """Run this script to update the operations metadata."""
 
-from obofoundry.constants import OPS_PATH
-import click
-import yaml
-import requests
 from textwrap import dedent
+
+import click
+import requests
+import yaml
 from tqdm import tqdm
+
+from obofoundry.constants import OPS_PATH
 
 #: WikiData SPARQL endpoint. See https://www.wikidata.org/wiki/Wikidata:SPARQL_query_service#Interfacing
 WIKIDATA_SPARQL = "https://query.wikidata.org/bigdata/namespace/wdq/sparql"
@@ -27,9 +29,10 @@ def main():
     operations_metadata = yaml.safe_load(OPS_PATH.read_text())
     for member in tqdm(operations_metadata["members"]):
         orcid = member["orcid"]
-        if "wikidata" not in member:
-            tqdm.write(f"{orcid} missing wikidata")
-            sparql = dedent(f"""\
+        if "wikidata" not in member or "github" not in member:
+            tqdm.write(f"{member['name']} ({orcid}) missing wikidata or github")
+            sparql = dedent(
+                f"""\
                 SELECT DISTINCT ?item ?github 
                 WHERE 
                 {{
@@ -37,15 +40,25 @@ def main():
                     OPTIONAL {{ ?item wdt:P2037 ?github }} .
                 }}
                 LIMIT 1
-                """)
+                """
+            )
             res = query_wikidata(sparql)
             if res:
-                member["wikidata"] = res[0]["item"]["value"].removeprefix("http://www.wikidata.org/entity/")
+                member["wikidata"] = res[0]["item"]["value"].removeprefix(
+                    "http://www.wikidata.org/entity/"
+                )
                 github = res[0].get("github")
                 if github:
                     member["github"] = github["value"]
-            OPS_PATH.write_text(yaml.safe_dump(operations_metadata, sort_keys=True, width=float("inf")))
+            OPS_PATH.write_text(
+                yaml.safe_dump(
+                    operations_metadata,
+                    sort_keys=True,
+                    width=float("inf"),
+                    allow_unicode=True,
+                )
+            )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/src/obofoundry/utils.py
+++ b/src/obofoundry/utils.py
@@ -4,14 +4,11 @@ from pathlib import Path
 
 import yaml
 
+from obofoundry.constants import ONTOLOGY_DIRECTORY
+
 __all__ = [
     "get_data",
-    "ONTOLOGY_DIRECTORY",
 ]
-
-HERE = Path(__file__).parent.resolve()
-ROOT = HERE.parent.parent.resolve()
-ONTOLOGY_DIRECTORY = ROOT.joinpath("ontology").resolve()
 
 
 def get_data():

--- a/tests/test_memberships.py
+++ b/tests/test_memberships.py
@@ -18,6 +18,8 @@ class Member(BaseModel):
 
     name: str
     orcid: str
+    wikidata: str
+    github: str
     affiliation: str
     country: str
     groups: List[Literal["editorial", "outreach", "technical"]]


### PR DESCRIPTION
Closes #2125

This PR adds a script that queries the SPARQL endpoint of Wikidata for ORCID identifiers of operations committee to get their wikidata identifier and GitHub. Originally, this was optional, but there were only 3 or 4 members who didn't have the data in their wikidata already so I just added it then made it required.