### PR TITLE
Unlink problematic ID space links

### DIFF
--- a/_layouts/ontology_detail.html
+++ b/_layouts/ontology_detail.html
@@ -188,7 +188,7 @@ page.preferredPrefix | upcase %} {% if upperPrefix != page.preferredPrefix %}
         <span data-toggle="tooltip" title="ID prefix" data-html="true"> </span>
       </dt>
       <dd>
-        <a href="http://purl.obolibrary.org/obo/{{page.id}}/">{{page.id}}</a>
+        {{page.id}}
       </dd>
 
       <dt>PURL</dt>


### PR DESCRIPTION
Closes issue #547 

All I did was unlink page ID text