### PR TITLE
Upgrade BioSharing links to FAIRsharing

### DIFF
--- a/ontology/cl.md
+++ b/ontology/cl.md
@@ -116,7 +116,7 @@ usages:
   publications:
   - id: https://www.ncbi.nlm.nih.gov/pubmed/25776021
     title: Ontology application and use at the ENCODE DCC
-  seeAlso: https://www.biosharing.org/biodbcore-000034
+  seeAlso: https://fairsharing.org/FAIRsharing.v0hbjs
   type: annotation
   user: https://www.encodeproject.org/
 - description: FANTOM5 is using Uberon and CL to annotate samples allowing for transcriptome analyses with cell-type and tissue-level specificity.

--- a/ontology/cl.md
+++ b/ontology/cl.md
@@ -116,7 +116,7 @@ usages:
   publications:
   - id: https://www.ncbi.nlm.nih.gov/pubmed/25776021
     title: Ontology application and use at the ENCODE DCC
-  seeAlso: https://fairsharing.org/FAIRsharing.v0hbjs
+  seeAlso: https://doi.org/10.25504/FAIRsharing.v0hbjs
   type: annotation
   user: https://www.encodeproject.org/
 - description: FANTOM5 is using Uberon and CL to annotate samples allowing for transcriptome analyses with cell-type and tissue-level specificity.

--- a/ontology/emapa.md
+++ b/ontology/emapa.md
@@ -37,7 +37,7 @@ taxon:
 tracker: https://github.com/obophenotype/mouse-anatomy-ontology/issues
 usages:
 - description: GXD
-  seeAlso: https://fairsharing.org/FAIRsharing.q9neh8
+  seeAlso: https://doi.org/10.25504/FAIRsharing.q9neh8
   user: http://www.informatics.jax.org/expression.shtml
 activity_status: active
 ---

--- a/ontology/emapa.md
+++ b/ontology/emapa.md
@@ -37,7 +37,7 @@ taxon:
 tracker: https://github.com/obophenotype/mouse-anatomy-ontology/issues
 usages:
 - description: GXD
-  seeAlso: https://www.biosharing.org/biodbcore-000659
+  seeAlso: https://fairsharing.org/FAIRsharing.q9neh8
   user: http://www.informatics.jax.org/expression.shtml
 activity_status: active
 ---

--- a/ontology/ma.md
+++ b/ontology/ma.md
@@ -30,7 +30,7 @@ taxon:
 tracker: https://github.com/obophenotype/mouse-anatomy-ontology/issues
 usages:
 - description: GXD
-  seeAlso: https://fairsharing.org/FAIRsharing.q9neh8
+  seeAlso: https://doi.org/10.25504/FAIRsharing.q9neh8
   user: http://www.informatics.jax.org/expression.shtml
 activity_status: active
 ---

--- a/ontology/ma.md
+++ b/ontology/ma.md
@@ -30,7 +30,7 @@ taxon:
 tracker: https://github.com/obophenotype/mouse-anatomy-ontology/issues
 usages:
 - description: GXD
-  seeAlso: https://www.biosharing.org/biodbcore-000659
+  seeAlso: https://fairsharing.org/FAIRsharing.q9neh8
   user: http://www.informatics.jax.org/expression.shtml
 activity_status: active
 ---

--- a/ontology/uberon.md
+++ b/ontology/uberon.md
@@ -140,7 +140,7 @@ usages:
   publications:
   - id: https://www.ncbi.nlm.nih.gov/pubmed/25776021
     title: Ontology application and use at the ENCODE DCC
-  seeAlso: https://fairsharing.org/FAIRsharing.v0hbjs
+  seeAlso: https://doi.org/10.25504/FAIRsharing.v0hbjs
   type: annotation
   user: https://www.encodeproject.org/
 - description: FANTOM5 is using Uberon and CL to annotate samples allowing for transcriptome analyses with cell-type and tissue-level specificity.

--- a/ontology/uberon.md
+++ b/ontology/uberon.md
@@ -133,14 +133,14 @@ usages:
   examples:
   - description: Uberon terms used to annotate expression of human hemoglobin subunit beta
     url: http://bgee.org/?page=gene&gene_id=ENSG00000244734
-  seeAlso: https://www.biosharing.org/biodbcore-000228
+  seeAlso: https://fairsharing.org/FAIRsharing.x6d6sx
   type: annotation
   user: http://bgee.org/
 - description: The National Human Genome Research Institute (NHGRI) launched a public research consortium named ENCODE, the Encyclopedia Of DNA Elements, in September 2003, to carry out a project to identify all functional elements in the human genome sequence. The ENCODE DCC users Uberon to annotate samples
   publications:
   - id: https://www.ncbi.nlm.nih.gov/pubmed/25776021
     title: Ontology application and use at the ENCODE DCC
-  seeAlso: https://www.biosharing.org/biodbcore-000034
+  seeAlso: https://fairsharing.org/FAIRsharing.v0hbjs
   type: annotation
   user: https://www.encodeproject.org/
 - description: FANTOM5 is using Uberon and CL to annotate samples allowing for transcriptome analyses with cell-type and tissue-level specificity.

--- a/ontology/uberon.md
+++ b/ontology/uberon.md
@@ -133,7 +133,7 @@ usages:
   examples:
   - description: Uberon terms used to annotate expression of human hemoglobin subunit beta
     url: http://bgee.org/?page=gene&gene_id=ENSG00000244734
-  seeAlso: https://fairsharing.org/FAIRsharing.x6d6sx
+  seeAlso: https://doi.org/10.25504/FAIRsharing.x6d6sx
   type: annotation
   user: http://bgee.org/
 - description: The National Human Genome Research Institute (NHGRI) launched a public research consortium named ENCODE, the Encyclopedia Of DNA Elements, in September 2003, to carry out a project to identify all functional elements in the human genome sequence. The ENCODE DCC users Uberon to annotate samples


### PR DESCRIPTION
This PR replaces legacy BioSharing links with FAIRsharing links.

| Name | BioSharing | FAIRsharing | Affects |
|-------|------|-----|------|
| ENCODE | https://www.biosharing.org/biodbcore-000034 | https://fairsharing.org/FAIRsharing.v0hbjs | CL, UBERON |
| GXD | https://www.biosharing.org/biodbcore-000659 | https://fairsharing.org/FAIRsharing.q9neh8 | EMAPA, MA |
| Bgee | https://www.biosharing.org/biodbcore-000228 | https://fairsharing.org/FAIRsharing.x6d6sx | UBERON |

Closes https://github.com/obophenotype/mouse-anatomy-ontology/issues/126, CC@allysonlister. 

@deepakunni3 I don't think this change requires contacting the ontology maintainers, this is just metadata oversight.