### PR TITLE
Mark FBbi as inactive

### DIFF
--- a/ontology/fbbi.md
+++ b/ontology/fbbi.md
@@ -23,5 +23,5 @@ repository: https://github.com/CRBS/Biological_Imaging_Methods_Ontology
 tags:
 - imaging experiments
 tracker: https://github.com/CRBS/Biological_Imaging_Methods_Ontology/issues
-activity_status: active
+activity_status: inactive
 ---


### PR DESCRIPTION
@wawong, the contact person for FBbi, has stated that the ontology is inactive and the people who are responsible for it have moved on. Reference: https://github.com/CRBS/Biological_Imaging_Methods_Ontology/issues/1#issuecomment-1769157042