### PR TITLE
Lint operations YML file

### DIFF
--- a/_data/operations.yml
+++ b/_data/operations.yml
@@ -94,8 +94,7 @@ members:
   orcid: 0000-0002-5714-991X
   wikidata: Q67220657
 - affiliation:
-    name: Centre for Infectious Disease Genomics and One Health, Simon Fraser University,
-      BC
+    name: Centre for Infectious Disease Genomics and One Health, Simon Fraser University, BC
     ror: 0213rcc28
   country: Canada
   github: ddooley
@@ -135,6 +134,16 @@ members:
   name: Deepak R. Unni
   orcid: 0000-0002-3583-7340
   wikidata: Q59690671
+- affiliation:
+    name: University of Nebraska, Lincoln, NE
+    ror: 043mer456
+  country: USA
+  github: erik-whiting
+  groups:
+  - technical
+  name: Erik Whiting
+  orcid: 0000-0003-1022-5281
+  wikidata: Q115716044
 - affiliation:
     name: Kansas State University, Manhattan, KS
     ror: 05p1j8758
@@ -244,8 +253,17 @@ members:
   orcid: 0000-0001-6315-3707
   wikidata: Q58106602
 - affiliation:
-    name: University of Oxford e-Research Centre, Department of Engineering Science,
-      Oxford
+    name: Université de Sherbrooke, Québec
+    ror: 00kybxq39
+  country: Canada
+  github: pfabry
+  groups:
+  - technical
+  name: Paul Fabry
+  orcid: 0000-0002-3336-2476
+  wikidata: Q108555457
+- affiliation:
+    name: University of Oxford e-Research Centre, Department of Engineering Science, Oxford
     ror: 052gg0110
   country: UK
   github: proccaserra
@@ -256,8 +274,7 @@ members:
   orcid: 0000-0001-9853-5668
   wikidata: Q28364404
 - affiliation:
-    name: Alfred Wegener Institute, Helmholtz Centre for Polar and Marine Research,
-      Bremerhaven
+    name: Alfred Wegener Institute, Helmholtz Centre for Polar and Marine Research, Bremerhaven
     ror: 032e6b942
   country: Germany
   github: pbuttigieg
@@ -340,23 +357,3 @@ members:
   name: Shawn Tan
   orcid: 0000-0001-7258-9596
   wikidata: Q57023310
-- affiliation:
-    name: Université de Sherbrooke, Québec
-    ror: 00kybxq39
-  country: Canada
-  github: pfabry
-  groups:
-  - technical
-  name: Paul Fabry
-  orcid: 0000-0002-3336-2476
-  wikidata: Q108555457
-- affiliation:
-    name: University of Nebraska, Lincoln, NE
-    ror: 043mer456
-  country: USA
-  github: erik-whiting
-  groups:
-  - technical
-  name: Erik Whiting
-  orcid: 0000-0003-1022-5281
-  wikidata: Q115716044

--- a/tests/test_memberships.py
+++ b/tests/test_memberships.py
@@ -75,7 +75,17 @@ class TestMembershipData(unittest.TestCase):
     def test_encoding(self):
         """Test correct encoding."""
         t = OPERATIONS_METADATA_PATH.read_text()
-        self.assertEqual(yaml.safe_dump(yaml.safe_load(t), allow_unicode=True), t)
+        self.maxDiff = None
+        self.assertEqual(
+            yaml.safe_dump(
+                yaml.safe_load(t),
+                allow_unicode=True,
+                sort_keys=True,
+                explicit_end=False,
+                width=float("inf"),
+            ),
+            t,
+        )
 
     def test_alumni(self):
         """Test the alumni data."""


### PR DESCRIPTION
This PR makes no content changes, it just runs the lint command. Will reduce diff for other upcoming PRs such as #2349.

This makes a minor fix in the test to handle long names.