### PR TITLE
Upgrade CARO to CC BY 4.0

### DIFF
--- a/ontology/caro.md
+++ b/ontology/caro.md
@@ -15,8 +15,8 @@ description: An upper level ontology to facilitate interoperability between exis
 domain: anatomy and development
 homepage: https://github.com/obophenotype/caro/
 license:
-  label: CC BY 3.0
-  url: https://creativecommons.org/licenses/by/3.0/
+  label: CC BY 4.0
+  url: https://creativecommons.org/licenses/by/4.0/
 preferredPrefix: CARO
 products:
 - id: caro.owl


### PR DESCRIPTION
CARO was changed to use CC BY 4.0 in https://github.com/obophenotype/caro/pull/35. This PR reflects this.

Closes https://github.com/obophenotype/caro/issues/33.