### PR TITLE
Add small preview of role information on top of Nicole's branch

### DIFF
--- a/docs/Membership.md
+++ b/docs/Membership.md
@@ -60,3 +60,21 @@ New members: follow the instructions on the [onboarding doc](https://docs.google
 {% endfor %}
 </tbody>
 </table>
+
+## Roles
+
+{% for role in site.data.roles %}
+
+### {{ role.name }}
+
+{{ role.description }}
+
+Requirements:
+
+<ol>
+{% for requirement in role.requirements %}
+    <li>{{ requirement }}</li>
+{% endfor %}
+</ol>
+
+{% endfor %}

--- a/docs/Membership.md
+++ b/docs/Membership.md
@@ -69,6 +69,7 @@ New members: follow the instructions on the [onboarding doc](https://docs.google
 
 {{ role.description }}
 
+{% if role.requirements %}
 Requirements:
 
 <ol>
@@ -76,5 +77,10 @@ Requirements:
     <li>{{ requirement }}</li>
 {% endfor %}
 </ol>
+{% endif %}
+
+{% if role.open %}
+This role is open to new members.
+{% endif %}
 
 {% endfor %}


### PR DESCRIPTION
This PR adds a small amount of templating to demo what the role list could look like on top of Nicole's branch in #2142 . Perhaps better in its own page, but anyway this is a place to start. It will also need updates to show all information.
<img width="947" alt="Screen Shot 2022-10-05 at 19 46 04" src="https://user-images.githubusercontent.com/5069736/194127438-e4d39368-2dea-4f11-96ae-838dda660839.png">

