### PR TITLE
Add Atom feed using the jekyll-feed plugin

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -10,6 +10,7 @@ author:
   name: OBO Technical WG
 plugins:
   - jekyll-sitemap
+  - jekyll-feed
 ## --Anything above this line can be edited in _config_header.yml --
 ## --Everything below this line automatically generated in _config.yml --
 ontologies:

--- a/_config.yml
+++ b/_config.yml
@@ -11,6 +11,8 @@ author:
 plugins:
   - jekyll-sitemap
   - jekyll-feed
+feed:
+  disable_in_development: true
 ## --Anything above this line can be edited in _config_header.yml --
 ## --Everything below this line automatically generated in _config.yml --
 ontologies:

--- a/_config_header.yml
+++ b/_config_header.yml
@@ -10,5 +10,6 @@ author:
   name: OBO Technical WG
 plugins:
   - jekyll-sitemap
+  - jekyll-feed
 ## --Anything above this line can be edited in _config_header.yml --
 ## --Everything below this line automatically generated in _config.yml --

--- a/_config_header.yml
+++ b/_config_header.yml
@@ -11,5 +11,7 @@ author:
 plugins:
   - jekyll-sitemap
   - jekyll-feed
+feed:
+  disable_in_development: true
 ## --Anything above this line can be edited in _config_header.yml --
 ## --Everything below this line automatically generated in _config.yml --

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -14,6 +14,8 @@
 <!-- Custom stylesheet -->
 <link rel="stylesheet" href="/assets/css/style.css">
 
+{% feed_meta %}
+
 <style>
 html, body {
     height: 100%;


### PR DESCRIPTION
This adds an Atom XML feed for content under `_posts` using [jekyl-feed](https://github.com/jekyll/jekyll-feed). No additional install steps should be necessary since that plugin is pre-installed for [GitHub Pages](https://pages.github.com/versions/) and the [Jekyll Docker image](https://github.com/envygeeks/jekyll-docker/blob/fb892998d444b7b2e4074adeb032197f67853c0a/repos/jekyll/opts.yml#L22).