### PR TITLE
Alternate approach to indenting home page bulleted lists

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,37 +14,41 @@ title: The OBO Foundry
     </h1>
 
     <h4>Learn about OBO best practices and community resources</h4>
-    <ul>
-        <li><a href="principles/fp-000-summary.html">OBO Foundry principles</a></li>
-        <li>
-            <a href="https://github.com/jamesaoverton/obo-tutorial">OBO tutorial</a>
-        </li>
-        <li><a href="resources">Ontology browsers, tutorials, and tools</a></li>
-    </ul>
+    <div>
+        <ul>
+            <li><a href="principles/fp-000-summary.html">OBO Foundry principles</a></li>
+            <li>
+                <a href="https://github.com/jamesaoverton/obo-tutorial">OBO tutorial</a>
+            </li>
+            <li><a href="resources">Ontology browsers, tutorials, and tools</a></li>
+        </ul>
+    </div>
 
     <h4>Participate</h4>
-    <ul>
-        <li><a href="docs/COC.html">Code of Conduct</a></li>
-        <li>
-            Join the <a href="https://groups.google.com/forum/#!forum/obo-discuss">OBO mailing list</a>
-            and the <a href="https://obo-communitygroup.slack.com/">OBO Community Slack workspace</a>
-        </li>
-        <li>
-            <a href="docs/OperationsCommittee.html">
-                OBO Foundry Operations and Working Groups
-            </a>
-        </li>
-        <li>
-            <a href="https://github.com/OBOFoundry/OBOFoundry.github.io/issues">
-                Submit bug reports or suggestions for improvement via GitHub
-            </a>
-        </li>
-        <li>
-            <a href="faq/how-do-i-register-my-ontology.html">
-                Submit your ontology to be considered for inclusion in the OBO Foundry
-            </a>
-        </li>
-    </ul>
+    <div>
+        <ul>
+            <li><a href="docs/COC.html">Code of Conduct</a></li>
+            <li>
+                Join the <a href="https://groups.google.com/forum/#!forum/obo-discuss">OBO mailing list</a>
+                and the <a href="https://obo-communitygroup.slack.com/">OBO Community Slack workspace</a>
+            </li>
+            <li>
+                <a href="docs/OperationsCommittee.html">
+                    OBO Foundry Operations and Working Groups
+                </a>
+            </li>
+            <li>
+                <a href="https://github.com/OBOFoundry/OBOFoundry.github.io/issues">
+                    Submit bug reports or suggestions for improvement via GitHub
+                </a>
+            </li>
+            <li>
+                <a href="faq/how-do-i-register-my-ontology.html">
+                    Submit your ontology to be considered for inclusion in the OBO Foundry
+                </a>
+            </li>
+        </ul>
+    </div>
 
     <h4>OBO Library: find, use, and contribute to community ontologies</h4>
 </div>


### PR DESCRIPTION
This approach wraps the lists in divs, which fixes the indentation without any css

CC @erik-whiting @matentzn 
 
<img width="1461" alt="Screenshot 2022-10-28 at 09 48 02" src="https://user-images.githubusercontent.com/5069736/198533208-56099e5b-a9e1-4f00-ae55-9f4b81884ba3.png">

