### PR TITLE
Fix URL for MP logo

### DIFF
--- a/ontology/mp.md
+++ b/ontology/mp.md
@@ -17,7 +17,7 @@ contact:
   github: sbello
   label: Sue Bello
   orcid: 0000-0003-4606-0597
-depicted_by: https://github.com/mgijax/mammalian-phenotype-ontology/blob/main/logo/2024_MP_logo_RGB_ICON_color.png
+depicted_by: https://raw.githubusercontent.com/mgijax/mammalian-phenotype-ontology/main/logo/2024_MP_logo_RGB_ICON_color.png
 description: Standard terms for annotating mammalian phenotypic data.
 domain: phenotype
 homepage: http://www.informatics.jax.org/searches/MP_form.shtml


### PR DESCRIPTION
This PR uses the raw github URL to point to the MP logo PNG. This should ensure that the logo renders properly in the website.

FYI @sbello 