### PR TITLE
fix link to publications page to cite OBO Foundry

### DIFF
--- a/faq/index.md
+++ b/faq/index.md
@@ -12,7 +12,7 @@ title: OBO Foundry Frequently Asked Questions
 
 ### Citation
 
-- [How do I cite the OBO Foundry?](/registry/publications.html)
+- [How do I cite the OBO Foundry?](/citation/RelatedPublications.html)
 - [How do I cite a specific ontology?](/docs/Citation.html)
 
 ### Terms


### PR DESCRIPTION
fixes #2703