### PR TITLE
Update sidebar for committee/WG pages

### DIFF
--- a/_includes/docs_toc.md
+++ b/_includes/docs_toc.md
@@ -1,10 +1,8 @@
 [Operations Committee](/docs/OperationsCommittee.html)
 
 - [Membership](/docs/Membership.html)
-- [Meetings](/docs/CommitteeMeetings.html)
+- [Logistics](/docs/OBOOpsLogistics.md)
 - [Policy Decisions](/docs/OperationsCommitteePolicyDecisions.html)
-- [Mailing Lists](/docs/MailingLists.html)
-- [OBO Calendar](/docs/OBOCalendar.html)
 
 [Editorial Working Group](/docs/EditorialWG.html)
 


### PR DESCRIPTION
Remove obsolete links, add new logistics page (see PR #2180). This should be merged along with #2180.