### PR TITLE
Mark MFMO as inactive

### DIFF
--- a/ontology/mfmo.md
+++ b/ontology/mfmo.md
@@ -23,7 +23,5 @@ taxon:
   id: NCBITaxon:40674
   label: Mammalian
 tracker: https://github.com/RDruzinsky/feedontology/issues
-activity_status: active
+activity_status: inactive
 ---
-
-ADD DESCRIPTION HERE


### PR DESCRIPTION
Robert (the contact for MFMO) said that the ontology is inactive, nobody is working on it anymore, and to his knowledge, nobody is using it. The last commit was made in 2015 and nobody is responsible for answering the issue tracker (I was able to get in touch by private email, though).
 
Ref: https://github.com/RDruzinsky/feedontology/issues/2#issuecomment-1770881833