### PR TITLE
Update Repeating Agenda Items

### DIFF
--- a/docs/SOP.md
+++ b/docs/SOP.md
@@ -114,12 +114,11 @@ The current processes of nomination, acceptance and onboarding are described [he
 #### Before the call (a day or two in advance):
 
 1. Prepare a stub in the OBO Operations Committee (OFOC) [rolling agenda](https://docs.google.com/document/d/1aka4i6R89i04IYPS7CyzItQPOyb3IgtW4m75G475qcc/edit) with the following <b>Repeating Agenda Items</b>:
-     1. Check for [pending members for obo-discuss](https://groups.google.com/g/obo-discuss/pending-members)
-     2. Get volunteers to sign up to lead upcoming meetings (if needed)
-     3. Review [new ontology requests](https://github.com/OBOFoundry/OBOFoundry.github.io/labels/new%20ontology)
-     4. Report from Editorial Working Group (EWG) (Darren)
-     5. Report from Technical Working Group (TWG) (Nico)
-     6. Review additional [open issues](https://github.com/OBOFoundry/OBOFoundry.github.io/labels/attn%3A%20OFOC%20call) and [pull requests](https://github.com/OBOFoundry/OBOFoundry.github.io/pulls?q=is%3Apr+is%3Aopen+label%3A%22attn%3A+OFOC+call%22) that are labeled "attn: OFOC call"
+     1. Get volunteers to sign up to lead upcoming meetings (if needed)
+     2. Review [new ontology requests](https://github.com/OBOFoundry/OBOFoundry.github.io/labels/new%20ontology)
+     3. Report from Editorial Working Group (EWG) (Darren)
+     4. Report from Technical Working Group (TWG) (Nico)
+     5. Review additional [open issues](https://github.com/OBOFoundry/OBOFoundry.github.io/labels/attn%3A%20OFOC%20call) and [pull requests](https://github.com/OBOFoundry/OBOFoundry.github.io/pulls?q=is%3Apr+is%3Aopen+label%3A%22attn%3A+OFOC+call%22) that are labeled "attn: OFOC call"
 
 2. Check the issues labeled ["attn:OFOC call"](https://github.com/OBOFoundry/OBOFoundry.github.io/labels/attn%3A%20OFOC%20call) found at the OBO foundry github repository. Pick one or two open issues you deem important and put them towards the end of the stub agenda, after the Working Group reports and before the review of additional open issues.
 3. Send an email to obo-operations-committee @ googlegroups.com (not obo-discuss!) with the subject "OBO Operations Committee meeting" and the following text given between quotes


### PR DESCRIPTION
remove "check obo-discuss for pending members"

This is now a duty of the OBO Google Service Manager so it doesn't need to be on the meeting agenda.