### PR TITLE
Add automated license correspondence check

### DIFF
--- a/src/obofoundry/utils.py
+++ b/src/obofoundry/utils.py
@@ -45,7 +45,7 @@ def query_wikidata(query: str):
 
 
 def get_new_data():
-    """Get records for ontologies that have additional checks
+    """Get records for ontologies that have additional checks.
 
     So far, this applies in the following scenarios:
 

--- a/src/obofoundry/utils.py
+++ b/src/obofoundry/utils.py
@@ -3,11 +3,12 @@
 import requests
 import yaml
 
-from obofoundry.constants import ONTOLOGY_DIRECTORY
+from obofoundry.constants import ONTOLOGY_DIRECTORY, ROOT
 
 __all__ = [
     "get_data",
     "query_wikidata",
+    "get_new_data",
 ]
 
 
@@ -41,3 +42,20 @@ def query_wikidata(query: str):
     res.raise_for_status()
     res_json = res.json()
     return res_json["results"]["bindings"]
+
+
+def get_new_data():
+    """Get records for ontologies that have additional checks
+
+    So far, this applies in the following scenarios:
+
+    1. New ontologies, i.e., there's a markdown file for the ontology in the ``/ontologies`` directory
+       but has it not yet been published and does not appear in the config.yml
+    """
+    data = get_data()
+    config_path = ROOT.joinpath("_config.yml")
+    config_data = yaml.safe_load(config_path.read_text())
+    published = {record["id"] for record in config_data["ontologies"]}
+    return {
+        prefix: record for prefix, record in data.items() if prefix not in published
+    }

--- a/tests/test_integrity.py
+++ b/tests/test_integrity.py
@@ -2,7 +2,6 @@
 
 import json
 import unittest
-from functools import lru_cache
 from io import StringIO
 from pathlib import Path
 from typing import Set

--- a/tests/test_integrity.py
+++ b/tests/test_integrity.py
@@ -300,6 +300,14 @@ class TestModernIntegrity(unittest.TestCase):
                 self.assertIsNotNone(
                     spdx, msg="No LICENSE file found in the repository"
                 )
+                self.assertNotEqual(
+                    "NOASSERTION",
+                    spdx,
+                    msg="Either no LICENSE file was found or the LICENSE file does not have a standard format that "
+                        "GitHub can parse. See https://docs.github.com/en/repositories/managing-your-"
+                        "repositorys-settings-and-features/customizing-your-repository/licensing-a-"
+                        "repository#detecting-a-license for information on how GitHub does this.",
+                )
                 self.assertIn(
                     spdx,
                     ALLOWED_SPDX,

--- a/tests/test_integrity.py
+++ b/tests/test_integrity.py
@@ -29,6 +29,11 @@ ALLOWED_SPDX = {
     "CC-BY-3.0",  # see https://bioregistry.io/spdx:CC-BY-3.0
     "CC-BY-4.0",  # see https://bioregistry.io/spdx:CC-BY-4.0
 }
+OBO_TO_SPDX = {
+    "CC BY 4.0": "CC-BY-4.0",
+    "CC BY 3.0": "CC-BY-3.0",
+    "CC0": "CC0-1.0",
+}
 
 
 class TestIntegrity(unittest.TestCase):
@@ -304,9 +309,9 @@ class TestModernIntegrity(unittest.TestCase):
                     "NOASSERTION",
                     spdx,
                     msg="Either no LICENSE file was found or the LICENSE file does not have a standard format that "
-                        "GitHub can parse. See https://docs.github.com/en/repositories/managing-your-"
-                        "repositorys-settings-and-features/customizing-your-repository/licensing-a-"
-                        "repository#detecting-a-license for information on how GitHub does this.",
+                    "GitHub can parse. See https://docs.github.com/en/repositories/managing-your-"
+                    "repositorys-settings-and-features/customizing-your-repository/licensing-a-"
+                    "repository#detecting-a-license for information on how GitHub does this.",
                 )
                 self.assertIn(
                     spdx,
@@ -314,4 +319,10 @@ class TestModernIntegrity(unittest.TestCase):
                     msg=f"LICENSE file does not follow a standard format for"
                     f" one of the allowed license types ({ALLOWED_SPDX})",
                 )
-                # TODO match github to metadata in obo submission
+
+                obo_license = data["license"]["label"]
+                self.assertEqual(
+                    spdx,
+                    OBO_TO_SPDX[obo_license],
+                    msg="OBO Foundry license annotation does not match GitHub license",
+                )

--- a/tests/test_integrity.py
+++ b/tests/test_integrity.py
@@ -314,3 +314,4 @@ class TestModernIntegrity(unittest.TestCase):
                     msg=f"LICENSE file does not follow a standard format for"
                     f" one of the allowed license types ({ALLOWED_SPDX})",
                 )
+                # TODO match github to metadata in obo submission

--- a/tests/test_memberships.py
+++ b/tests/test_memberships.py
@@ -56,7 +56,8 @@ class TestMembershipData(unittest.TestCase):
         for person in res.members:
             with self.subTest(name=person.name):
                 self.assertFalse(
-                    person.affiliation.ror is None and person.affiliation.wikidata is None,
+                    person.affiliation.ror is None
+                    and person.affiliation.wikidata is None,
                     msg=dedent(
                         f"""\
                         No ROR nor Wikidata identifier was curated for {person.name}.


### PR DESCRIPTION
Closes #2276

This PR adds a check for new ontologies that are currently in review to check that the license in the submitted metadata matches what's shown in GitHub. Implicitly, this now requires new ontologies have an appropriate LICENSE file.