### PR TITLE
Curate RORs for operations committee

### DIFF
--- a/_data/operations.yml
+++ b/_data/operations.yml
@@ -7,6 +7,7 @@ members:
   link: http://sciencecommons.org/about/whoweare/ruttenberg/
   name: Alan Ruttenberg
   orcid: 0000-0002-1604-3078
+  ror: 01y64my43
   wikidata: Q30508557
 - affiliation: University at Buffalo, Buffalo, NY
   country: USA
@@ -15,6 +16,7 @@ members:
   - technical
   name: Alexander Diehl
   orcid: 0000-0001-9990-8331
+  ror: 01y64my43
   wikidata: Q47502183
 - affiliation: University at Buffalo, Buffalo, NY
   country: USA
@@ -23,6 +25,7 @@ members:
   - outreach
   name: Barry Smith
   orcid: 0000-0003-1384-116X
+  ror: 01y64my43
   wikidata: Q809101
 - affiliation: University of Florida, Gainseville, FL
   country: USA
@@ -31,6 +34,7 @@ members:
   - editorial
   name: Bill Duncan
   orcid: 0000-0001-9625-1899
+  ror: 02y3ad647
   wikidata: Q89881908
 - affiliation: University of Florida, Gainseville, FL
   country: USA
@@ -39,6 +43,7 @@ members:
   - editorial
   name: Bill Hogan
   orcid: 0000-0002-9881-1017
+  ror: 02y3ad647
   wikidata: Q56590169
 - affiliation: La Jolla Institute for Immunology, La Jolla, CA
   country: USA
@@ -48,6 +53,7 @@ members:
   link: https://www.lji.org/labs/peters/
   name: Bjoern Peters
   orcid: 0000-0002-8457-6693
+  ror: 05vkpd318
   wikidata: Q60541156
 - affiliation: Lawrence Berkeley National Laboratory, Berkeley, CA
   country: USA
@@ -57,6 +63,7 @@ members:
   link: https://github.com/cmungall/
   name: Chris Mungall
   orcid: 0000-0002-6601-2165
+  ror: 02jbv0t02
   wikidata: Q20746118
 - affiliation: University of Pennsylvania, Philadelphia, PA
   country: USA
@@ -66,6 +73,7 @@ members:
   - editorial
   name: Chris Stoeckert
   orcid: 0000-0002-5714-991X
+  ror: 00b30xv10
   wikidata: Q67220657
 - affiliation: Centre for Infectious Disease Genomics and One Health, Simon Fraser University, BC
   country: Canada
@@ -74,6 +82,7 @@ members:
   - outreach
   name: Damion Dooley
   orcid: 0000-0002-8844-9165
+  ror: 0213rcc28
   wikidata: Q91868864
 - affiliation: Georgetown University Medical Center, Washington DC
   country: USA
@@ -83,6 +92,7 @@ members:
   link: http://pir.georgetown.edu/pirwww/aboutpir/natalebio.shtml
   name: Darren Natale
   orcid: 0000-0001-5809-9523
+  ror: 00hjz7x27
   wikidata: Q99552327
 - affiliation: EMBL-EBI, Cambridge
   country: UK
@@ -91,6 +101,7 @@ members:
   - outreach
   name: David Osumi-Sutherland
   orcid: 0000-0002-7073-9172
+  ror: 02catss52
   wikidata: Q54303418
 - affiliation: Kansas State University, Manhattan, KS
   country: USA
@@ -100,8 +111,10 @@ members:
   - outreach
   name: Hande Küçük McGinty
   orcid: 0000-0002-9025-5538
+  ror: 05p1j8758
   wikidata: Q107527234
 - affiliation: Knocean Inc., Toronto
+  affiliation_wikidata: Q115518163
   country: Canada
   github: jamesaoverton
   groups:
@@ -118,6 +131,7 @@ members:
   - technical
   name: Jie Zheng
   orcid: 0000-0002-2999-0103
+  ror: 00b30xv10
   wikidata: Q90780528
 - affiliation: RENCI, University of North Carolina, Chapel Hill, NC
   country: USA
@@ -126,6 +140,7 @@ members:
   - technical
   name: Jim Balhoff
   orcid: 0000-0002-8688-6599
+  ror: 01s91ey96
   wikidata: Q37649212
 - affiliation: University of Maryland School of Medicine, Baltimore, MD
   country: USA
@@ -136,8 +151,9 @@ members:
   link: http://www.medschool.umaryland.edu/profiles/Schriml-Lynn/
   name: Lynn Schriml
   orcid: 0000-0001-8910-9851
+  ror: 01r0c1p88
   wikidata: Q28913673
-- affiliation: Unversity of Colorado Anschutz Medical Campus, Auroa, CO
+- affiliation: University of Colorado Anschutz Medical Campus, Aurora, CO
   country: USA
   github: mbrush
   groups:
@@ -157,6 +173,7 @@ members:
   ror: 03wmf1y16
   wikidata: Q28368079
 - affiliation: Semanticly, Athens
+  affiliation_wikidata: Q115518213
   country: Greece
   github: matentzn
   groups:
@@ -182,6 +199,7 @@ members:
   - technical
   name: Nomi Harris
   orcid: 0000-0001-6315-3707
+  ror: 02jbv0t02
   wikidata: Q58106602
 - affiliation: University of Oxford e-Research Centre, Department of Engineering Science, Oxford
   country: UK
@@ -191,6 +209,7 @@ members:
   link: https://eng.ox.ac.uk/people/philippe-rocca-serra/
   name: Philippe Rocca-Serra
   orcid: 0000-0001-9853-5668
+  ror: 052gg0110
   wikidata: Q28364404
 - affiliation: Alfred Wegener Institute, Helmholtz Centre for Polar and Marine Research, Bremerhaven
   country: Germany
@@ -200,6 +219,7 @@ members:
   - outreach
   name: Pier Luigi Buttigieg
   orcid: 0000-0002-4366-3088
+  ror: 032e6b942
   wikidata: Q41566750
 - affiliation: CyVerse, University of Arizona, Tucson, AZ
   country: USA
@@ -210,6 +230,7 @@ members:
   link: http://www.cyverse.org/ramona-walls
   name: Ramona Walls
   orcid: 0000-0001-8815-0078
+  ror: 03m2x1q45
   wikidata: Q63240627
 - affiliation: La Jolla Institute for Immunology, La Jolla, CA
   country: USA
@@ -218,6 +239,7 @@ members:
   - outreach
   name: Randi Vita
   orcid: 0000-0001-8957-7612
+  ror: 05vkpd318
   wikidata: Q58116889
 - affiliation: Intelligent Medical Objects (IMO), Rosemont, IL
   country: USA
@@ -226,6 +248,7 @@ members:
   - technical
   name: Rebecca Jackson
   orcid: 0000-0003-4871-5569
+  ror: 03y46nb69
   wikidata: Q59539088
 - affiliation: J. Craig Venter Institute, La Jolla, CA
   country: USA
@@ -235,6 +258,7 @@ members:
   link: https://www.jcvi.org/about/rscheuermann
   name: Richard Scheuermann
   orcid: 0000-0003-1355-892X
+  ror: 049r1ts75
   wikidata: Q30508615
 - affiliation: Lawrence Berkeley National Laboratory, Berkeley, CA
   country: USA
@@ -243,6 +267,7 @@ members:
   - technical
   name: Seth Carbon
   orcid: 0000-0001-8244-1536
+  ror: 02jbv0t02
   wikidata: Q57081961
 - affiliation: European Bioinformatics Institute, Cambridge
   country: UK
@@ -251,4 +276,5 @@ members:
   - technical
   name: Shawn Tan
   orcid: 0000-0001-7258-9596
+  ror: 02catss52
   wikidata: Q57023310

--- a/tests/test_memberships.py
+++ b/tests/test_memberships.py
@@ -3,7 +3,8 @@
 import unittest
 from collections import Counter
 from pathlib import Path
-from typing import List, Literal
+from textwrap import dedent
+from typing import List, Literal, Optional
 
 import yaml
 from pydantic import BaseModel
@@ -23,8 +24,10 @@ class Member(BaseModel):
     wikidata: str
     github: str
     affiliation: str
+    affiliation_wikidata: Optional[str]
     country: str
     groups: List[Literal["editorial", "outreach", "technical"]]
+    ror: Optional[str]
 
 
 class Group(BaseModel):
@@ -40,9 +43,22 @@ class TestMembershipData(unittest.TestCase):
         """Test the working group data is clean."""
         res = Group.parse_obj(yaml.safe_load(OPERATIONS_METADATA_PATH.read_text()))
         self.assertIsNotNone(res)
-        counter = Counter(member.orcid for member in res.members if member.orcid)
+        counter = Counter(member.orcid for member in res.members)
         counter = {orcid for orcid, count in counter.items() if count > 1}
         self.assertEqual(0, len(counter), msg=f"Duplicate: {counter}")
+        for person in res.members:
+            with self.subTest(name=person.name):
+                self.assertTrue(
+                    person.ror is not None or person.affiliation_wikidata is not None,
+                    msg=dedent(
+                        f"""\
+                        No ROR nor Wikidata identifier was curated for {person.name}.
+                        Please search https://ror.org for their affiliation. If none exists, please
+                        submit a new ROR ID request (linked from bottom of homepage). If the request
+                        is rejected, create a Wikidata entry and annotate in the `affiliation_wikidata` field.
+                    """.rstrip()
+                    ),
+                )
 
     def test_alumni(self):
         """Test the alumni data."""


### PR DESCRIPTION
As a follow-up to https://github.com/OBOFoundry/OBOFoundry.github.io/pull/2131, this PR closes #2127 by adding RORs for all OBO operations committee members. For the case of Nico and James whose primary affiliations are companies, I tried doing ROR requests (https://github.com/ror-community/ror-updates/issues/1735 and https://github.com/ror-community/ror-updates/issues/1737) but these were rejected due to one-person companies being out of scope for ROR, so I made Wikidata identifiers instead.

## Benefits of RORs

There are lots of typos and inconsistencies in the affiliations written so far - RORs are a nice way of being able to programatically look up information about affiliations (e.g., country, city) and assigning a canonical name. These will be useful for some of the OBO Foundry community summaries I've been developing.

## Drawbacks of RORs

It's explicitly out of scope for ROR to model internal organizational structure (so no colleges, departments, etc can get RORs) so it's not super granular.