### PR TITLE
Strengthen metadata standards for roles

### DIFF
--- a/_data/operations.yml
+++ b/_data/operations.yml
@@ -18,15 +18,6 @@ members:
   orcid: 0000-0001-9990-8331
   ror: 01y64my43
   wikidata: Q47502183
-- affiliation: University at Buffalo, Buffalo, NY
-  country: USA
-  github: phismith
-  groups:
-  - outreach
-  name: Barry Smith
-  orcid: 0000-0003-1384-116X
-  ror: 01y64my43
-  wikidata: Q809101
 - affiliation: European Bioinformatics Institute (EMBL-EBI), Cambridge
   country: UK
   github: anitacaron
@@ -36,6 +27,15 @@ members:
   orcid: 0000-0002-6523-4866
   ror: 02catss52
   wikidata: Q114518421
+- affiliation: University at Buffalo, Buffalo, NY
+  country: USA
+  github: phismith
+  groups:
+  - outreach
+  name: Barry Smith
+  orcid: 0000-0003-1384-116X
+  ror: 01y64my43
+  wikidata: Q809101
 - affiliation: University of Florida, Gainseville, FL
   country: USA
   github: wdduncan
@@ -250,6 +250,15 @@ members:
   orcid: 0000-0001-8957-7612
   ror: 05vkpd318
   wikidata: Q58116889
+- affiliation: European Bioinformatics Institute (EMBL-EBI), Cambridge
+  country: UK
+  github: rays22
+  groups:
+  - technical
+  name: Ray Stefancsik
+  orcid: 0000-0001-8314-2140
+  ror: 02catss52
+  wikidata: Q52097457
 - affiliation: Intelligent Medical Objects (IMO), Rosemont, IL
   country: USA
   github: beckyjackson
@@ -287,12 +296,3 @@ members:
   orcid: 0000-0001-7258-9596
   ror: 02catss52
   wikidata: Q57023310
-- affiliation: European Bioinformatics Institute (EMBL-EBI), Cambridge
-  country: UK
-  github: rays22
-  groups:
-  - technical
-  name: Ray Stefancsik
-  orcid: 0000-0001-8314-2140
-  ror: 02catss52
-  wikidata: Q52097457

--- a/_data/roles.yml
+++ b/_data/roles.yml
@@ -22,7 +22,9 @@
       github: matentzn
       orcid: 0000-0002-7356-1779
       status: support
-    - name: deepakunni3
+      start: "0000-00-00"
+    - github: deepakunni3
+      name: Deepak Unni
       orcid: 0000-0002-3583-7340
       status: lead
       start: 2022-12
@@ -49,7 +51,8 @@
       orcid: 0000-0002-7356-1779
       status: support
       start: "0000-00-00"
-    - name: pfabry
+    - github: pfabry
+      name: Paul Fabry
       orcid: 0000-0002-3336-2476
       status: lead
       start: 2022-12
@@ -110,7 +113,8 @@
     to OBO Ops.
   responsibilities:
   people:
-    - name: rays22
+    - github: rays22
+      name: Ray Stefancsik
       orcid: 0000-0001-8314-2140
       status: lead
       start: 2022-12
@@ -218,7 +222,8 @@
     - Managing public and internal OBO Google Drives
     - Report adding members to the to any OBO Google drive with Write or Admin rights to the OBO Operations Committee
   people:
-    - name: nlharris
+    - github: nlharris
+      name: Nomi Harris
       orcid: 0000-0001-6315-3707
       status: lead
       start: 2019-01

--- a/_data/roles.yml
+++ b/_data/roles.yml
@@ -18,7 +18,8 @@
     - The Registry Metadata Steward is not required to fix issues with the metadata proactively, but may choose to do so at their own discretion.
     - Provide monthly summary to Technical Working Group OBO Operations liaison for report to OBO Operations Committee.
   people:
-    - name: matentzn
+    - name: Nico Matentzoglu
+      github: matentzn
       orcid: 0000-0002-7356-1779
       status: support
     - name: deepakunni3
@@ -43,9 +44,11 @@
     - Assigning and reminding OBO Operations Committee Members as reviewers
     - Assisting successful NOR submitters to making registry metadata and PURL pull requests
   people:
-    - name: matentzn
+    - name: Nico Matentzoglu
+      github: matentzn
       orcid: 0000-0002-7356-1779
       status: support
+      start: "0000-00-00"
     - name: pfabry
       orcid: 0000-0002-3336-2476
       status: lead
@@ -61,13 +64,16 @@
   description: You will be responsible for gatekeeping community changes to the website.
   responsibilities:
   people:
-    - name: erik-whiting
+    - github: erik-whiting
+      name: Erik Whiting
       orcid: 0000-0003-1022-5281
       status: lead
       start: 2022-12
-    - name: matentzn
+    - github: matentzn
+      name: Nico Matentzoglu
       orcid: 0000-0002-7356-1779
       status: support
+      start: "0000-00-00"
 - name: OBO Dashboard Maintainer
   open: false
   commitment: 2-10 hours per month
@@ -80,11 +86,14 @@
     Working with OBO Ops to find people for extending dashboard when new principles come along.
   responsibilities:
   people:
-    - name: anitacaron
+    - github: anitacaron
+      name: Anita Caron
       orcid: 0000-0002-6523-4866
       status: lead
       start: 2022-12
-    - name: matentzn
+    - github: matentzn
+      name: Nico Matentzoglu
+      start: "0000-00-00"
       orcid: 0000-0002-7356-1779
       status: support
 - name: Technical Working Group OBO Operations liaison
@@ -105,16 +114,19 @@
       orcid: 0000-0001-8314-2140
       status: lead
       start: 2022-12
-    - name: matentzn
+    - github: matentzn
+      name: Nico Matentzoglu
       orcid: 0000-0002-7356-1779
       status: support
+      start: "0000-00-00"
 - name: PURL system maintainer
   open: false
   description: |
     PURL config curation and PURL server maintenance.
   responsibilities:
   people:
-    - name: jamesaoverton
+    - name: James A. Overton
+      github: jamesaoverton
       orcid: 0000-0001-5139-5557
       status: lead
       start: 2015-11
@@ -125,12 +137,16 @@
     owners pass them.
   responsibilities:
   people:
-    - name: zhengj2007
+    - name: Jie Zheng
+      github: zhengj2007
       orcid: 0000-0002-2999-0103
       status: lead
-    - name: matentzn
+      start: "0000-00-00"
+    - name: Nico Matentzoglu
+      github: matentzn
       orcid: 0000-0002-7356-1779
       status: lead
+      start: "0000-00-00"
 - name: OBO Tools coordinator
   open: false
   description: |
@@ -138,7 +154,8 @@
      making sure tools align with OBO principles and support them, etc.)
   responsibilities:
   people:
-    - name: jamesaoverton
+    - name: James A. Overton
+      github: jamesaoverton
       orcid: 0000-0001-5139-5557
       status: lead
       start: 2017
@@ -148,27 +165,33 @@
     Maintaining https://oboacademy.github.io/obook/ and organising OBO Tutorials.
   responsibilities:
   people:
-    - name: nicolevasilevsky
+    - name: Nicole Vasilevsky
+      github: nicolevasilevsky
       orcid: 0000-0001-5208-3432
       status: lead
       start: 2021-06
-    - name: matentzn
+    - name: Nico Matentzoglu
+      github: matentzn
       orcid: 0000-0002-7356-1779
       status: lead
       start: 2021-06
-    - name: jamesaoverton
+    - name: James A. Overton
+      github: jamesaoverton
       orcid: 0000-0001-5139-5557
       status: support
       start: 2021-06
-    - name: beckyjackson
+    - name: Rebecca Jackson
+      github: beckyjackson
       orcid: 0000-0003-4871-5569
       status: support
       start: 2021-06
-    - name: shawntanzk
+    - name: Shawn Tan
+      github: shawntanzk
       orcid: 0000-0001-7258-9596
       status: support
       start: 2022
-    - name: bvarner-ebi
+    - name: Bradley Varner
+      github: bvarner-ebi
       status: support
       orcid: 0000-0002-1773-2692
       start: 2022
@@ -179,7 +202,8 @@
   responsibilities:
     - "Tagging metadata related issues with 'attn: Technical Working WG' and 'metadata'."
   people:
-    - name: nlharris
+    - name: Nomi Harris
+      github: nlharris
       orcid: 0000-0001-6315-3707
       status: lead
       start: 2019-01

--- a/docs/roles/overview.md
+++ b/docs/roles/overview.md
@@ -48,6 +48,7 @@ See [here]({{ role.sop }}).
 <thead>
 <tr>
 <th>Name</th>
+<th>GitHub</th>
 <th>ORCID</th>
 <th>Status</th>
 <th>Start</th>
@@ -57,6 +58,7 @@ See [here]({{ role.sop }}).
 {% for person in role.people %}
 <tr>
     <td>{{ person.name }}</td>
+    <td><a href="https://github.com/{{ person.github }}">{{ person.github }}</a></td>
     <td><a href="https://orcid.org/{{ person.orcid }}">{{ person.orcid }}</a></td>
     <td>{{ person.status }}</td>
     <td>{{ person.start }}</td>

--- a/tests/test_roles.py
+++ b/tests/test_roles.py
@@ -19,10 +19,11 @@ class Person(BaseModel):
     """A model for a person."""
 
     name: str
+    github: str
     orcid: str
     status: Literal["lead", "support"]
-    start: Optional[str]  # can later be parsed more carefully
-    # TODO add github
+    start: str
+    end: Optional[str]
 
 
 class Role(BaseModel):


### PR DESCRIPTION
This PR does the following:

1.  enforces that start dates are added for all people (adds placeholders for the many roles of Nico)
2. Renames `name` field to `github` for all people, not sure how this misannotation happened in a community of esteemed OBO curators :p 
3. Adds readable names to all people