### PR TITLE
Change column header

### DIFF
--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -102,7 +102,7 @@ jQuery(document).ready(function() {
                             </th>
                             <th scope="col">
                                 <span class="sort-button" title="Sort by status" data-sort="license" >
-                                    Re-Use <i class="bi-chevron-up" aria-hidden="true"></i>
+                                    OBO Principles <i class="bi-chevron-up" aria-hidden="true"></i>
                                 </span>
                             </th>
                             <th scope="col">


### PR DESCRIPTION
The second-to-last column of the ontology table is currently labeled "Re-Use", but it contains both the dashboard results and the license. I was in favor of separating those into separate columns, but there was concern that that would make the table too wide. The proposed compromise was to change the column header, as I have done. address #2611