### PR TITLE
reorder fields in a more logical way

### DIFF
--- a/_data/operations.yml
+++ b/_data/operations.yml
@@ -1,374 +1,374 @@
 members:
-- affiliation:
-    name: University at Buffalo, Buffalo
-    ror: 01y64my43
-  country: USA
-  github: alanruttenberg
-  groups:
-  - outreach
-  link: http://sciencecommons.org/about/whoweare/ruttenberg/
-  name: Alan Ruttenberg
+- name: Alan Ruttenberg
   orcid: 0000-0002-1604-3078
   wikidata: Q30508557
-- affiliation:
-    name: University at Buffalo, Buffalo, NY
-    ror: 01y64my43
   country: USA
-  github: addiehl
-  groups:
-  - technical
-  name: Alexander Diehl
+  github: alanruttenberg
+  groups: 
+  - outreach
+  link: http://sciencecommons.org/about/whoweare/ruttenberg/
+  affiliation: 
+    name: University at Buffalo, Buffalo
+    ror: 01y64my43
+- name: Alexander Diehl
   orcid: 0000-0001-9990-8331
   wikidata: Q47502183
-- affiliation:
-    name: European Bioinformatics Institute (EMBL-EBI), Cambridge
-    ror: 02catss52
-  country: UK
-  github: anitacaron
-  groups:
+  country: USA
+  github: addiehl
+  groups: 
   - technical
-  name: Anita R. Caron
+  affiliation: 
+    ror: 01y64my43
+    name: University at Buffalo, Buffalo, NY
+- name: Anita R. Caron
   orcid: 0000-0002-6523-4866
   wikidata: Q114518421
-- affiliation:
-    name: University at Buffalo, Buffalo, NY
-    ror: 01y64my43
-  country: USA
-  github: phismith
-  groups:
-  - outreach
-  name: Barry Smith
+  country: UK
+  github: anitacaron
+  groups: 
+  - technical
+  affiliation: 
+    name: European Bioinformatics Institute (EMBL-EBI), Cambridge
+    ror: 02catss52
+- name: Barry Smith
   orcid: 0000-0003-1384-116X
   wikidata: Q809101
-- affiliation:
-    name: University of Florida, Gainseville, FL
-    ror: 02y3ad647
   country: USA
-  github: hoganwr
-  groups:
-  - editorial
-  name: Bill Hogan
+  github: phismith
+  groups: 
+  - outreach
+  affiliation: 
+    name: University at Buffalo, Buffalo, NY
+    ror: 01y64my43
+- name: Bill Hogan
   orcid: 0000-0002-9881-1017
   wikidata: Q56590169
-- affiliation:
-    name: La Jolla Institute for Immunology, La Jolla, CA
-    ror: 05vkpd318
   country: USA
-  github: bpeters42
-  groups:
-  - outreach
-  link: https://www.lji.org/labs/peters/
-  name: Bjoern Peters
+  github: hoganwr
+  groups: 
+  - editorial
+  affiliation: 
+    ror: 02y3ad647
+    name: University of Florida, Gainseville, FL
+- name: Bjoern Peters
   orcid: 0000-0002-8457-6693
   wikidata: Q60541156
-- affiliation:
-    name: Lawrence Berkeley National Laboratory, Berkeley, CA
-    ror: 02jbv0t02
   country: USA
-  github: cmungall
-  groups:
-  - technical
-  link: https://github.com/cmungall/
-  name: Chris Mungall
+  github: bpeters42
+  groups: 
+  - outreach
+  link: https://www.lji.org/labs/peters/
+  affiliation: 
+    ror: 05vkpd318
+    name: La Jolla Institute for Immunology, La Jolla, CA
+- name: Chris Mungall
   orcid: 0000-0002-6601-2165
   wikidata: Q20746118
-- affiliation:
-    name: University of Pennsylvania, Philadelphia, PA
-    ror: 00b30xv10
   country: USA
-  github: cstoeckert
-  groups:
-  - outreach
-  name: Chris Stoeckert
+  github: cmungall
+  groups: 
+  - technical
+  link: https://github.com/cmungall/
+  affiliation: 
+    ror: 02jbv0t02
+    name: Lawrence Berkeley National Laboratory, Berkeley, CA
+- name: Chris Stoeckert
   orcid: 0000-0002-5714-991X
   wikidata: Q67220657
-- affiliation:
-    name: Centre for Infectious Disease Genomics and One Health, Simon Fraser University, BC
-    ror: 0213rcc28
-  country: Canada
-  github: ddooley
-  groups:
+  country: USA
+  github: cstoeckert
+  groups: 
   - outreach
-  name: Damion Dooley
+  affiliation: 
+    ror: 00b30xv10
+    name: University of Pennsylvania, Philadelphia, PA
+- name: Damion Dooley
   orcid: 0000-0002-8844-9165
   wikidata: Q91868864
-- affiliation:
-    name: Georgetown University Medical Center, Washington DC
-    ror: 00hjz7x27
-  country: USA
-  github: nataled
-  groups:
-  - editorial
-  link: http://pir.georgetown.edu/pirwww/aboutpir/natalebio.shtml
-  name: Darren Natale
+  country: Canada
+  github: ddooley
+  groups: 
+  - outreach
+  affiliation: 
+    name: Centre for Infectious Disease Genomics and One Health, Simon Fraser University, BC
+    ror: 0213rcc28
+- name: Darren Natale
   orcid: 0000-0001-5809-9523
   wikidata: Q99552327
-- affiliation:
-    name: EMBL-EBI, Cambridge
-    ror: 02catss52
-  country: UK
-  github: dosumis
-  groups:
-  - outreach
-  name: David Osumi-Sutherland
+  country: USA
+  github: nataled
+  groups: 
+  - editorial
+  link: http://pir.georgetown.edu/pirwww/aboutpir/natalebio.shtml
+  affiliation: 
+    name: Georgetown University Medical Center, Washington DC
+    ror: 00hjz7x27
+- name: David Osumi-Sutherland
   orcid: 0000-0002-7073-9172
   wikidata: Q54303418
-- affiliation:
-    name: SIB Swiss Institute of Bioinformatics, Basel
-    ror: 002n09z45
-  country: Switzerland
-  github: deepakunni3
-  groups:
-  - technical
-  name: Deepak R. Unni
+  country: UK
+  github: dosumis
+  groups: 
+  - outreach
+  affiliation: 
+    name: EMBL-EBI, Cambridge
+    ror: 02catss52
+- name: Deepak R. Unni
   orcid: 0000-0002-3583-7340
   wikidata: Q59690671
-- affiliation:
-    name: University of Nebraska, Lincoln, NE
-    ror: 043mer456
-  country: USA
-  github: erik-whiting
-  groups:
+  country: Switzerland
+  github: deepakunni3
+  groups: 
   - technical
-  name: Erik Whiting
+  affiliation: 
+    ror: 002n09z45
+    name: SIB Swiss Institute of Bioinformatics, Basel
+- name: Erik Whiting
   orcid: 0000-0003-1022-5281
   wikidata: Q115716044
-- affiliation:
-    name: Kansas State University, Manhattan, KS
-    ror: 05p1j8758
   country: USA
-  github: handemcginty
-  groups:
-  - editorial
-  - outreach
-  name: Hande Küçük McGinty
+  github: erik-whiting
+  groups: 
+  - technical
+  affiliation: 
+    name: University of Nebraska, Lincoln, NE
+    ror: 043mer456
+- name: Hande Küçük McGinty
   orcid: 0000-0002-9025-5538
   wikidata: Q107527234
-- affiliation:
-    name: Knocean Inc., Toronto
-    wikidata: Q115518163
-  country: Canada
-  github: jamesaoverton
-  groups:
-  - technical
-  link: http://james.overton.ca/
-  name: James A. Overton
+  country: USA
+  github: handemcginty
+  groups: 
+  - editorial
+  - outreach
+  affiliation: 
+    ror: 05p1j8758
+    name: Kansas State University, Manhattan, KS
+- name: James A. Overton
   orcid: 0000-0001-5139-5557
   wikidata: Q106221456
-- affiliation:
-    name: Nationwide Children's Hospital, Columbus, OH
-    ror: 003rfsp33
-  country: USA
-  github: jsstevenson
-  groups:
+  country: Canada
+  github: jamesaoverton
+  groups: 
   - technical
-  link: https://jsstevenson.github.io
-  name: James Stevenson
+  link: http://james.overton.ca/
+  affiliation: 
+    wikidata: Q115518163
+    name: Knocean Inc., Toronto
+- name: James Stevenson
   orcid: 0000-0002-2568-6163
   wikidata: Q125208044
-- affiliation:
-    name: University of Pennsylvania, Philadelphia, PA
-    ror: 00b30xv10
   country: USA
-  github: zhengj2007
-  groups:
-  - outreach
+  github: jsstevenson
+  groups: 
   - technical
-  name: Jie Zheng
+  link: https://jsstevenson.github.io
+  affiliation: 
+    ror: 003rfsp33
+    name: Nationwide Children's Hospital, Columbus, OH
+- name: Jie Zheng
   orcid: 0000-0002-2999-0103
   wikidata: Q90780528
-- affiliation:
-    name: RENCI, University of North Carolina, Chapel Hill, NC
-    ror: 01s91ey96
   country: USA
-  github: balhoff
-  groups:
+  github: zhengj2007
+  groups: 
+  - outreach
   - technical
-  name: Jim Balhoff
+  affiliation: 
+    ror: 00b30xv10
+    name: University of Pennsylvania, Philadelphia, PA
+- name: Jim Balhoff
   orcid: 0000-0002-8688-6599
   wikidata: Q37649212
-- affiliation:
-    name: Independent Volunteer
-    ror: 01cwqze88
   country: USA
-  github: LK112019
-  groups:
-  - outreach
-  name: Leila Kiani
+  github: balhoff
+  groups: 
+  - technical
+  affiliation: 
+    name: RENCI, University of North Carolina, Chapel Hill, NC
+    ror: 01s91ey96
+- name: Leila Kiani
   orcid: 0009-0009-6722-6147
   wikidata: Q118105252
-- affiliation:
-    name: University of Maryland School of Medicine, Baltimore, MD
-    ror: 01r0c1p88
   country: USA
-  github: lschriml
-  groups:
+  github: LK112019
+  groups: 
   - outreach
-  link: http://www.medschool.umaryland.edu/profiles/Schriml-Lynn/
-  name: Lynn Schriml
+  affiliation: 
+    ror: 01cwqze88
+    name: Independent Volunteer
+- name: Lynn Schriml
   orcid: 0000-0001-8910-9851
   wikidata: Q28913673
-- affiliation:
-    name: University of Colorado Anschutz Medical Campus, Aurora, CO
-    ror: 03wmf1y16
   country: USA
-  github: mbrush
-  groups:
-  - technical
-  name: Matt Brush
+  github: lschriml
+  groups: 
+  - outreach
+  link: http://www.medschool.umaryland.edu/profiles/Schriml-Lynn/
+  affiliation: 
+    name: University of Maryland School of Medicine, Baltimore, MD
+    ror: 01r0c1p88
+- name: Matt Brush
   orcid: 0000-0002-1048-5019
   wikidata: Q88110949
-- affiliation:
-    name: Unversity of Colorado Anschutz Medical Campus, Auroa, CO
-    ror: 03wmf1y16
   country: USA
-  github: mellybelly
-  groups:
-  - outreach
-  link: https://www.ohsu.edu/people/melissa-haendel/AFE044BDE8046E5D6FBDA51F448BDE2A
-  name: Melissa Haendel
+  github: mbrush
+  groups: 
+  - technical
+  affiliation: 
+    ror: 03wmf1y16
+    name: University of Colorado Anschutz Medical Campus, Aurora, CO
+- name: Melissa Haendel
   orcid: 0000-0001-9114-8737
   wikidata: Q28368079
-- affiliation:
-    name: Semanticly, Athens
-    wikidata: Q115518213
-  country: Greece
-  github: matentzn
-  groups:
-  - technical
-  name: Nico Matentzoglu
+  country: USA
+  github: mellybelly
+  groups: 
+  - outreach
+  link: https://www.ohsu.edu/people/melissa-haendel/AFE044BDE8046E5D6FBDA51F448BDE2A
+  affiliation: 
+    name: Unversity of Colorado Anschutz Medical Campus, Auroa, CO
+    ror: 03wmf1y16
+- name: Nico Matentzoglu
   orcid: 0000-0002-7356-1779
   wikidata: Q60972192
-- affiliation:
-    name: Critical Path Institute, Tucson, AZ
-    ror: 03wmf1y16
-  country: USA
-  github: nicolevasilevsky
-  groups:
-  - outreach
-  name: Nicole Vasilevsky
+  country: Greece
+  github: matentzn
+  groups: 
+  - technical
+  affiliation: 
+    wikidata: Q115518213
+    name: Semanticly, Athens
+- name: Nicole Vasilevsky
   orcid: 0000-0001-5208-3432
   wikidata: Q42763131
-- affiliation:
-    name: Lawrence Berkeley National Laboratory, Berkeley, CA
-    ror: 02jbv0t02
   country: USA
-  github: nlharris
-  groups:
+  github: nicolevasilevsky
+  groups: 
   - outreach
-  - technical
-  name: Nomi Harris
+  affiliation: 
+    ror: 03wmf1y16
+    name: Critical Path Institute, Tucson, AZ
+- name: Nomi Harris
   orcid: 0000-0001-6315-3707
   wikidata: Q58106602
-- affiliation:
-    name: Université de Sherbrooke, Québec
-    ror: 00kybxq39
-  country: Canada
-  github: pfabry
-  groups:
+  country: USA
+  github: nlharris
+  groups: 
+  - outreach
   - technical
-  name: Paul Fabry
-  orcid: 0000-0002-3336-2476
-  wikidata: Q108555457
-- affiliation:
-    name: University of Oxford e-Research Centre, Department of Engineering Science, Oxford
-    ror: 052gg0110
-  country: UK
-  github: proccaserra
-  groups:
-  - outreach
-  link: https://eng.ox.ac.uk/people/philippe-rocca-serra/
-  name: Philippe Rocca-Serra
-  orcid: 0000-0001-9853-5668
-  wikidata: Q28364404
-- affiliation:
-    name: Alfred Wegener Institute, Helmholtz Centre for Polar and Marine Research, Bremerhaven
-    ror: 032e6b942
-  country: Germany
-  github: pbuttigieg
-  groups:
-  - outreach
-  name: Pier Luigi Buttigieg
-  orcid: 0000-0002-4366-3088
-  wikidata: Q41566750
-- affiliation:
-    name: La Jolla Institute for Immunology, La Jolla, CA
-    ror: 05vkpd318
-  country: USA
-  github: rvita
-  groups:
-  - outreach
-  name: Randi Vita
-  orcid: 0000-0001-8957-7612
-  wikidata: Q58116889
-- affiliation:
-    name: Intelligent Medical Objects (IMO), Rosemont, IL
-    ror: 03y46nb69
-  country: USA
-  github: beckyjackson
-  groups:
-  - technical
-  name: Rebecca Jackson
-  orcid: 0000-0003-4871-5569
-  wikidata: Q59539088
-- affiliation:
-    name: J. Craig Venter Institute, La Jolla, CA
-    ror: 049r1ts75
-  country: USA
-  github: scheuerm
-  groups:
-  - outreach
-  link: https://www.jcvi.org/about/rscheuermann
-  name: Richard Scheuermann
-  orcid: 0000-0003-1355-892X
-  wikidata: Q30508615
-- affiliation:
-    name: La Jolla Institute for Immunology, La Jolla, CA
-    ror: 05vkpd318
-  country: USA
-  github: sebastianduesing
-  groups:
-  - technical
-  name: Sebastian Duesing
-  orcid: 0009-0009-4008-3801
-  wikidata: Q6463245
-- affiliation:
+  affiliation: 
     name: Lawrence Berkeley National Laboratory, Berkeley, CA
     ror: 02jbv0t02
-  country: USA
-  github: kltm
-  groups:
+- name: Paul Fabry
+  orcid: 0000-0002-3336-2476
+  wikidata: Q108555457
+  country: Canada
+  github: pfabry
+  groups: 
   - technical
-  name: Seth Carbon
+  affiliation: 
+    name: Université de Sherbrooke, Québec
+    ror: 00kybxq39
+- name: Philippe Rocca-Serra
+  orcid: 0000-0001-9853-5668
+  wikidata: Q28364404
+  country: UK
+  github: proccaserra
+  groups: 
+  - outreach
+  link: https://eng.ox.ac.uk/people/philippe-rocca-serra/
+  affiliation: 
+    name: University of Oxford e-Research Centre, Department of Engineering Science, Oxford
+    ror: 052gg0110
+- name: Pier Luigi Buttigieg
+  orcid: 0000-0002-4366-3088
+  wikidata: Q41566750
+  country: Germany
+  github: pbuttigieg
+  groups: 
+  - outreach
+  affiliation: 
+    ror: 032e6b942
+    name: Alfred Wegener Institute, Helmholtz Centre for Polar and Marine Research, Bremerhaven
+- name: Randi Vita
+  orcid: 0000-0001-8957-7612
+  wikidata: Q58116889
+  country: USA
+  github: rvita
+  groups: 
+  - outreach
+  affiliation: 
+    ror: 05vkpd318
+    name: La Jolla Institute for Immunology, La Jolla, CA
+- name: Rebecca Jackson
+  orcid: 0000-0003-4871-5569
+  wikidata: Q59539088
+  country: USA
+  github: beckyjackson
+  groups: 
+  - technical
+  affiliation: 
+    name: Intelligent Medical Objects (IMO), Rosemont, IL
+    ror: 03y46nb69
+- name: Richard Scheuermann
+  orcid: 0000-0003-1355-892X
+  wikidata: Q30508615
+  country: USA
+  github: scheuerm
+  groups: 
+  - outreach
+  link: https://www.jcvi.org/about/rscheuermann
+  affiliation: 
+    name: J. Craig Venter Institute, La Jolla, CA
+    ror: 049r1ts75
+- name: Sebastian Duesing
+  orcid: 0009-0009-4008-3801
+  wikidata: Q6463245
+  country: USA
+  github: sebastianduesing
+  groups: 
+  - technical
+  affiliation: 
+    ror: 05vkpd318
+    name: La Jolla Institute for Immunology, La Jolla, CA
+- name: Seth Carbon
   orcid: 0000-0001-8244-1536
   wikidata: Q57081961
-- affiliation:
-    name: European Bioinformatics Institute, Cambridge
-    ror: 02catss52
-  country: UK
-  github: shawntanzk
-  groups:
+  country: USA
+  github: kltm
+  groups: 
   - technical
-  name: Shawn Tan
+  affiliation: 
+    ror: 02jbv0t02
+    name: Lawrence Berkeley National Laboratory, Berkeley, CA
+- name: Shawn Tan
   orcid: 0000-0001-7258-9596
   wikidata: Q57023310
-- affiliation:
-    name: European Bioinformatics Institute, Cambridge
-    wikidata: Q695267
-  country: United Kingdom
-  github: souzadevinicius
-  groups:
+  country: UK
+  github: shawntanzk
+  groups: 
   - technical
-  name: Vinícius de Souza
+  affiliation: 
+    ror: 02catss52
+    name: European Bioinformatics Institute, Cambridge
+- name: Vinícius de Souza
   orcid: 0000-0003-3961-0247
   wikidata: Q125502774
-- affiliation:
-    name: SciBite
-    ror: 055j8ya05
-  country: UK
-  github: janelomax
-  groups:
-  - outreach
-  name: Jane Lomax
+  country: United Kingdom
+  github: souzadevinicius
+  groups: 
+  - technical
+  affiliation: 
+    wikidata: Q695267
+    name: European Bioinformatics Institute, Cambridge
+- name: Jane Lomax
   orcid: 0000-0001-8865-4321
   wikidata: Q20746117
+  country: UK
+  github: janelomax
+  groups: 
+  - outreach
+  affiliation: 
+    name: SciBite
+    ror: 055j8ya05


### PR DESCRIPTION
why did these records start with affiliation, with name buried somewhere in the middle? that makes it much tricker to correctly make edits (adding or removing someone).

i reordered the fields (with the help of a Claude-generated script) to put name first and affiliation list, in hopes of making this file more maintainable both in the short term (i need to move some members to alumni) and longer term.

lmk if anything looks wonky; i only spot-checked.