### PR TITLE
Update OntoBee URLpattern

### DIFF
--- a/_includes/ontology_table.html
+++ b/_includes/ontology_table.html
@@ -110,7 +110,7 @@ Download table as: [ <a href="/registry/ontologies.yml">YAML</a> |
 
       <td>
         <a
-          href="https://ontobee.org/browser/index.php?o={{ont.id}}"
+          href="https://ontobee.org/ontology/{{ont.id}}"
           class="btn btn-outline-primary"
           aria-label="Browse {{ ont.title }} on OntoBee"
           title="Browse on Ontobee"

--- a/_layouts/ontology_detail.html
+++ b/_layouts/ontology_detail.html
@@ -55,7 +55,7 @@ page.preferredPrefix | upcase %} {% if upperPrefix != page.preferredPrefix %}
     <div class="card" style="margin-bottom: 1.5em;">
       <div class="card-body">
         <!-- TODO: each ontology should configure which browsers to be exposed in -->
-        <a href="https://ontobee.org/browser/index.php?o={{page.id}}" class="btn btn-outline-primary">
+        <a href="https://ontobee.org/ontology/{{page.id}}" class="btn btn-outline-primary">
           OntoBee
         </a>
         {% if page.aberowl_id %}

--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -242,7 +242,7 @@ jQuery(document).ready(function() {
                             <a class="btn btn-outline-primary" href="http://purl.obolibrary.org/obo/${id}.owl" aria-label="Download ${title} in OWL format" title="Download ${title} in OWL format">
                                 <i class="bi-download" aria-hidden="true"></i>
                             </a>
-                            <a class="btn btn-outline-primary" href="http://www.ontobee.org/ontology/${id}" aria-label="Browse ${title} on OntoBee" title="Browse ${title} on OntoBee">
+                            <a class="btn btn-outline-primary" href="https://www.ontobee.org/ontology/${id}" aria-label="Browse ${title} on OntoBee" title="Browse ${title} on OntoBee">
                                 <i class="bi-eye" aria-hidden="true"></i>
                             </a>
                             ${tracker}

--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -242,7 +242,7 @@ jQuery(document).ready(function() {
                             <a class="btn btn-outline-primary" href="http://purl.obolibrary.org/obo/${id}.owl" aria-label="Download ${title} in OWL format" title="Download ${title} in OWL format">
                                 <i class="bi-download" aria-hidden="true"></i>
                             </a>
-                            <a class="btn btn-outline-primary" href="http://www.ontobee.org/browser/index.php?o=${id}" aria-label="Browse ${title} on OntoBee" title="Browse ${title} on OntoBee">
+                            <a class="btn btn-outline-primary" href="http://www.ontobee.org/ontology/${id}" aria-label="Browse ${title} on OntoBee" title="Browse ${title} on OntoBee">
                                 <i class="bi-eye" aria-hidden="true"></i>
                             </a>
                             ${tracker}

--- a/ontology/obi.md
+++ b/ontology/obi.md
@@ -78,7 +78,7 @@ activity_status: active
 
 The Ontology for Biomedical Investigations (OBI) project is developing an integrated ontology for the description of life-science and clinical investigations.
 
-- [Browse OBI on Ontobee](http://www.ontobee.org/browser/index.php?o=obi)
+- [Browse OBI on Ontobee](http://www.ontobee.org/ontology/obi)
 - Download OBI: [http://purl.obolibrary.org/obo/obi.owl](http://purl.obolibrary.org/obo/obi.owl)
 - [OBI homepage](http://obi-ontology.org)
 - [OBI mailing list](http://groups.google.com/group/obi-users)

--- a/ontology/obi.md
+++ b/ontology/obi.md
@@ -78,7 +78,7 @@ activity_status: active
 
 The Ontology for Biomedical Investigations (OBI) project is developing an integrated ontology for the description of life-science and clinical investigations.
 
-- [Browse OBI on Ontobee](http://www.ontobee.org/ontology/obi)
+- [Browse OBI on Ontobee](https://www.ontobee.org/ontology/obi)
 - Download OBI: [http://purl.obolibrary.org/obo/obi.owl](http://purl.obolibrary.org/obo/obi.owl)
 - [OBI homepage](http://obi-ontology.org)
 - [OBI mailing list](http://groups.google.com/group/obi-users)

--- a/ontology/poro.md
+++ b/ontology/poro.md
@@ -47,7 +47,7 @@ An ontology covering the anatomy of Porifera (sponges)
 
 ## Browse ##
 
-The ontology can be browsed in [OntoBee](http://www.ontobee.org/browser/index.php?o=PORO)
+The ontology can be browsed in [OntoBee](http://www.ontobee.org/ontology/PORO)
 
 Example entry points:
 

--- a/ontology/poro.md
+++ b/ontology/poro.md
@@ -47,7 +47,7 @@ An ontology covering the anatomy of Porifera (sponges)
 
 ## Browse ##
 
-The ontology can be browsed in [OntoBee](http://www.ontobee.org/ontology/PORO)
+The ontology can be browsed in [OntoBee](https://www.ontobee.org/ontology/PORO)
 
 Example entry points:
 


### PR DESCRIPTION
Solves #2362 

Maybe OntoBee updated their URL patterns and redirect logic? I don't know, but it used to be that you would append `browser/index.php?o=` and the ontology ID to the OntoBee URL. That doesn't work now and for some reason, their redirect logic turns the `?` into a URL safe `%3f` which is a page that, of course, doesn't exist.

Anyway, I just updated the URL patterns, it should work now. I had to update some pretty old ontology pages too because they were using the "old" URL. I'm not sure if it's ok for me to just edit an ontology so let me know if this is some kind of faux pas and I'll undo that part.