### PR TITLE
Update principle 3 to make upper case prefix mandatory

### DIFF
--- a/principles/fp-003-uris.md
+++ b/principles/fp-003-uris.md
@@ -22,7 +22,7 @@ Each ontology MUST have a unique IRI in the form of an OBO Foundry permanent URL
 ### Ontology Namespace:
 
 The namespace is a short string of letters (usually 2-5) that represents the ontology. 
-When used as part of a CURIE, on its own, or as part of a term ID, the namespace must be capitalized.
+When used as part of a CURIE, on its own, or as part of a term ID, the namespace MUST be capitalized.
 As per [vote on 31st May 2024](https://github.com/OBOFoundry/OBOFoundry.github.io/issues/2596), this applies to all ontologies submitted for acceptance after the 1st June 2024. Ontologies submitted before the 1st June 2024 may retain their mixed case prefixes.
 When used as part of the ontology IRI, the namespace is in lower case. See examples below.
 

--- a/principles/fp-003-uris.md
+++ b/principles/fp-003-uris.md
@@ -1,4 +1,4 @@
----
+<img width="1023" alt="image" src="https://github.com/OBOFoundry/OBOFoundry.github.io/assets/7070631/132e3781-9753-4fd8-abd6-c29a7242bc48">---
 layout: principle
 id: fp-003-uris
 title: URI/Identifier Space (principle 3)
@@ -21,7 +21,10 @@ Each ontology MUST have a unique IRI in the form of an OBO Foundry permanent URL
 
 ### Ontology Namespace:
 
-The namespace is a short string of letters (usually 2-5) that represents the ontology. When used as part of a CURIE, on its own, or as part of a term ID, the namespace is generally capitalized. When used as part of the ontology IRI, the namespace is in lower case. See examples below.
+The namespace is a short string of letters (usually 2-5) that represents the ontology. 
+When used as part of a CURIE, on its own, or as part of a term ID, the namespace must be capitalized.
+As per [vote on 31st May 2024](https://github.com/OBOFoundry/OBOFoundry.github.io/issues/2596), this applies to all ontologies submitted for acceptance after the 1st June 2024. Ontologies submitted before the 1st June 2024 may retain their mixed case prefixes.
+When used as part of the ontology IRI, the namespace is in lower case. See examples below.
 
 To request a new namespace, ontology developers MUST follow the guidelines outlined here. Note that very short namespaces (2-3 characters) are reserved for ontologies that cover a general domain and are likely to be frequently used.
 

--- a/principles/fp-003-uris.md
+++ b/principles/fp-003-uris.md
@@ -1,4 +1,4 @@
-<img width="1023" alt="image" src="https://github.com/OBOFoundry/OBOFoundry.github.io/assets/7070631/132e3781-9753-4fd8-abd6-c29a7242bc48">---
+---
 layout: principle
 id: fp-003-uris
 title: URI/Identifier Space (principle 3)


### PR DESCRIPTION
For a while it was not clear whether upper case prefixes are mandated or merely encouraged for new submissions. 

We have conducted a vote (https://github.com/OBOFoundry/OBOFoundry.github.io/issues/2596) which clarifies the situation. The decision was that for new ontology submissions, ontology prefixes _must be_ upper case.