### PR TITLE
Update new-ontology.yml instructions to better conform to principle 6

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-ontology.yml
+++ b/.github/ISSUE_TEMPLATE/new-ontology.yml
@@ -268,7 +268,7 @@ body:
           required: false
         - label: My term labels are in English and conform to the OBO Foundry [Naming Conventions](http://obofoundry.org/http://obofoundry.org/principles/fp-012-naming-conventions.html)
           required: false
-        - label: I understand that term definitions, while not mandatory, are key to understanding the intentions of a term especially when the ontology is used in curation. I made sure that a reasonable majority of terms in my ontology have definitions, in English, using the [IAO:0000115](https://ontobee.org/ontology/IAO?iri=http://purl.obolibrary.org/obo/IAO_0000115) property.
+        - label: I understand that term definitions are key to understanding the intentions of a term, especially when the ontology is used in curation. I made sure that a reasonable majority of terms in my ontology--and all top level terms--have definitions, in English, using the [IAO:0000115](https://ontobee.org/ontology/IAO?iri=http://purl.obolibrary.org/obo/IAO_0000115) property.
           required: false
         - label: For every term in my ontology, I checked whether another OBO Foundry ontology has one with the same meaning. If so, I re-used that term directly (not by cross-reference, by directly using the IRI).
           required: false


### PR DESCRIPTION
In order to promote the importance of term descriptions, the instructions have been revised to remove the clause "while not necessary". At the same time, the necessity of descriptions for top-level terms is now emphasized. These changes bring the new ontology request form in better alignment with principle 6.