### PR TITLE
Add ORCID and GitHub to ontology detail

### DIFF
--- a/_layouts/ontology_detail.html
+++ b/_layouts/ontology_detail.html
@@ -241,6 +241,16 @@ page.preferredPrefix | upcase %} {% if upperPrefix != page.preferredPrefix %}
       <dd>
         <a href="mailto:{{page.contact.email}}">{{page.contact.label}}</a>
       </dd>
+      {% if page.contact.orcid %}
+      <dd>
+        <a href="https://orcid.org/{{ page.contact.orcid }}">{{ page.contact.orcid }}</a>
+      </dd>
+      {% endif %}
+      {% if page.contact.github %}
+      <dd>
+        <a href="https://github.com/{{ page.contact.github }}">@{{ page.contact.github }}</a>
+      </dd>
+      {% endif %}
 
       {% if page.repository and page.repository != page.homepage %}
       <dt>Repository</dt>


### PR DESCRIPTION
It occurred to me that to find out the github handle for OGMS, I had to go to source data. This PR adds the GitHub handle and ORCID to the ontology detail page to improve transparency

<img width="1227" alt="Screenshot 2023-03-16 at 17 27 20" src="https://user-images.githubusercontent.com/5069736/225687468-68545053-5b70-4482-873e-13dd09537e86.png">
