### PR TITLE
Add Sebastian Duesing to OBO Operations Committee

### DIFF
--- a/_data/operations.yml
+++ b/_data/operations.yml
@@ -343,6 +343,16 @@ members:
   orcid: 0000-0003-1355-892X
   wikidata: Q30508615
 - affiliation:
+    name: La Jolla Institute for Immunology, La Jolla, CA
+    ror: 05vkpd318
+  country: USA
+  github: sebastianduesing
+  groups:
+  - technical
+  name: Sebastian Duesing
+  orcid: 0009-0009-4008-3801
+  wikidata: Q6463245
+- affiliation:
     name: Lawrence Berkeley National Laboratory, Berkeley, CA
     ror: 02jbv0t02
   country: USA


### PR DESCRIPTION
Adds entry to operations.yml and headshot to images/ofoc for me, per instructions in the onboarding document.