### PR TITLE
Add missing ORCIDs for seveal deprecated/obsolete ontologies

### DIFF
--- a/ontology/aao.md
+++ b/ontology/aao.md
@@ -5,6 +5,7 @@ title: Amphibian gross anatomy
 contact:
   email: david.c.blackburn@gmail.com
   label: David Blackburn
+  orcid: 0000-0002-1810-9886
 domain: anatomy and development
 homepage: http://github.com/seger/aao
 is_obsolete: true

--- a/ontology/ato.md
+++ b/ontology/ato.md
@@ -5,6 +5,7 @@ title: Amphibian taxonomy
 contact:
   email: david.c.blackburn@gmail.com
   label: David Blackburn
+  orcid: 0000-0002-1810-9886
 domain: organisms
 homepage: http://www.amphibanat.org
 is_obsolete: true

--- a/ontology/bila.md
+++ b/ontology/bila.md
@@ -8,7 +8,9 @@ build:
   source_url: http://4dx.embl.de/4DXpress_4d/edocs/bilateria_mrca.obo
 contact:
   email: henrich@embl.de
-  label: Thorsten Heinrich
+  github: ThorstenHen
+  label: Thorsten Henrich
+  orcid: 0000-0002-1548-3290
 domain: anatomy and development
 homepage: http://4dx.embl.de/4DXpress
 is_obsolete: true

--- a/ontology/mfo.md
+++ b/ontology/mfo.md
@@ -3,8 +3,10 @@ layout: ontology_detail
 id: mfo
 title: Medaka fish anatomy and development
 contact:
-  email: Thorsten.Henrich@embl-heidelberg.de
+  email: henrich@embl.de
+  github: ThorstenHen
   label: Thorsten Henrich
+  orcid: 0000-0002-1548-3290
 description: A structured controlled vocabulary of the anatomy and development of the Japanese medaka fish, <i>Oryzias latipes</i>.
 domain: anatomy and development
 is_obsolete: true

--- a/ontology/nif_cell.md
+++ b/ontology/nif_cell.md
@@ -5,6 +5,7 @@ title: NIF Cell
 contact:
   email: smtifahim@gmail.com
   label: Fahim Imam
+  orcid: 0000-0003-4752-543X
 description: Neuronal cell types
 domain: anatomy and development
 homepage: http://neuinfo.org/

--- a/ontology/nif_dysfunction.md
+++ b/ontology/nif_dysfunction.md
@@ -5,6 +5,7 @@ title: NIF Dysfunction
 contact:
   email: smtifahim@gmail.com
   label: Fahim Imam
+  orcid: 0000-0003-4752-543X
 domain: health
 homepage: http://neuinfo.org/
 is_obsolete: true

--- a/ontology/nif_grossanatomy.md
+++ b/ontology/nif_grossanatomy.md
@@ -5,6 +5,7 @@ title: NIF Gross Anatomy
 contact:
   email: smtifahim@gmail.com
   label: Fahim Imam
+  orcid: 0000-0003-4752-543X
 domain: anatomy and development
 homepage: http://neuinfo.org/
 is_obsolete: true

--- a/ontology/pd_st.md
+++ b/ontology/pd_st.md
@@ -4,7 +4,9 @@ id: pd_st
 title: Platynereis stage ontology
 contact:
   email: henrich@embl.de
-  label: Thorsten Heinrich
+  github: ThorstenHen
+  label: Thorsten Henrich
+  orcid: 0000-0002-1548-3290
 domain: anatomy and development
 homepage: http://4dx.embl.de/platy
 is_obsolete: true

--- a/ontology/resid.md
+++ b/ontology/resid.md
@@ -5,6 +5,7 @@ title: Protein covalent bond
 contact:
   email: john.garavelli@ebi.ac.uk
   label: John Garavelli
+  orcid: 0000-0002-4131-735X
 description: For the description of covalent bonds in proteins.
 domain: chemistry and biochemistry
 homepage: http://www.ebi.ac.uk/RESID/


### PR DESCRIPTION
It seems to be the case that Thorsten Henrich's name was misspelled in many places, making it hard to identify this individual. This is now resolved.

I also was able to find the ORCID for Fahim Imam (related to obsolete NIF ontologies)

All of the updates in this PR refer to obsolete/orphaned ontologies and therefore I don't think needs confirmation from these people (though if anyone knows Fahim's GitHub handle, it would be nice to include)
