### PR TITLE
Remove former OBO Ops members

### DIFF
--- a/_data/operations.yml
+++ b/_data/operations.yml
@@ -1,16 +1,5 @@
 members:
 - affiliation:
-    name: University at Buffalo, Buffalo
-    ror: 01y64my43
-  country: USA
-  github: alanruttenberg
-  groups:
-  - outreach
-  link: http://sciencecommons.org/about/whoweare/ruttenberg/
-  name: Alan Ruttenberg
-  orcid: 0000-0002-1604-3078
-  wikidata: Q30508557
-- affiliation:
     name: University at Buffalo, Buffalo, NY
     ror: 01y64my43
   country: USA
@@ -30,16 +19,6 @@ members:
   name: Anita R. Caron
   orcid: 0000-0002-6523-4866
   wikidata: Q114518421
-- affiliation:
-    name: University at Buffalo, Buffalo, NY
-    ror: 01y64my43
-  country: USA
-  github: phismith
-  groups:
-  - outreach
-  name: Barry Smith
-  orcid: 0000-0003-1384-116X
-  wikidata: Q809101
 - affiliation:
     name: University of Florida, Gainseville, FL
     ror: 02y3ad647
@@ -94,16 +73,6 @@ members:
   orcid: 0000-0001-5809-9523
   wikidata: Q99552327
 - affiliation:
-    name: EMBL-EBI, Cambridge
-    ror: 02catss52
-  country: UK
-  github: dosumis
-  groups:
-  - outreach
-  name: David Osumi-Sutherland
-  orcid: 0000-0002-7073-9172
-  wikidata: Q54303418
-- affiliation:
     name: SIB Swiss Institute of Bioinformatics, Basel
     ror: 002n09z45
   country: Switzerland
@@ -113,16 +82,6 @@ members:
   name: Deepak R. Unni
   orcid: 0000-0002-3583-7340
   wikidata: Q59690671
-- affiliation:
-    name: University of Nebraska, Lincoln, NE
-    ror: 043mer456
-  country: USA
-  github: erik-whiting
-  groups:
-  - technical
-  name: Erik Whiting
-  orcid: 0000-0003-1022-5281
-  wikidata: Q115716044
 - affiliation:
     name: Kansas State University, Manhattan, KS
     ror: 05p1j8758
@@ -199,27 +158,6 @@ members:
   orcid: 0000-0001-8910-9851
   wikidata: Q28913673
 - affiliation:
-    name: University of Colorado Anschutz Medical Campus, Aurora, CO
-    ror: 03wmf1y16
-  country: USA
-  github: mbrush
-  groups:
-  - technical
-  name: Matt Brush
-  orcid: 0000-0002-1048-5019
-  wikidata: Q88110949
-- affiliation:
-    name: Unversity of Colorado Anschutz Medical Campus, Auroa, CO
-    ror: 03wmf1y16
-  country: USA
-  github: mellybelly
-  groups:
-  - outreach
-  link: https://www.ohsu.edu/people/melissa-haendel/AFE044BDE8046E5D6FBDA51F448BDE2A
-  name: Melissa Haendel
-  orcid: 0000-0001-9114-8737
-  wikidata: Q28368079
-- affiliation:
     name: Semanticly, Athens
     wikidata: Q115518213
   country: Greece
@@ -261,17 +199,6 @@ members:
   orcid: 0000-0002-3336-2476
   wikidata: Q108555457
 - affiliation:
-    name: University of Oxford e-Research Centre, Department of Engineering Science, Oxford
-    ror: 052gg0110
-  country: UK
-  github: proccaserra
-  groups:
-  - outreach
-  link: https://eng.ox.ac.uk/people/philippe-rocca-serra/
-  name: Philippe Rocca-Serra
-  orcid: 0000-0001-9853-5668
-  wikidata: Q28364404
-- affiliation:
     name: Alfred Wegener Institute, Helmholtz Centre for Polar and Marine Research, Bremerhaven
     ror: 032e6b942
   country: Germany
@@ -285,53 +212,12 @@ members:
     name: La Jolla Institute for Immunology, La Jolla, CA
     ror: 05vkpd318
   country: USA
-  github: rvita
-  groups:
-  - outreach
-  name: Randi Vita
-  orcid: 0000-0001-8957-7612
-  wikidata: Q58116889
-- affiliation:
-    name: Intelligent Medical Objects (IMO), Rosemont, IL
-    ror: 03y46nb69
-  country: USA
-  github: beckyjackson
-  groups:
-  - technical
-  name: Rebecca Jackson
-  orcid: 0000-0003-4871-5569
-  wikidata: Q59539088
-- affiliation:
-    name: J. Craig Venter Institute, La Jolla, CA
-    ror: 049r1ts75
-  country: USA
-  github: scheuerm
-  groups:
-  - outreach
-  link: https://www.jcvi.org/about/rscheuermann
-  name: Richard Scheuermann
-  orcid: 0000-0003-1355-892X
-  wikidata: Q30508615
-- affiliation:
-    name: La Jolla Institute for Immunology, La Jolla, CA
-    ror: 05vkpd318
-  country: USA
   github: sebastianduesing
   groups:
   - technical
   name: Sebastian Duesing
   orcid: 0009-0009-4008-3801
   wikidata: Q6463245
-- affiliation:
-    name: Lawrence Berkeley National Laboratory, Berkeley, CA
-    ror: 02jbv0t02
-  country: USA
-  github: kltm
-  groups:
-  - technical
-  name: Seth Carbon
-  orcid: 0000-0001-8244-1536
-  wikidata: Q57081961
 - affiliation:
     name: European Bioinformatics Institute, Cambridge
     ror: 02catss52


### PR DESCRIPTION
(Moved to alumni.yml in separate PR)

I did this by hand; hope I didn't mess anything up!