### PR TITLE
Remove redundant page in editorial WG

### DIFF
--- a/docs/EditorialWG.md
+++ b/docs/EditorialWG.md
@@ -22,7 +22,6 @@ Current activities are focused on creating guidelines for reviews. Once those gu
 
 - [Ontology review process guidelines](/docs/ReviewProcessGuidelines.html)
 - [Ontology review criteria policies](/docs/ReviewCriteriaPolicies.html)
-- [Ontology review management guidelines](/docs/ReviewManagementGuidelines.html)
 
 ### Principles Review
 

--- a/docs/ReviewManagementGuidelines.md
+++ b/docs/ReviewManagementGuidelines.md
@@ -1,7 +1,0 @@
----
-layout: doc
-id: ReviewManagementGuidelines
-title: Review Management Guidelines
----
-
-This page was originally created to cover guidelines for managing reviews. That material is not covered in the [ontology review process guidelines](/docs/ReviewProcessGuidelines.html) and the [ontology review criteria policies](/docs/ReviewCriteriaPolicies.html).


### PR DESCRIPTION
ReviewManagementGuidelines.md has links to two other newer files and is otherwise a stub page.

EditorialWG.md is the only file that links to it, and directly next to that link are also the two links that it contains.

This file is completely redundant.