### PR TITLE
Improve newsletter

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,3 +32,25 @@ The project will strive for full consensus on everything until it runs into a pr
 
 All Python code in this repository should conform to `black` and `isort`. You
 can automatically apply them with `tox -e lint`.
+
+## Adding Newsletter Entries
+
+This site uses Jekyll's built-in blog system for newsletters. Take the following steps to get a new post up:
+
+1. Create a markdown file in the [`_posts`](_posts) directory. This file name should start with the date of writing in
+   YYYY-MM-DD format, then the remainder of the file name can be a short description of the contents. Use lowercase
+   words and have dashes between them instead of spaces.
+2. Inside the markdown file, you need the following "frontmatter"
+   ```yaml
+    ---
+    layout: post
+    categories: newsletter
+    title: YOUR TITLE
+    author: YOUR NAME
+    date: YYYY-MM-DD
+    ---
+    ```
+   Where you replace the title and author fields with free text and the date field with a day formatted with YYYY-MM-DD
+   that matches the file name.
+3. Do not begin the newsletter with a title (that uses a `#` in markdown).
+4. The first paragraph of text in the newsletter will serve as a short description

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,7 @@ This site uses Jekyll's built-in blog system for newsletters. Take the following
 1. Create a markdown file in the [`_posts`](_posts) directory. This file name should start with the date of writing in
    YYYY-MM-DD format, then the remainder of the file name can be a short description of the contents. Use lowercase
    words and have dashes between them instead of spaces. Example: `2023-06-16-inaugural-newsletter.md`.
-2. Inside the markdown file, you need the following "frontmatter"
+2. At the top of the the markdown file, you need the following "frontmatter" (which is YAML hiding between two `---`)
    ```yaml
     ---
     layout: post

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,7 @@ This site uses Jekyll's built-in blog system for newsletters. Take the following
 
 1. Create a markdown file in the [`_posts`](_posts) directory. This file name should start with the date of writing in
    YYYY-MM-DD format, then the remainder of the file name can be a short description of the contents. Use lowercase
-   words and have dashes between them instead of spaces.
+   words and have dashes between them instead of spaces. Example: `2023-06-16-inaugural-newsletter.md`.
 2. Inside the markdown file, you need the following "frontmatter"
    ```yaml
     ---

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,6 +33,8 @@ The project will strive for full consensus on everything until it runs into a pr
 All Python code in this repository should conform to `black` and `isort`. You
 can automatically apply them with `tox -e lint`.
 
+<a id="newsletter"></a>
+
 ## Adding Newsletter Entries
 
 This site uses Jekyll's built-in blog system for newsletters. Take the following steps to get a new post up:

--- a/_data/roles.yml
+++ b/_data/roles.yml
@@ -84,7 +84,7 @@
   commitment: 2-4 hours per month
   requirements:
     - Should have a basic journalistic instinct, compiling the most relevant discussion points, decisions and issues for the wider community
-  description: You will be responsible for managing, compiling and disseminating the OBO Newletter
+  description: You will be responsible for managing, compiling and disseminating the OBO Newsletter. Instructions for archiving the newsletter on the OBO Foundry's GitHub Repository can be found [here](https://github.com/OBOFoundry/OBOFoundry.github.io/blob/master/CONTRIBUTING.md#newsletter).
   responsibilities:
     - Manage a Google doc with the current and previous newsletter drafts based on the newsletter skeleton
     - Add GitHub issues and/or pull requests tagged with "newsletter" to the newsletter, with one or two sentences of summary

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -151,7 +151,11 @@
                         Newsletter
                     </a>
                     <ul class="dropdown-menu" aria-labelledby="navbarNewsletterDropdown">
-                        <li><a class="dropdown-item" href="/posts/2023-06-16-InauguralNewsletter.html">Inaugural Newsletter 15th June 2023</a></li>
+                        {% for post in site.posts %}
+                        {% if post.categories contains "newsletter" %}
+                        <li><a class="dropdown-item" href="{{ post.url | relative_url }}">{{ post.title }}</a></li>
+                        {% endif %}
+                        {% endfor %}
                     </ul>
                 </li>
 

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -1,121 +1,35 @@
 ---
 layout: default
 ---
+<article class="post h-entry" itemscope itemtype="http://schema.org/BlogPosting">
 
-<div class="content">
-  <div class="row">
-    <div class="span7 column">
-      <h1>{{ page.title }}</h1>
+    <header class="post-header">
+        <h1 class="post-title p-name" itemprop="name headline">{{ page.title | escape }}</h1>
+        <p class="post-meta">
+            {%- assign date_format = site.minima.date_format | default: "%b %-d, %Y" -%}
+            <time class="dt-published" datetime="{{ page.date | date_to_xmlschema }}" itemprop="datePublished">
+                {{ page.date | date: date_format }}
+            </time>
+            {%- if page.modified_date -%}
+            ~
+            {%- assign mdate = page.modified_date | date_to_xmlschema -%}
+            <time class="dt-modified" datetime="{{ mdate }}" itemprop="dateModified">
+                {{ mdate | date: date_format }}
+            </time>
+            {%- endif -%}
+            {%- if page.author -%}
+            • {% for author in page.author %}
+            <span itemprop="author" itemscope itemtype="http://schema.org/Person">
+            <span class="p-author h-card" itemprop="name">{{ author }}</span></span>
+            {%- if forloop.last == false %}, {% endif -%}
+            {% endfor %}
+            {%- endif -%}
+        </p>
+    </header>
+
+    <div class="post-content e-content" itemprop="articleBody">
+        {{ content }}
     </div>
 
-    <div class="span7 columns">
-      {{ page.summary }}
-      <br />
-    </div>
-    <div>
-      <img
-        class="listImage img-rounded"
-        border="0"
-        src="{{ page.image }}"
-        alt="{{ page.title }} image"
-      />
-    </div>
-  </div>
-
-  <div class="row">
-    <div class="span7 columns">{{ content }}</div>
-  </div>
-
-  <div class="pager hidden-phone hidden-tablet">
-    <a
-      class="prev"
-      href="{{ page.previous.url }}"
-      title="Previous Post: {{page.previous.title}}"
-      ><i class="icon-arrow-left icon-white"></i
-    ></a>
-    <a
-      class="next"
-      href="{{ page.next.url }}"
-      title="Previous Post: {{page.next.title}}"
-      ><i class="icon-arrow-right icon-white"></i
-    ></a>
-  </div>
-
-  <div class="row">
-    <div class="span7 column">
-      <p>
-        <i>{{ page.author}}</i>
-        <i class="icon-calendar"></i> {{ page.date | date: "%B %e, %Y" }} |
-        <i class="icon-comment"></i> <a href="{{ page.url }}#disqus_thread"></a>
-        <br />
-        <a
-          href="https://twitter.com/share"
-          class="twitter-share-button"
-          data-via="{{ site.project.twitter }}"
-          >Tweet</a
-        >
-      </p>
-    </div>
-  </div>
-
-  {% if page.comments %}
-  <div class="row">
-    <div class="span7 columns">
-      <h2>Comments Section</h2>
-      <p>Feel free to comment on the post but keep it clean and on topic.</p>
-      <div id="disqus_thread"></div>
-      <script type="text/javascript">
-        /* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */
-        var disqus_shortname = "{{ site.comments.disqus.short_name }}";
-
-        /* * * DON'T EDIT BELOW THIS LINE * * */
-        (function () {
-          var dsq = document.createElement("script");
-          dsq.type = "text/javascript";
-          dsq.async = true;
-          dsq.src = "http://" + disqus_shortname + ".disqus.com/embed.js";
-          (
-            document.getElementsByTagName("head")[0] ||
-            document.getElementsByTagName("body")[0]
-          ).appendChild(dsq);
-        })();
-      </script>
-      <noscript
-        >Please enable JavaScript to view the
-        <a href="http://disqus.com/?ref_noscript"
-          >comments powered by Disqus.</a
-        ></noscript
-      >
-      <a href="http://disqus.com" class="dsq-brlink"
-        >comments powered by <span class="logo-disqus">Disqus</span></a
-      >
-    </div>
-  </div>
-  {% endif %}
-
-  <!-- Twitter -->
-  <script>
-    !(function (d, s, id) {
-      var js,
-        fjs = d.getElementsByTagName(s)[0];
-      if (!d.getElementById(id)) {
-        js = d.createElement(s);
-        js.id = id;
-        js.src = "//platform.twitter.com/widgets.js";
-        fjs.parentNode.insertBefore(js, fjs);
-      }
-    })(document, "script", "twitter-wjs");
-  </script>
-
-  <!-- Google + -->
-  <script type="text/javascript">
-    (function () {
-      var po = document.createElement("script");
-      po.type = "text/javascript";
-      po.async = true;
-      po.src = "https://apis.google.com/js/plusone.js";
-      var s = document.getElementsByTagName("script")[0];
-      s.parentNode.insertBefore(po, s);
-    })();
-  </script>
-</div>
+    <a class="u-url" href="{{ page.url | relative_url }}" hidden></a>
+</article>

--- a/_posts/2023-06-16-inaugural-newsletter.md
+++ b/_posts/2023-06-16-inaugural-newsletter.md
@@ -1,9 +1,10 @@
 ---
 layout: post
+categories: newsletter
 title: "Inaugural OBO Foundry Newsletter"
 date: 2023-06-16
-author: Leila Kiani
-categories: newsletter
+author: 
+  - Leila Kiani
 ---
 
 We are thrilled to bring you this first edition while we celebrate our 20<sup>th</sup> anniversary, packed with exciting updates and information about the OBO Foundry and its community.
@@ -242,9 +243,9 @@ The National Student Data Corps, an initiative within the [Northeast Big Data In
 
 ## International Society for Biocuration Career Awards
 
-The International Society of Biocuration (ISB; https://www.biocuration.org) has recently announced the winners for the prestigious [Early Career Award, Advanced Career Award, and Lifetime Achievement Award](https://www.biocuration.org/announcement-for-2023-winners-of-excellence-in-biocuration-awards/). We are delighted to announce that two of the winners of this year's "Excellence in Biocuration Award" are active contributors to the OBO Foundry: The Early Career Award was given to Charlie Hoyt, and the Advanced Career Award was given to Nico Matentzoglu.
+The [International Society of Biocuration (ISB)](https://www.biocuration.org) has recently announced the winners for the prestigious [Early Career Award, Advanced Career Award, and Lifetime Achievement Award](https://www.biocuration.org/announcement-for-2023-winners-of-excellence-in-biocuration-awards/). We are delighted to announce that two of the winners of this year's "Excellence in Biocuration Award" are active contributors to the OBO Foundry: The Early Career Award was given to Charlie Hoyt, and the Advanced Career Award was given to Nico Matentzoglu.
 
-[Charles Tapley Hoyt](https://orcid.org/0000-0003-4423-4370), a Research Fellow at Harvard Medical School, is an exceptional biocurator. He leads the development of community datasets and databases like Bioregistry, Biomappings, and Chemical Roles Graph. He actively contributes to the OBO Foundry ontology community and related standards development, including the SSSOM standard. Charlie's active engagement in the Biocuration community includes co-chairing the recent Biocuration 2023 conference.
+[Charles Tapley Hoyt](https://orcid.org/0000-0003-4423-4370), a Research Fellow at Harvard Medical School, is an exceptional biocurator. He leads the development of community datasets and databases like the [Bioregistry](https://bioregistry.io/), [Biomappings](https://github.com/biopragmatics/biomappings), and Chemical Roles Graph. He actively contributes to the OBO Foundry ontology community and related standards development, including the SSSOM standard. Charlie's active engagement in the Biocuration community includes co-chairing the recent Biocuration 2023 conference.
 
 [Nicolas Matentzoglu](https://orcid.org/0000-0002-7356-1779), a celebrated figure in bio-ontology and biocuration, passionately advocates open science. He co-leads the OBO Academy and leads the development of the Ontology Development Kit (ODK). Nico also spearheads the development of the Simple Standard for Sharing Ontological Mappings (SSSOM). His efforts have attracted and united diverse contributors in the biocuration community.
 

--- a/_posts/2023-06-16-inaugural-newsletter.md
+++ b/_posts/2023-06-16-inaugural-newsletter.md
@@ -1,12 +1,12 @@
 ---
 layout: post
-title: "Welcome to the inaugural issue of the OBO Foundry Newsletter -  Celebrating our 20th anniversary (June 2023)"
+title: "Inaugural OBO Foundry Newsletter"
 date: 2023-06-16
-categories: update
-summary: "The inaugural edition of our newly formed OBO Newsletter."
+author: Leila Kiani
+categories: newsletter
 ---
 
-We are thrilled to bring you this first edition while we celebrate our 20th anniversary, packed with exciting updates and information about the OBO Foundry and its community.
+We are thrilled to bring you this first edition while we celebrate our 20<sup>th</sup> anniversary, packed with exciting updates and information about the OBO Foundry and its community.
 
 In this issue, you will find a range of content, including general announcements, training opportunities, and details about recent and upcoming events. Our goal with the OBO Foundry's Quarterly Newsletter is to inform community members about the latest activities and advancements within the OBO Foundry.
 
@@ -78,8 +78,7 @@ By collaborating across these different areas and pulling together volunteers fr
 
 In this section we introduce the volunteers that recently joined the OBO Operations Committee. [Mathias Brochhausen](https://github.com/mbrochhausen) recently rejoined the OBO Operations Committee, after a period of absence. Welcome back Mathias!
 
-
-<table>
+<table class="table">
   <tr>
    <td><strong>Picture</strong>
    </td>
@@ -96,7 +95,7 @@ In this section we introduce the volunteers that recently joined the OBO Operati
   </tr>
   <tr>
    <td>
-    <img src="https://obofoundry.org/images/ofoc/anitacaron.png" width="" alt="Anita Caron" />
+    <img src="https://obofoundry.org/images/ofoc/anitacaron.png" style="max-height: 150px" alt="Anita Caron" />
    </td>
    <td>Anita R. Caron
    </td>
@@ -111,7 +110,7 @@ In this section we introduce the volunteers that recently joined the OBO Operati
   </tr>
   <tr>
    <td>
-    <img src="https://obofoundry.org/images/ofoc/deepakunni3.png" width="" alt="Deepak Unni" />
+    <img src="https://obofoundry.org/images/ofoc/deepakunni3.png" style="max-height: 150px" alt="Deepak Unni" />
    </td>
    <td>Deepak R. Unni
    </td>
@@ -126,7 +125,7 @@ In this section we introduce the volunteers that recently joined the OBO Operati
   </tr>
   <tr>
    <td>
-    <img src="https://obofoundry.org/images/ofoc/erik-whiting.png" width="" alt="Erik Whiting" />
+    <img src="https://obofoundry.org/images/ofoc/erik-whiting.png" style="max-height: 150px" alt="Erik Whiting" />
    </td>
    <td>Erik Whiting
    </td>
@@ -141,7 +140,7 @@ In this section we introduce the volunteers that recently joined the OBO Operati
   </tr>
   <tr>
    <td>
-    <img src="https://obofoundry.org/images/ofoc/LK112019.png" width="" alt="Leila Kiani" />
+    <img src="https://obofoundry.org/images/ofoc/LK112019.png" style="max-height: 150px" alt="Leila Kiani" />
    </td>
    <td>Leila Kiani
    </td>
@@ -156,7 +155,7 @@ In this section we introduce the volunteers that recently joined the OBO Operati
   </tr>
   <tr>
    <td>
-    <img src="https://obofoundry.org/images/ofoc/pfabry.png" width="" alt="Paul Fabry" />
+    <img src="https://obofoundry.org/images/ofoc/pfabry.png" style="max-height: 150px" alt="Paul Fabry" />
    </td>
    <td>Paul Fabry
    </td>
@@ -171,7 +170,7 @@ In this section we introduce the volunteers that recently joined the OBO Operati
   </tr>
   <tr>
    <td>
-    <img src="https://obofoundry.org/images/ofoc/rays22.png" alt="Ray Stefancsik" />
+    <img src="https://obofoundry.org/images/ofoc/rays22.png" style="max-height: 150px" alt="Ray Stefancsik" />
    </td>
    <td>Ray Stefancsik
    </td>
@@ -261,7 +260,7 @@ Monarch OBO Training is a virtual training session that is offered biweekly on T
 
 ### [ICBO OBO Tutorial 2023](https://oboacademy.github.io/obook/courses/icbo2023/): Using and Reusing Ontologies
 
-Date: Exact data TBD. Workshops/tutorials will be held August 28-30, 2023 \
+Date: Exact date TBD. Workshops/tutorials will be held August 28-30, 2023 \
 Location: In person at [ICBO2023](https://www.icbo2023.ncor-brasil.org/) in Brazil and virtual  \
 Organizers: [Nicole Vasilevsky](https://orcid.org/0000-0001-5208-3432) and [Nico Matentzoglu](https://orcid.org/0000-0002-7356-1779) \
 The ICBO OBO Tutorial 2023, "Using and Reusing Ontologies," is targeted towards  novice and experienced ontology users and developers. The tutorial, a longstanding tradition at ICBO, introduces OBO and ontologies in general and will include more advanced topics including using ROBOT and ChatGPT.


### PR DESCRIPTION
This pull request does the following:

1. Moves the newsletter into the correct `_posts` directory that is natively part of Jekyll's blogging system
2. Update the layout for posts
3. Automate updating the newsletter dropdown based on posts annotated with "newsletter" as one of its categories
4. Add contributing guide for new newsletter entries
5. Add note in the description of the OBO Newsletter Steward role to see the contribution guidelines
6. Small reformatting to newsletter (add superscripts, add maximum height to images, rename nonsensically long title)

Note that this changes the URL of the post to https://obofoundry.org/newsletter/2023/06/16/inaugural-newsletter.html. This is better as it's much more regular.

Future TO-DO, when a second newsletter is written and ready to publish
- We can implement a page that actually lists all of the posts
- Should we prune some of the old posts that aren't really informative?