### PR TITLE
Fix python version in qa workflow

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -9,7 +9,7 @@ jobs:
     if: github.triggering_actor != 'github-actions[bot]'
     strategy:
       matrix:
-        python-version: [ "3.7", "3.10" ]
+        python-version: [ "3.8", "3.10" ]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}

--- a/util/check_schema.py
+++ b/util/check_schema.py
@@ -51,9 +51,11 @@ def _check_schema(max_cutoff: int = 3, links: bool = True):
                 (
                     k,
                     ", ".join(
-                        f"[{prefix}](https://obofoundry.org/ontologies/{prefix})"
-                        if links
-                        else prefix
+                        (
+                            f"[{prefix}](https://obofoundry.org/ontologies/{prefix})"
+                            if links
+                            else prefix
+                        )
                         for prefix in prefixes
                     ),
                 )


### PR DESCRIPTION
Our qa workflow (`qa.yml`) is failing only on Python 3.10 and not Python 3.7.
This is because the version of `black` used with Python 3.7 (`black<=23.12.1`) is different than the one used with Python 3.10 (`black==24.1.1`)

And it looks like Black library has made some changes, in the latest release (24.1.1), on how it formats inline if-else statements.

Due to the slightly different style of formatting, the workflow succeeds on the old Python 3.7 but fails on the new Python 3.10.

But there is also the question of whether we want to have the workflow running on Python 3.7 since it reached its end of life (EOL) in June 2023.

To fix this situation, the PR 
- removes Python 3.7 from the job matrix and adds Python 3.8 instead
- fixes the formatting according to the latest release of Black (24.1.1)
