### PR TITLE
Add note about OFOC members stepping down

### DIFF
--- a/docs/NewOBOFC.md
+++ b/docs/NewOBOFC.md
@@ -23,5 +23,6 @@ or [Technical Working Group](https://obofoundry.org/docs/TechnicalWG.html).
 ## Onboarding
 
 Once a candidate has gone through the steps above and been confirmed as a new OFOC member, they need to onboard.
-Currently, the onboarding steps to be taken by or on behalf of a new OFOC member are listed in a Google doc called "OBO Operations Onboarding" in the OBO Operations gdrive folder.
+Currently, the onboarding steps to be taken by or on behalf of a new OFOC member are listed in a Google doc called "OBO Operations Onboarding" in the OBO Operations gdrive folder. (When an OFOC member steps down, the appropriate steps are listed in the "SOP for members stepping down" section of that document.)
 This may in the future become a public GitHub doc, if that can be done safely.
+


### PR DESCRIPTION
As discussed on the OFOC call today, we need an SOP for members stepping down and being removed from the various mailing lists and resources. Since the onboarding instructions are in the "OBO Operations Onboarding" Google Doc, I added some "offboarding" instructions there as well.