### PR TITLE
Fix depicted_by URL in ontology/vbo.md

### DIFF
--- a/ontology/vbo.md
+++ b/ontology/vbo.md
@@ -9,7 +9,7 @@ contact:
   orcid: 0000-0002-4142-7153
 dependencies:
 - id: ncbitaxon
-depicted_by: https://github.com/tis-lab/closed-illustrations/blob/15058315cba1018e09572b28ebeee262a458b1c6/logos/vbo-logo/VBO-black-logo-stackedv2.png
+depicted_by: https://raw.githubusercontent.com/tis-lab/closed-illustrations/master/logos/vbo-logo/VBO-black-logo-stackedv2.png
 description: Vertebrate Breed Ontology is an ontology created to serve as a single computable resource for vertebrate breed names.
 domain: organisms
 homepage: https://github.com/monarch-initiative/vertebrate-breed-ontology


### PR DESCRIPTION
Updated the URL for the depicted_by field to use the raw content link.