### PR TITLE
Mark CARO as obsolete

### DIFF
--- a/ontology/caro.md
+++ b/ontology/caro.md
@@ -22,7 +22,10 @@ products:
 - id: caro.owl
 repository: https://github.com/obophenotype/caro
 tracker: https://github.com/obophenotype/caro/issues
-activity_status: active
+activity_status: obsolete
 ---
 
-The Common Anatomy Reference Ontology (CARO) is being developed to facilitate interoperability between existing anatomy ontologies for different species, and will provide a template for building new anatomy ontologies. CARO will be described in Anatomy Ontologies for Bioinformatics: Principles and Practice Albert Burger, Duncan Davidson and Richard Baldock (Editors)
+The Common Anatomy Reference Ontology (CARO) is being developed to facilitate interoperability between existing anatomy ontologies for different species, and will provide a template for building new anatomy ontologies. CARO will be described in Anatomy Ontologies for Bioinformatics: Principles and Practice Albert Burger, Duncan Davidson and Richard Baldock (Editors).
+
+**Important note**: CARO has been _obsoleted_ in favour of Uberon.
+However, not all CARO terms have been migrated to Uberon; please request any terms you were using from CARO and are missing from Uberon on the Uberon issue tracker: https://github.com/obophenotype/uberon/issues.


### PR DESCRIPTION
This PR officially marks CARO as obsolete in favour of Uberon. Before merging, please make sure the following people have given their approval:

- [ ] @mellybelly (the CARO contact)
- [ ] @dosumis (one of the key CARO developers)
- [ ] @cmungall

Let me know if any other people need to be specifically asked for a review.