### PR TITLE
Add usage entry for COB

### DIFF
--- a/ontology/cob.md
+++ b/ontology/cob.md
@@ -34,13 +34,13 @@ products:
 repository: https://github.com/OBOFoundry/COB
 tracker: https://github.com/OBOFoundry/COB/issues
 usages:
-- user: (multiple)
-  description: Ontologies using COB terms
+- description: Ontologies using COB terms
   examples:
-   - url: http://dashboard.obofoundry.org/dashboard/cob/dashboard.html
-     description: List of ontologies using at least one COB term (See section entitled "Info: Which ontologies use it?")
-   - url: https://ontobee.org/ontology/COB?iri=http://purl.obolibrary.org/obo/COB_0000022
-     description: List of ontologies using the term 'organism' (See section entitled "Ontologies that use the Class")
+  - description: List of ontologies using at least one COB term (See section entitled "Which ontologies use it?")
+    url: http://dashboard.obofoundry.org/dashboard/cob/dashboard.html
+  - description: List of ontologies using the term 'organism' (See section entitled "Ontologies that use the Class")
+    url: https://ontobee.org/ontology/COB?iri=http://purl.obolibrary.org/obo/COB_0000022
+  user: (multiple)
 activity_status: active
 ---
 


### PR DESCRIPTION
COB has been failing the Dashboard's "Users" check because of missing metadata. I adapted the example from <https://obofoundry.org/principles/fp-009-users.html#examples> to provide one usage entry.