### PR TITLE
new OBO Ops logistics page

### DIFF
--- a/docs/OBOOpsLogistics.md
+++ b/docs/OBOOpsLogistics.md
@@ -1,0 +1,43 @@
+---
+layout: doc
+id: OBOOpsLogistics
+title: OBO Operations Committee: Logistics
+---
+
+## Joining the OBO Operations Committee
+Please see the [SOP](https://obofoundry.org/docs/SOP.html#OPS_MEMBER)
+
+## Chairing an OBO Operations Committee meeting call
+Please see the [SOP](https://obofoundry.org/docs/SOP.html#OPS_CHAIR)
+
+## Meeting calendar
+
+The OBO Foundry calendar is publicly available to view at http://www.google.com/calendar/embed?src=cW8yM2Q3NDliajh0ZGwwb2VlNnRhdnBoc3NAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ. Please see below for how to add it to your own calendar.
+Everybody can see it; however only a subset of people can edit it. Maintenance of the calendar is done on a per request basis, and only approved people have editing rights to prevent spamming.
+
+This calendar contains event such as
+(1) OBO meetings, for example the regular OBI developer call or the ad-hoc OGMS discussion on diagnosis
+(2) events of interest to the community: the NCBO webinars, or the ontolog sessions
+(3) meetings and workshops, such as ICBO, NCBO events etc. Deadlines would be acceptable (e.g. September 5th, deadline for tutorial proposal for some conference)
+
+Personal events are not appropriate for this calendar (e.g. Z on vacation) and adding those will result in editing rights being revoked.
+
+### Add the OBO Foundry calendar to your own
+
+The iCal URL of the OBO Foundry calendar is https://www.google.com/calendar/ical/qo23d749bj8tdl0oee6tavphss%40group.calendar.google.com/public/basic.ics
+
+To add it to your google calendar, select "Other calendars" in the left menu, then click the arrow and choose "add by URL"
+
+(based on information from http://support.google.com/calendar/bin/answer.py?hl=en&answer=37100)
+
+### Warning regarding responding to invitations on the OBO calendar
+
+When replying to a calendar invitation **you need to accept/decline in your own copy of the event**. Declining an event in the shared calendar deletes it for everybody.
+
+## Mailing lists
+
+(All are restricted access and subscription, non-members may post (posts held for moderator approval))
+- [obo-operations-committee](https://groups.google.com/forum/?fromgroups#!forum/obo-operations-committee)
+- [Technical group](https://groups.google.com/forum/?fromgroups#!forum/obo-foundry-technical-working-group)
+- [Editorial working group](https://groups.google.com/forum/?fromgroups#!forum/obo-foundry-editorial-working-group)
+- [Outreach working group](https://groups.google.com/forum/?fromgroups#!forum/obo-foundry-outreach-working-group)

--- a/docs/OBOOpsLogistics.md
+++ b/docs/OBOOpsLogistics.md
@@ -1,7 +1,6 @@
 ---
 layout: doc
-id: OBOOpsLogistics
-title: OBO Operations Committee: Logistics
+title: OBO Operations Committee Logistics
 ---
 
 ## Joining the OBO Operations Committee
@@ -20,7 +19,7 @@ This calendar contains event such as
 (2) events of interest to the community: the NCBO webinars, or the ontolog sessions
 (3) meetings and workshops, such as ICBO, NCBO events etc. Deadlines would be acceptable (e.g. September 5th, deadline for tutorial proposal for some conference)
 
-Personal events are not appropriate for this calendar (e.g. Z on vacation) and adding those will result in editing rights being revoked.
+Personal events are not appropriate for this calendar (e.g. "Z on vacation") and adding those will result in editing rights being revoked.
 
 ### Add the OBO Foundry calendar to your own
 


### PR DESCRIPTION
merges content from https://obofoundry.org/docs/CommitteeMeetings.html, https://obofoundry.org/docs/OBOCalendar.html, and https://obofoundry.org/docs/MailingLists.html (and will therefore obsolete all of these pages; I will also remove links to them from the sidebar) addresses latest comment in #2167