### PR TITLE
Update JSON product to use correct download PURL cl.md

### DIFF
--- a/ontology/cl.md
+++ b/ontology/cl.md
@@ -45,7 +45,7 @@ products:
   derived_from: cl.owl
   description: Complete ontology, plus inter-ontology axioms, and imports modules merged in
   format: obo
-- id: cl.json
+- id: cl/cl.json
   title: CL OBOGraph-JSON format edition
   derived_from: cl.owl
   description: Complete ontology, plus inter-ontology axioms, and imports modules merged in


### PR DESCRIPTION
Fixes #2710

This is, if I remember correctly the consequence of a design decision for the PURL system.

While the PURL defined by ODK etc is http://purl.obolibrary.org/obo/cl.json, the PURL system only recognises a tiny number of defaults _above_ the ontology namespace `http://purl.obolibrary.org/obo/cl/` (including cl.owl and cl.obo), but cl.json is not part of it.

We could argue that we should also add cl.json to this list.

For those with energy and a sense of beauty, the next steps from this would be:

1. Either allow cl.json (or ideally `http://purl.obolibrary.org/obo/cl.[a-z0-1]+`) as valid PURL defaults, make [issue here](https://github.com/OBOFoundry/purl.obolibrary.org/issues) OR
2. Change ODK to set the PURL for all _but_ the obo and owl versions to `http://purl.obolibrary.org/obo/cl/cl.[a-z0-1]+` syntax

