### PR TITLE
Check for triggering_actor instead of actor in github actions

### DIFF
--- a/.github/workflows/obo-test.yml
+++ b/.github/workflows/obo-test.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    if: github.actor != 'github-actions[bot]'
+    if: github.triggering_actor != 'github-actions[bot]'
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -6,7 +6,7 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
-    if: github.actor != 'github-actions[bot]'
+    if: github.triggering_actor != 'github-actions[bot]'
     strategy:
       matrix:
         python-version: [ "3.7", "3.10" ]


### PR DESCRIPTION
This PR adds a check for triggering actor instead of github actor to prevent unnecessary runs when the derived files are created by github-actions bot.