### PR TITLE
Add placeholder for missing fields in vario.md

### DIFF
--- a/ontology/vario.md
+++ b/ontology/vario.md
@@ -29,5 +29,7 @@ publications:
   title: 'Variation ontology: annotator guide'
 - id: https://www.ncbi.nlm.nih.gov/pubmed/25616435
   title: Types and effects of protein variations
+repository: ???
+tracker: ???
 activity_status: orphaned
 ---

--- a/ontology/vario.md
+++ b/ontology/vario.md
@@ -29,7 +29,7 @@ publications:
   title: 'Variation ontology: annotator guide'
 - id: https://www.ncbi.nlm.nih.gov/pubmed/25616435
   title: Types and effects of protein variations
-repository: ???
-tracker: ???
+repository: N/A
+tracker: http://variationontology.org/instructions.shtml
 activity_status: orphaned
 ---


### PR DESCRIPTION
This PR attempts at fixing a previously (prematurely) merged PR.

For Vario, the `repository` and `tracker` metadata fields were missing.
There doesn't seem to be a public repository where Vario is managed.

@maunov: Do you have a public repository URL where Vario is currently hosted?

@matentzn What is the course of action if there is no public repository URL for Vario?