### PR TITLE
Add OBO Dashboard badge to ontology detail

### DIFF
--- a/_layouts/ontology_detail.html
+++ b/_layouts/ontology_detail.html
@@ -365,6 +365,12 @@ page.preferredPrefix | upcase %} {% if upperPrefix != page.preferredPrefix %}
         >
       </dd>
       <dd>{% endif %}</dd>
+      <dt>OBO Dashboard</dt>
+      <dd>
+        <a href="http://dashboard.obofoundry.org/dashboard/{{ page.id }}/dashboard.html">
+          <img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2FOBOFoundry%2Fobo-dash.github.io%2Fgh-pages%2Fdashboard%2F{{ page.id }}%2Fdashboard-qc-badge.json" alt="OBO Dashboard badge for {{ page.id }}"/>
+        </a>
+      </dd>
     </dl>
 
     <div class="btn-group pull-right" role="group" aria-label="Source">


### PR DESCRIPTION
Based on https://github.com/OBOFoundry/OBOFoundry.github.io/issues/1739, this PR adds a badge to the ontology detail page that shows the OBO Dashboard status (e.g., number of errors, number of warnings) and links to the dashboard detail page.

## Demo

<img width="840" alt="Screenshot 2023-03-21 at 13 17 02" src="https://user-images.githubusercontent.com/5069736/226603333-a8b79c93-c981-4086-8302-547895f9f6fb.png">
