### PR TITLE
Add check for OFOC images

### DIFF
--- a/tests/test_memberships.py
+++ b/tests/test_memberships.py
@@ -14,6 +14,7 @@ from obofoundry.constants import ALUMNI_METADATA_PATH, OPERATIONS_METADATA_PATH
 HERE = Path(__file__).parent.resolve()
 ROOT = HERE.parent.resolve()
 DATA = ROOT.joinpath("_data")
+OFOC_IMAGS = ROOT.joinpath("images", "ofoc")
 
 
 class Affiliation(BaseModel):
@@ -64,6 +65,14 @@ class TestMembershipData(unittest.TestCase):
                         is rejected, create a Wikidata entry and annotate in the `affiliation_wikidata` field.
                     """.rstrip()
                     ),
+                )
+                stub = OFOC_IMAGS.joinpath(person.github)
+                self.assertTrue(
+                    any(
+                        stub.with_suffix(suffix).is_file()
+                        for suffix in [".png", ".jpg"]
+                    ),
+                    msg=f"{person.name} is missing a photo in {OFOC_IMAGS} that matches their github handle",
                 )
 
     def test_encoding(self):

--- a/tests/test_memberships.py
+++ b/tests/test_memberships.py
@@ -68,10 +68,7 @@ class TestMembershipData(unittest.TestCase):
                 )
                 stub = OFOC_IMAGS.joinpath(person.github)
                 self.assertTrue(
-                    any(
-                        stub.with_suffix(suffix).is_file()
-                        for suffix in [".png", ".jpg"]
-                    ),
+                    OFOC_IMAGS.joinpath(person.github).with_suffix(".png").is_file(),
                     msg=f"{person.name} is missing a photo in {OFOC_IMAGS} that matches their github handle",
                 )
 


### PR DESCRIPTION
This PR adds a unit test checking that each OFOC member has a corresponding photo in the images/ofoc folder that corresponds to their github handle