### PR TITLE
Update actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,5 +35,4 @@ jobs:
           title: 'Update OBO foundry metadata'
           body: |
             Recreates all OBO metadata.
-            Tagging @deepakunni3 for review.
           assignees: deepakunni3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,5 +34,6 @@ jobs:
           commit-message: Update OBO foundry metadata
           title: 'Update OBO foundry metadata'
           body: |
-            Recreates all OBO metadata
+            Recreates all OBO metadata.
+            Tagging @deepakunni3 for review.
           assignees: deepakunni3

--- a/.github/workflows/obo-test.yml
+++ b/.github/workflows/obo-test.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-
+    if: github.actor != 'github-actions[bot]'
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -6,6 +6,7 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    if: github.actor != 'github-actions[bot]'
     strategy:
       matrix:
         python-version: [ "3.7", "3.10" ]


### PR DESCRIPTION
This PR does the following:
- tag the the metadata steward for review when creating a PR after 'Build derived files' action
- add conditional check to skip QC and tests if the actions are triggered from changes introduced by 'github-actions' bot

The latter should prevent actions from running immediately after 'Build derived files' action.

**Note:** The skip only applies when 'github-actions' bot commits files and creates a PR. All other user actions will still trigger the checks for QC and tests.

