### PR TITLE
fix: clean up some language regarding citations

### DIFF
--- a/_layouts/ontology_detail.html
+++ b/_layouts/ontology_detail.html
@@ -85,7 +85,7 @@ page.preferredPrefix | upcase %} {% if upperPrefix != page.preferredPrefix %}
     </div>
 
     {% if page.publications %}
-    <div class="card" style="margin-bottom: 1.5em;">
+    <div class="card" style="margin-bottom: 1.5em;" id="publications">
       <div class="card-header">
         Publications
       </div>

--- a/docs/Citation.md
+++ b/docs/Citation.md
@@ -37,7 +37,7 @@ The ontology IRI or ontology version IRI should be accompanied by a citation of 
 
 ## Citing an ontology
 
-Some ontologies recommend citation of specific publications. Please see their respective homepages for this information. For example, [Uberon](http://obofoundry.org/ontology/uberon) lists two publications under "Cite."
+Some ontologies recommend citation of specific publications. Please see their respective homepages for this information. For example, [Uberon]({{ "ontology/uberon.html#publications" | prepend: site.baseurl }}) lists two publications under "Publications."
 
 In addition to the recommended publication, you should also cite the ontology using its IRI and the [new data citation extension to JATS](https://peerj.com/articles/cs-1/). When no specific publication is recommended, you must cite the ontology by its IRI. Here is an example citation:
 

--- a/registry/publications.md
+++ b/registry/publications.md
@@ -18,7 +18,9 @@ Barry Smith, Michael Ashburner, Cornelius Rosse, Jonathan Bard, William Bug, Wer
 
 [Google Scholar list of papers citing The OBO Foundry](https://scholar.google.ca/scholar?cites=13806088078865650870&as_sdt=2005&sciodt=0,5&hl=en)
 
-### Some Ontology Project Publications (not a complete list)
+### Known Ontology Project Publications
+
+This list is generated automatically from OBO Foundry ontology metadata. It is not intended to be authoritative or exhaustive.
 
 <ul>
 {% for ontology in site.ontologies %}


### PR DESCRIPTION
a few possible changes -- let me know if they need to go through additional channels first:

* Fix wording on the Citation policy page, which refers to a "Cite" section on the ontology detail page (the header is actually "Publications")
* add a linkable anchor to the "publications" header on an ontology's detail page, so that the citation policy page can link to it directly
* Alter wording on the big "list of publications" page. When I first saw it, I assumed it was totally ad-hoc and wanted to instead generate it from publication annotations from the ontology metadata -- then I looked at the code and realized that's what was already happening. So, I thought it might be helpful to give a brief explanation of where the list comes from.