### PR TITLE
Remove Hector from Operations

### DIFF
--- a/_data/alumni.yml
+++ b/_data/alumni.yml
@@ -24,3 +24,11 @@ members:
 - name: Susanna-Assunta Sansone
   orcid: 0000-0001-5306-5690
 - name: Carlo Tornial
+- affiliation: La Jolla Institute for Immunology, La Jolla, CA
+  country: USA
+  github: hectorguzor
+  groups:
+  - outreach
+  name: Hector Guzman-Orozco
+  orcid: 0000-0003-3430-8997
+  wikidata: Q114354576

--- a/_data/operations.yml
+++ b/_data/operations.yml
@@ -101,14 +101,6 @@ members:
   name: Hande Küçük McGinty
   orcid: 0000-0002-9025-5538
   wikidata: Q107527234
-- affiliation: La Jolla Institute for Immunology, La Jolla, CA
-  country: USA
-  github: hectorguzor
-  groups:
-  - outreach
-  name: Hector Guzman-Orozco
-  orcid: 0000-0003-3430-8997
-  wikidata: Q114354576
 - affiliation: Knocean Inc., Toronto
   country: Canada
   github: jamesaoverton


### PR DESCRIPTION
Hector is stepping down from OBO Foundry Operations Committee, so I'm removing him from `operations.yml` and adding him to `alumni.yml`