### PR TITLE
Remove several fields used less than five times

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,10 @@ jobs:
         with:
           persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN, instead of your personal token
           fetch-depth: 0 # otherwise, you will failed to push refs to dest repo
+
+      - name: "Install uv"
+        uses: "astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57" # v8.0.0
+
       - name: Create local changes
         run: |
           python -m pip install -r requirements.txt

--- a/.github/workflows/obo-test.yml
+++ b/.github/workflows/obo-test.yml
@@ -14,6 +14,10 @@ jobs:
     if: github.triggering_actor != 'github-actions[bot]'
     steps:
       - uses: actions/checkout@v2
+
+      - name: "Install uv"
+        uses: "astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57" # v8.0.0
+
       - uses: actions/setup-python@v2
         with:
           python-version: '3.9'

--- a/_config.yml
+++ b/_config.yml
@@ -763,7 +763,6 @@ ontologies:
   title: Confidence Information Ontology
   tracker: https://github.com/BgeeDB/confidence-information-ontology
 - activity_status: active
-  canonical: cl.owl
   contact:
     email: do12@sanger.ac.uk
     github: dosumis
@@ -783,7 +782,6 @@ ontologies:
   domain: anatomy and development
   homepage: https://obophenotype.github.io/cell-ontology/
   id: cl
-  label: Cell Ontology
   layout: ontology_detail
   license:
     label: CC BY 4.0
@@ -1945,7 +1943,6 @@ ontologies:
   domain: health
   homepage: https://github.com/SCAI-BIO/EpilepsyOntology
   id: epio
-  label: Epilepsy Ontology
   layout: ontology_detail
   license:
     label: CC BY 4.0
@@ -2785,8 +2782,6 @@ ontologies:
   homepage: http://geneontology.org/
   id: go
   in_foundry_order: 1
-  integration_server: http://build.berkeleybop.org/view/GO
-  label: GO
   layout: ontology_detail
   license:
     label: CC BY 4.0
@@ -3310,7 +3305,6 @@ ontologies:
   publications:
   - id: https://doi.org/10.5281/zenodo.6522019
     title: 'LABO: An Ontology for Laboratory Test Prescription and Reporting'
-  releases: https://github.com/OpenLHS/LABO/releases/
   repository: https://github.com/OpenLHS/LABO
   tags:
   - clinical documentation
@@ -3667,7 +3661,6 @@ ontologies:
   - id: https://doi.org/10.1089/omi.2006.10.231
     title: 'Taking the First Steps towards a Standard for Reporting on Phylogenies:
       Minimum Information about a Phylogenetic Analysis (MIAPA)'
-  releases: https://github.com/evoinfo/miapa/releases
   repository: https://github.com/evoinfo/miapa
   title: MIAPA Ontology
   tracker: https://github.com/evoinfo/miapa/issues
@@ -3777,7 +3770,6 @@ ontologies:
   - label: Monarch
     title: Monarch Initiative Disease Browser
     url: https://monarchinitiative.org/disease/MONDO:0019609
-  canonical: mondo.owl
   contact:
     email: Sabrina@tislab.org
     github: sabrinatoro
@@ -3789,7 +3781,6 @@ ontologies:
   domain: health
   homepage: https://monarch-initiative.github.io/mondo
   id: mondo
-  label: Mondo
   layout: ontology_detail
   license:
     label: CC BY 4.0
@@ -4099,8 +4090,6 @@ ontologies:
   domain: investigations
   homepage: http://www.psidev.info/groups/controlled-vocabularies
   id: ms
-  integration_server: https://raw.githubusercontent.com/HUPO-PSI/psi-ms-CV/master
-  label: MS
   layout: ontology_detail
   license:
     label: CC BY 3.0
@@ -4211,7 +4200,6 @@ ontologies:
         pertussis as the source organism.
       url: http://www.iedb.org/assay/1505273
     user: https://www.iedb.org
-  wasDerivedFrom: ftp://ftp.ebi.ac.uk/pub/databases/taxonomy/taxonomy.dat
 - activity_status: active
   contact:
     email: noreply@example.com
@@ -4299,7 +4287,6 @@ ontologies:
   title: Next Generation Biobanking Ontology
   tracker: https://github.com/Dalalghamdi/NGBO/issues
 - activity_status: active
-  canonical: nomen.owl
   contact:
     email: diapriid@gmail.com
     github: mjy
@@ -4313,7 +4300,6 @@ ontologies:
     title: NSF ABI-1356381
   homepage: https://github.com/SpeciesFileGroup/nomen
   id: nomen
-  label: NOMEN
   layout: ontology_detail
   license:
     label: CC0 1.0
@@ -4515,7 +4501,6 @@ ontologies:
   homepage: http://obi-ontology.org
   id: obi
   in_foundry_order: 1
-  integration_server: http://build.berkeleybop.org/job/build-obi/
   layout: ontology_detail
   license:
     label: CC BY 4.0
@@ -4965,7 +4950,6 @@ ontologies:
   domain: diet, metabolomics, and nutrition
   homepage: https://github.com/cyang0128/Nutritional-epidemiologic-ontologies
   id: one
-  label: Ontology for Nutritional Epidemiology
   layout: ontology_detail
   license:
     label: CC BY 4.0
@@ -5004,7 +4988,6 @@ ontologies:
   domain: diet, metabolomics, and nutrition
   homepage: https://github.com/enpadasi/Ontology-for-Nutritional-Studies
   id: ons
-  label: Ontology for Nutritional Studies
   layout: ontology_detail
   license:
     label: CC BY 4.0
@@ -5792,7 +5775,6 @@ ontologies:
     orcid: 0000-0001-5809-9523
   depicted_by: https://raw.githubusercontent.com/PROconsortium/logo/master/PROlogo_small.png
   description: An ontological representation of protein-related entities
-  documentation: https://proconsortium.org/download/current/pro_readme.txt
   domain: chemistry and biochemistry
   homepage: http://proconsortium.org
   id: pr
@@ -6030,14 +6012,12 @@ ontologies:
   title: Radiation Biology Ontology
   tracker: https://github.com/Radiobiology-Informatics-Consortium/RBO/issues
 - activity_status: active
-  canonical: ro.owl
   contact:
     email: cjmungall@lbl.gov
     github: cmungall
     label: Chris Mungall
     orcid: 0000-0002-6601-2165
   description: Relationship types shared across multiple ontologies
-  documentation: https://oborel.github.io/obo-relations/
   domain: upper
   homepage: https://oborel.github.io/
   id: ro
@@ -6724,7 +6704,6 @@ ontologies:
   - label: KnowledgeSpace
     title: INCF KnowledgeSpace Portal
     url: https://knowledge-space.org/index.php/pages/view/UBERON:0000061
-  canonical: uberon.owl
   contact:
     email: cjmungall@lbl.gov
     github: cmungall
@@ -6758,7 +6737,6 @@ ontologies:
     title: NSF DEB-0956049
   homepage: http://uberon.org
   id: uberon
-  label: Uberon
   layout: ontology_detail
   license:
     label: CC BY 3.0
@@ -6823,9 +6801,7 @@ ontologies:
   - id: https://www.ncbi.nlm.nih.gov/pubmed/25009735
     title: Unification of multi-species vertebrate anatomy ontologies for comparative
       biology in Uberon
-  releases: http://purl.obolibrary.org/obo/uberon/releases/
   repository: https://github.com/obophenotype/uberon
-  slack: https://obo-communitygroup.slack.com/archives/C01CR698CF2
   taxon:
     id: NCBITaxon:33208
     label: Metazoa
@@ -6897,7 +6873,6 @@ ontologies:
       title: 'ChEMBL: towards direct deposition of bioassay data'
     type: Database
     user: https://www.ebi.ac.uk/chembl/
-  wikidata_template: https://en.wikipedia.org/wiki/Template:Uberon
 - activity_status: active
   contact:
     email: g.gkoutos@gmail.com
@@ -7432,7 +7407,6 @@ ontologies:
   domain: chemistry and biochemistry
   homepage: http://www.psidev.info/groups/controlled-vocabularies
   id: xlmod
-  label: xlmod
   layout: ontology_detail
   license:
     label: CC BY 3.0
@@ -7877,7 +7851,6 @@ ontologies:
   publications:
   - id: https://www.ncbi.nlm.nih.gov/pubmed/22027554
     title: Controlled vocabularies and semantics in systems biology
-  releases: https://github.com/SED-ML/KiSAO/releases
   repository: https://github.com/SED-ML/KiSAO
   tags:
   - systems biology
@@ -8859,7 +8832,6 @@ ontologies:
     label: Marc Ciriello
   description: An ontology of research resources such as instruments. protocols, reagents,
     animal models and biospecimens.
-  documentation: https://open.med.harvard.edu/wiki/display/eaglei/Ontology
   domain: information
   homepage: https://open.med.harvard.edu/wiki/display/eaglei/Ontology
   id: ero

--- a/ontology/cl.md
+++ b/ontology/cl.md
@@ -2,7 +2,6 @@
 layout: ontology_detail
 id: cl
 title: Cell Ontology
-canonical: cl.owl
 contact:
   email: do12@sanger.ac.uk
   github: dosumis
@@ -20,7 +19,6 @@ depicted_by: /images/CL-logo.jpg
 description: The Cell Ontology is a structured controlled vocabulary for cell types in animals.
 domain: anatomy and development
 homepage: https://obophenotype.github.io/cell-ontology/
-label: Cell Ontology
 license:
   label: CC BY 4.0
   url: http://creativecommons.org/licenses/by/4.0/

--- a/ontology/epio.md
+++ b/ontology/epio.md
@@ -12,7 +12,6 @@ dependencies:
 description: A application driven Epilepsy Ontology with official terms from the ILAE.
 domain: health
 homepage: https://github.com/SCAI-BIO/EpilepsyOntology
-label: Epilepsy Ontology
 license:
   label: CC BY 4.0
   url: http://creativecommons.org/licenses/by/4.0/

--- a/ontology/ero.md
+++ b/ontology/ero.md
@@ -6,7 +6,6 @@ contact:
   email: Marc_Ciriello@hms.harvard.edu
   label: Marc Ciriello
 description: An ontology of research resources such as instruments. protocols, reagents, animal models and biospecimens.
-documentation: https://open.med.harvard.edu/wiki/display/eaglei/Ontology
 domain: information
 homepage: https://open.med.harvard.edu/wiki/display/eaglei/Ontology
 is_obsolete: true

--- a/ontology/go.md
+++ b/ontology/go.md
@@ -35,8 +35,6 @@ description: An ontology for describing the function of genes and gene products
 domain: biological systems
 homepage: http://geneontology.org/
 in_foundry_order: 1
-integration_server: http://build.berkeleybop.org/view/GO
-label: GO
 license:
   label: CC BY 4.0
   url: https://creativecommons.org/licenses/by/4.0/

--- a/ontology/kisao.md
+++ b/ontology/kisao.md
@@ -34,7 +34,6 @@ products:
 publications:
 - id: https://www.ncbi.nlm.nih.gov/pubmed/22027554
   title: Controlled vocabularies and semantics in systems biology
-releases: https://github.com/SED-ML/KiSAO/releases
 repository: https://github.com/SED-ML/KiSAO
 tags:
 - systems biology

--- a/ontology/labo.md
+++ b/ontology/labo.md
@@ -26,7 +26,6 @@ products:
 publications:
 - id: https://doi.org/10.5281/zenodo.6522019
   title: 'LABO: An Ontology for Laboratory Test Prescription and Reporting'
-releases: https://github.com/OpenLHS/LABO/releases/
 repository: https://github.com/OpenLHS/LABO
 tags:
 - clinical documentation

--- a/ontology/miapa.md
+++ b/ontology/miapa.md
@@ -20,7 +20,6 @@ products:
 publications:
 - id: https://doi.org/10.1089/omi.2006.10.231
   title: 'Taking the First Steps towards a Standard for Reporting on Phylogenies: Minimum Information about a Phylogenetic Analysis (MIAPA)'
-releases: https://github.com/evoinfo/miapa/releases
 repository: https://github.com/evoinfo/miapa
 tracker: https://github.com/evoinfo/miapa/issues
 activity_status: active

--- a/ontology/mondo.md
+++ b/ontology/mondo.md
@@ -6,7 +6,6 @@ browsers:
 - title: Monarch Initiative Disease Browser
   label: Monarch
   url: https://monarchinitiative.org/disease/MONDO:0019609
-canonical: mondo.owl
 contact:
   email: Sabrina@tislab.org
   github: sabrinatoro
@@ -16,7 +15,6 @@ depicted_by: https://raw.githubusercontent.com/monarch-initiative/mondo/master/d
 description: A global community effort to harmonize multiple disease resources to yield a coherent merged ontology.
 domain: health
 homepage: https://monarch-initiative.github.io/mondo
-label: Mondo
 license:
   label: CC BY 4.0
   url: http://creativecommons.org/licenses/by/4.0/

--- a/ontology/ms.md
+++ b/ontology/ms.md
@@ -13,8 +13,6 @@ dependencies:
 description: A structured controlled vocabulary for the annotation of experiments concerned with proteomics mass spectrometry.
 domain: investigations
 homepage: http://www.psidev.info/groups/controlled-vocabularies
-integration_server: https://raw.githubusercontent.com/HUPO-PSI/psi-ms-CV/master
-label: MS
 license:
   label: CC BY 3.0
   url: https://creativecommons.org/licenses/by/3.0/

--- a/ontology/ncbitaxon.md
+++ b/ontology/ncbitaxon.md
@@ -42,7 +42,6 @@ usages:
   - description: A specific assay curated in the IEDB using the NCBITaxon:520 Bordetella pertussis as the source organism.
     url: http://www.iedb.org/assay/1505273
   user: https://www.iedb.org
-wasDerivedFrom: ftp://ftp.ebi.ac.uk/pub/databases/taxonomy/taxonomy.dat
 activity_status: active
 ---
 

--- a/ontology/nomen.md
+++ b/ontology/nomen.md
@@ -2,7 +2,6 @@
 layout: ontology_detail
 id: nomen
 title: NOMEN - A nomenclatural ontology for biological names
-canonical: nomen.owl
 contact:
   email: diapriid@gmail.com
   github: mjy
@@ -14,7 +13,6 @@ funded_by:
 - id: https://www.nsf.gov/awardsearch/showAward?AWD_ID=1356381
   title: NSF ABI-1356381
 homepage: https://github.com/SpeciesFileGroup/nomen
-label: NOMEN
 license:
   label: CC0 1.0
   url: https://creativecommons.org/publicdomain/zero/1.0/

--- a/ontology/obi.md
+++ b/ontology/obi.md
@@ -16,7 +16,6 @@ description: An integrated ontology for the description of life-science and clin
 domain: investigations
 homepage: http://obi-ontology.org
 in_foundry_order: 1
-integration_server: http://build.berkeleybop.org/job/build-obi/
 license:
   label: CC BY 4.0
   url: https://creativecommons.org/licenses/by/4.0/

--- a/ontology/one.md
+++ b/ontology/one.md
@@ -14,7 +14,6 @@ dependencies:
 description: An ontology to standardize research output of nutritional epidemiologic studies.
 domain: diet, metabolomics, and nutrition
 homepage: https://github.com/cyang0128/Nutritional-epidemiologic-ontologies
-label: Ontology for Nutritional Epidemiology
 license:
   label: CC BY 4.0
   url: https://creativecommons.org/licenses/by/4.0/

--- a/ontology/ons.md
+++ b/ontology/ons.md
@@ -19,7 +19,6 @@ dependencies:
 description: An ontology for description of concepts in the nutritional studies domain.
 domain: diet, metabolomics, and nutrition
 homepage: https://github.com/enpadasi/Ontology-for-Nutritional-Studies
-label: Ontology for Nutritional Studies
 license:
   label: CC BY 4.0
   url: https://creativecommons.org/licenses/by/4.0/

--- a/ontology/pr.md
+++ b/ontology/pr.md
@@ -16,7 +16,6 @@ contact:
   orcid: 0000-0001-5809-9523
 depicted_by: https://raw.githubusercontent.com/PROconsortium/logo/master/PROlogo_small.png
 description: An ontological representation of protein-related entities
-documentation: https://proconsortium.org/download/current/pro_readme.txt
 domain: chemistry and biochemistry
 homepage: http://proconsortium.org
 in_foundry_order: 1

--- a/ontology/ro.md
+++ b/ontology/ro.md
@@ -2,14 +2,12 @@
 layout: ontology_detail
 id: ro
 title: Relation Ontology
-canonical: ro.owl
 contact:
   email: cjmungall@lbl.gov
   github: cmungall
   label: Chris Mungall
   orcid: 0000-0002-6601-2165
 description: Relationship types shared across multiple ontologies
-documentation: https://oborel.github.io/obo-relations/
 domain: upper
 homepage: https://oborel.github.io/
 license:

--- a/ontology/uberon.md
+++ b/ontology/uberon.md
@@ -18,7 +18,6 @@ browsers:
 - title: INCF KnowledgeSpace Portal
   label: KnowledgeSpace
   url: https://knowledge-space.org/index.php/pages/view/UBERON:0000061
-canonical: uberon.owl
 contact:
   email: cjmungall@lbl.gov
   github: cmungall
@@ -50,7 +49,6 @@ funded_by:
 - id: https://www.nsf.gov/awardsearch/showAward?AWD_ID=0956049
   title: NSF DEB-0956049
 homepage: http://uberon.org
-label: Uberon
 license:
   label: CC BY 3.0
   url: http://creativecommons.org/licenses/by/3.0/
@@ -103,7 +101,6 @@ publications:
   title: Uberon, an integrative multi-species anatomy ontology
 - id: https://www.ncbi.nlm.nih.gov/pubmed/25009735
   title: Unification of multi-species vertebrate anatomy ontologies for comparative biology in Uberon
-releases: http://purl.obolibrary.org/obo/uberon/releases/
 repository: https://github.com/obophenotype/uberon
 slack: https://obo-communitygroup.slack.com/archives/C01CR698CF2
 taxon:
@@ -161,7 +158,6 @@ usages:
     title: 'ChEMBL: towards direct deposition of bioassay data'
   type: Database
   user: https://www.ebi.ac.uk/chembl/
-wikidata_template: https://en.wikipedia.org/wiki/Template:Uberon
 activity_status: active
 ---
 

--- a/ontology/uberon.md
+++ b/ontology/uberon.md
@@ -102,7 +102,6 @@ publications:
 - id: https://www.ncbi.nlm.nih.gov/pubmed/25009735
   title: Unification of multi-species vertebrate anatomy ontologies for comparative biology in Uberon
 repository: https://github.com/obophenotype/uberon
-slack: https://obo-communitygroup.slack.com/archives/C01CR698CF2
 taxon:
   id: NCBITaxon:33208
   label: Metazoa

--- a/ontology/xlmod.md
+++ b/ontology/xlmod.md
@@ -10,7 +10,6 @@ contact:
 description: A structured controlled vocabulary for cross-linking reagents used with proteomics mass spectrometry.
 domain: chemistry and biochemistry
 homepage: http://www.psidev.info/groups/controlled-vocabularies
-label: xlmod
 license:
   label: CC BY 3.0
   url: https://creativecommons.org/licenses/by/3.0/

--- a/registry/ontologies.jsonld
+++ b/registry/ontologies.jsonld
@@ -1047,7 +1047,6 @@
         },
         {
             "activity_status": "active",
-            "canonical": "cl.owl",
             "contact": {
                 "email": "do12@sanger.ac.uk",
                 "github": "dosumis",
@@ -1082,7 +1081,6 @@
             "domain": "anatomy and development",
             "homepage": "https://obophenotype.github.io/cell-ontology/",
             "id": "cl",
-            "label": "Cell Ontology",
             "layout": "ontology_detail",
             "license": {
                 "label": "CC BY 4.0",
@@ -2728,7 +2726,6 @@
             "domain": "health",
             "homepage": "https://github.com/SCAI-BIO/EpilepsyOntology",
             "id": "epio",
-            "label": "Epilepsy Ontology",
             "layout": "ontology_detail",
             "license": {
                 "label": "CC BY 4.0",
@@ -3961,8 +3958,6 @@
             "homepage": "http://geneontology.org/",
             "id": "go",
             "in_foundry_order": 1,
-            "integration_server": "http://build.berkeleybop.org/view/GO",
-            "label": "GO",
             "layout": "ontology_detail",
             "license": {
                 "label": "CC BY 4.0",
@@ -4673,7 +4668,6 @@
                     "title": "LABO: An Ontology for Laboratory Test Prescription and Reporting"
                 }
             ],
-            "releases": "https://github.com/OpenLHS/LABO/releases/",
             "repository": "https://github.com/OpenLHS/LABO",
             "tags": [
                 "clinical documentation"
@@ -5201,7 +5195,6 @@
                     "title": "Taking the First Steps towards a Standard for Reporting on Phylogenies: Minimum Information about a Phylogenetic Analysis (MIAPA)"
                 }
             ],
-            "releases": "https://github.com/evoinfo/miapa/releases",
             "repository": "https://github.com/evoinfo/miapa",
             "title": "MIAPA Ontology",
             "tracker": "https://github.com/evoinfo/miapa/issues"
@@ -5352,7 +5345,6 @@
                     "url": "https://monarchinitiative.org/disease/MONDO:0019609"
                 }
             ],
-            "canonical": "mondo.owl",
             "contact": {
                 "email": "Sabrina@tislab.org",
                 "github": "sabrinatoro",
@@ -5364,7 +5356,6 @@
             "domain": "health",
             "homepage": "https://monarch-initiative.github.io/mondo",
             "id": "mondo",
-            "label": "Mondo",
             "layout": "ontology_detail",
             "license": {
                 "label": "CC BY 4.0",
@@ -5784,8 +5775,6 @@
             "domain": "investigations",
             "homepage": "http://www.psidev.info/groups/controlled-vocabularies",
             "id": "ms",
-            "integration_server": "https://raw.githubusercontent.com/HUPO-PSI/psi-ms-CV/master",
-            "label": "MS",
             "layout": "ontology_detail",
             "license": {
                 "label": "CC BY 3.0",
@@ -5939,8 +5928,7 @@
                     ],
                     "user": "https://www.iedb.org"
                 }
-            ],
-            "wasDerivedFrom": "ftp://ftp.ebi.ac.uk/pub/databases/taxonomy/taxonomy.dat"
+            ]
         },
         {
             "activity_status": "active",
@@ -6045,7 +6033,6 @@
         },
         {
             "activity_status": "active",
-            "canonical": "nomen.owl",
             "contact": {
                 "email": "diapriid@gmail.com",
                 "github": "mjy",
@@ -6062,7 +6049,6 @@
             ],
             "homepage": "https://github.com/SpeciesFileGroup/nomen",
             "id": "nomen",
-            "label": "NOMEN",
             "layout": "ontology_detail",
             "license": {
                 "label": "CC0 1.0",
@@ -6342,7 +6328,6 @@
             "homepage": "http://obi-ontology.org",
             "id": "obi",
             "in_foundry_order": 1,
-            "integration_server": "http://build.berkeleybop.org/job/build-obi/",
             "layout": "ontology_detail",
             "license": {
                 "label": "CC BY 4.0",
@@ -6926,7 +6911,6 @@
             "domain": "diet, metabolomics, and nutrition",
             "homepage": "https://github.com/cyang0128/Nutritional-epidemiologic-ontologies",
             "id": "one",
-            "label": "Ontology for Nutritional Epidemiology",
             "layout": "ontology_detail",
             "license": {
                 "label": "CC BY 4.0",
@@ -6989,7 +6973,6 @@
             "domain": "diet, metabolomics, and nutrition",
             "homepage": "https://github.com/enpadasi/Ontology-for-Nutritional-Studies",
             "id": "ons",
-            "label": "Ontology for Nutritional Studies",
             "layout": "ontology_detail",
             "license": {
                 "label": "CC BY 4.0",
@@ -8125,7 +8108,6 @@
             },
             "depicted_by": "https://raw.githubusercontent.com/PROconsortium/logo/master/PROlogo_small.png",
             "description": "An ontological representation of protein-related entities",
-            "documentation": "https://proconsortium.org/download/current/pro_readme.txt",
             "domain": "chemistry and biochemistry",
             "homepage": "http://proconsortium.org",
             "id": "pr",
@@ -8486,7 +8468,6 @@
         },
         {
             "activity_status": "active",
-            "canonical": "ro.owl",
             "contact": {
                 "email": "cjmungall@lbl.gov",
                 "github": "cmungall",
@@ -8494,7 +8475,6 @@
                 "orcid": "0000-0002-6601-2165"
             },
             "description": "Relationship types shared across multiple ontologies",
-            "documentation": "https://oborel.github.io/obo-relations/",
             "domain": "upper",
             "homepage": "https://oborel.github.io/",
             "id": "ro",
@@ -9424,7 +9404,6 @@
                     "url": "https://knowledge-space.org/index.php/pages/view/UBERON:0000061"
                 }
             ],
-            "canonical": "uberon.owl",
             "contact": {
                 "email": "cjmungall@lbl.gov",
                 "github": "cmungall",
@@ -9492,7 +9471,6 @@
             ],
             "homepage": "http://uberon.org",
             "id": "uberon",
-            "label": "Uberon",
             "layout": "ontology_detail",
             "license": {
                 "label": "CC BY 3.0",
@@ -9574,9 +9552,7 @@
                     "title": "Unification of multi-species vertebrate anatomy ontologies for comparative biology in Uberon"
                 }
             ],
-            "releases": "http://purl.obolibrary.org/obo/uberon/releases/",
             "repository": "https://github.com/obophenotype/uberon",
-            "slack": "https://obo-communitygroup.slack.com/archives/C01CR698CF2",
             "taxon": {
                 "id": "NCBITaxon:33208",
                 "label": "Metazoa"
@@ -9672,8 +9648,7 @@
                     "type": "Database",
                     "user": "https://www.ebi.ac.uk/chembl/"
                 }
-            ],
-            "wikidata_template": "https://en.wikipedia.org/wiki/Template:Uberon"
+            ]
         },
         {
             "activity_status": "active",
@@ -10430,7 +10405,6 @@
             "domain": "chemistry and biochemistry",
             "homepage": "http://www.psidev.info/groups/controlled-vocabularies",
             "id": "xlmod",
-            "label": "xlmod",
             "layout": "ontology_detail",
             "license": {
                 "label": "CC BY 3.0",
@@ -11049,7 +11023,6 @@
                     "title": "Controlled vocabularies and semantics in systems biology"
                 }
             ],
-            "releases": "https://github.com/SED-ML/KiSAO/releases",
             "repository": "https://github.com/SED-ML/KiSAO",
             "tags": [
                 "systems biology",
@@ -12434,7 +12407,6 @@
                 "label": "Marc Ciriello"
             },
             "description": "An ontology of research resources such as instruments. protocols, reagents, animal models and biospecimens.",
-            "documentation": "https://open.med.harvard.edu/wiki/display/eaglei/Ontology",
             "domain": "information",
             "homepage": "https://open.med.harvard.edu/wiki/display/eaglei/Ontology",
             "id": "ero",

--- a/registry/ontologies.yml
+++ b/registry/ontologies.yml
@@ -746,7 +746,6 @@ ontologies:
   title: Confidence Information Ontology
   tracker: https://github.com/BgeeDB/confidence-information-ontology
 - activity_status: active
-  canonical: cl.owl
   contact:
     email: do12@sanger.ac.uk
     github: dosumis
@@ -766,7 +765,6 @@ ontologies:
   domain: anatomy and development
   homepage: https://obophenotype.github.io/cell-ontology/
   id: cl
-  label: Cell Ontology
   layout: ontology_detail
   license:
     label: CC BY 4.0
@@ -1928,7 +1926,6 @@ ontologies:
   domain: health
   homepage: https://github.com/SCAI-BIO/EpilepsyOntology
   id: epio
-  label: Epilepsy Ontology
   layout: ontology_detail
   license:
     label: CC BY 4.0
@@ -2768,8 +2765,6 @@ ontologies:
   homepage: http://geneontology.org/
   id: go
   in_foundry_order: 1
-  integration_server: http://build.berkeleybop.org/view/GO
-  label: GO
   layout: ontology_detail
   license:
     label: CC BY 4.0
@@ -3293,7 +3288,6 @@ ontologies:
   publications:
   - id: https://doi.org/10.5281/zenodo.6522019
     title: 'LABO: An Ontology for Laboratory Test Prescription and Reporting'
-  releases: https://github.com/OpenLHS/LABO/releases/
   repository: https://github.com/OpenLHS/LABO
   tags:
   - clinical documentation
@@ -3650,7 +3644,6 @@ ontologies:
   - id: https://doi.org/10.1089/omi.2006.10.231
     title: 'Taking the First Steps towards a Standard for Reporting on Phylogenies:
       Minimum Information about a Phylogenetic Analysis (MIAPA)'
-  releases: https://github.com/evoinfo/miapa/releases
   repository: https://github.com/evoinfo/miapa
   title: MIAPA Ontology
   tracker: https://github.com/evoinfo/miapa/issues
@@ -3760,7 +3753,6 @@ ontologies:
   - label: Monarch
     title: Monarch Initiative Disease Browser
     url: https://monarchinitiative.org/disease/MONDO:0019609
-  canonical: mondo.owl
   contact:
     email: Sabrina@tislab.org
     github: sabrinatoro
@@ -3772,7 +3764,6 @@ ontologies:
   domain: health
   homepage: https://monarch-initiative.github.io/mondo
   id: mondo
-  label: Mondo
   layout: ontology_detail
   license:
     label: CC BY 4.0
@@ -4082,8 +4073,6 @@ ontologies:
   domain: investigations
   homepage: http://www.psidev.info/groups/controlled-vocabularies
   id: ms
-  integration_server: https://raw.githubusercontent.com/HUPO-PSI/psi-ms-CV/master
-  label: MS
   layout: ontology_detail
   license:
     label: CC BY 3.0
@@ -4194,7 +4183,6 @@ ontologies:
         pertussis as the source organism.
       url: http://www.iedb.org/assay/1505273
     user: https://www.iedb.org
-  wasDerivedFrom: ftp://ftp.ebi.ac.uk/pub/databases/taxonomy/taxonomy.dat
 - activity_status: active
   contact:
     email: noreply@example.com
@@ -4282,7 +4270,6 @@ ontologies:
   title: Next Generation Biobanking Ontology
   tracker: https://github.com/Dalalghamdi/NGBO/issues
 - activity_status: active
-  canonical: nomen.owl
   contact:
     email: diapriid@gmail.com
     github: mjy
@@ -4296,7 +4283,6 @@ ontologies:
     title: NSF ABI-1356381
   homepage: https://github.com/SpeciesFileGroup/nomen
   id: nomen
-  label: NOMEN
   layout: ontology_detail
   license:
     label: CC0 1.0
@@ -4498,7 +4484,6 @@ ontologies:
   homepage: http://obi-ontology.org
   id: obi
   in_foundry_order: 1
-  integration_server: http://build.berkeleybop.org/job/build-obi/
   layout: ontology_detail
   license:
     label: CC BY 4.0
@@ -4948,7 +4933,6 @@ ontologies:
   domain: diet, metabolomics, and nutrition
   homepage: https://github.com/cyang0128/Nutritional-epidemiologic-ontologies
   id: one
-  label: Ontology for Nutritional Epidemiology
   layout: ontology_detail
   license:
     label: CC BY 4.0
@@ -4987,7 +4971,6 @@ ontologies:
   domain: diet, metabolomics, and nutrition
   homepage: https://github.com/enpadasi/Ontology-for-Nutritional-Studies
   id: ons
-  label: Ontology for Nutritional Studies
   layout: ontology_detail
   license:
     label: CC BY 4.0
@@ -5775,7 +5758,6 @@ ontologies:
     orcid: 0000-0001-5809-9523
   depicted_by: https://raw.githubusercontent.com/PROconsortium/logo/master/PROlogo_small.png
   description: An ontological representation of protein-related entities
-  documentation: https://proconsortium.org/download/current/pro_readme.txt
   domain: chemistry and biochemistry
   homepage: http://proconsortium.org
   id: pr
@@ -6013,14 +5995,12 @@ ontologies:
   title: Radiation Biology Ontology
   tracker: https://github.com/Radiobiology-Informatics-Consortium/RBO/issues
 - activity_status: active
-  canonical: ro.owl
   contact:
     email: cjmungall@lbl.gov
     github: cmungall
     label: Chris Mungall
     orcid: 0000-0002-6601-2165
   description: Relationship types shared across multiple ontologies
-  documentation: https://oborel.github.io/obo-relations/
   domain: upper
   homepage: https://oborel.github.io/
   id: ro
@@ -6707,7 +6687,6 @@ ontologies:
   - label: KnowledgeSpace
     title: INCF KnowledgeSpace Portal
     url: https://knowledge-space.org/index.php/pages/view/UBERON:0000061
-  canonical: uberon.owl
   contact:
     email: cjmungall@lbl.gov
     github: cmungall
@@ -6741,7 +6720,6 @@ ontologies:
     title: NSF DEB-0956049
   homepage: http://uberon.org
   id: uberon
-  label: Uberon
   layout: ontology_detail
   license:
     label: CC BY 3.0
@@ -6806,9 +6784,7 @@ ontologies:
   - id: https://www.ncbi.nlm.nih.gov/pubmed/25009735
     title: Unification of multi-species vertebrate anatomy ontologies for comparative
       biology in Uberon
-  releases: http://purl.obolibrary.org/obo/uberon/releases/
   repository: https://github.com/obophenotype/uberon
-  slack: https://obo-communitygroup.slack.com/archives/C01CR698CF2
   taxon:
     id: NCBITaxon:33208
     label: Metazoa
@@ -6880,7 +6856,6 @@ ontologies:
       title: 'ChEMBL: towards direct deposition of bioassay data'
     type: Database
     user: https://www.ebi.ac.uk/chembl/
-  wikidata_template: https://en.wikipedia.org/wiki/Template:Uberon
 - activity_status: active
   contact:
     email: g.gkoutos@gmail.com
@@ -7415,7 +7390,6 @@ ontologies:
   domain: chemistry and biochemistry
   homepage: http://www.psidev.info/groups/controlled-vocabularies
   id: xlmod
-  label: xlmod
   layout: ontology_detail
   license:
     label: CC BY 3.0
@@ -7860,7 +7834,6 @@ ontologies:
   publications:
   - id: https://www.ncbi.nlm.nih.gov/pubmed/22027554
     title: Controlled vocabularies and semantics in systems biology
-  releases: https://github.com/SED-ML/KiSAO/releases
   repository: https://github.com/SED-ML/KiSAO
   tags:
   - systems biology
@@ -8842,7 +8815,6 @@ ontologies:
     label: Marc Ciriello
   description: An ontology of research resources such as instruments. protocols, reagents,
     animal models and biospecimens.
-  documentation: https://open.med.harvard.edu/wiki/display/eaglei/Ontology
   domain: information
   homepage: https://open.med.harvard.edu/wiki/display/eaglei/Ontology
   id: ero

--- a/src/obofoundry/remove_field.py
+++ b/src/obofoundry/remove_field.py
@@ -18,8 +18,8 @@ def remove_field(name: str) -> None:
 
     schema_path = ROOT.joinpath("util", "schema", "registry_schema.json")
     schema = json.loads(schema_path.read_text())
-    if name in schema['properties']:
-        del schema['properties'][name]
+    if name in schema["properties"]:
+        del schema["properties"][name]
     schema_path.write_text(json.dumps(schema, indent=2) + "\n")
 
 

--- a/src/obofoundry/remove_field.py
+++ b/src/obofoundry/remove_field.py
@@ -1,12 +1,13 @@
 """A workflow for removing a field from all ontology markdown files' metadata."""
 
+import json
 from io import StringIO
 from pathlib import Path
 
 import click
 import yaml
 
-from obofoundry.constants import ONTOLOGY_DIRECTORY
+from obofoundry.constants import ONTOLOGY_DIRECTORY, ROOT
 from obofoundry.standardize_metadata import ModifiedDumper
 
 
@@ -14,6 +15,12 @@ def remove_field(name: str) -> None:
     """Remove the metadata key from all ontologies' metadata."""
     for path in ONTOLOGY_DIRECTORY.glob("*.md"):
         remove_field_from_file(path, name)
+
+    schema_path = ROOT.joinpath("util", "schema", "registry_schema.json")
+    schema = json.loads(schema_path.read_text())
+    if name in schema['properties']:
+        del schema['properties'][name]
+    schema_path.write_text(json.dumps(schema, indent=2) + "\n")
 
 
 def remove_field_from_file(path: Path, name: str) -> None:
@@ -41,10 +48,11 @@ def remove_field_from_file(path: Path, name: str) -> None:
 
 
 @click.command()
-@click.argument("name")
-def main(name: str) -> None:
+@click.argument("names", nargs=-1)
+def main(names: list[str]) -> None:
     """Remove the metadata key from all ontologies' metadata."""
-    remove_field(name)
+    for name in names:
+        remove_field(name)
 
 
 if __name__ == "__main__":

--- a/util/check_schema.py
+++ b/util/check_schema.py
@@ -21,14 +21,14 @@ SKIP_KEYS = {
 
 
 @click.command()
-@click.option("--max-cutoff", type=int, default=3, show_default=True)
+@click.option("--max-cutoff", type=int, default=20, show_default=True)
 @click.option("--links", is_flag=True)
 def main(max_cutoff: int, links: bool):
     """Check schema usage."""
     _check_schema(max_cutoff=max_cutoff, links=links)
 
 
-def _check_schema(max_cutoff: int = 3, links: bool = True):
+def _check_schema(max_cutoff: int, links: bool = True):
     ontologies = get_data()
 
     property_usage = Counter()
@@ -44,27 +44,31 @@ def _check_schema(max_cutoff: int = 3, links: bool = True):
             if key in data:
                 r[key].add(prefix)
 
-    print(f"Fields used at most {max_cutoff} times:")
-    print(
-        tabulate(
-            [
-                (
-                    k,
-                    ", ".join(
-                        (
-                            f"[{prefix}](https://obofoundry.org/ontologies/{prefix})"
-                            if links
-                            else prefix
-                        )
-                        for prefix in prefixes
-                    ),
-                )
-                for k, prefixes in r.items()
-            ],
-            tablefmt="github",
-            headers=["key", "ontologies"],
+    if r:
+        print(f"Fields used at most {max_cutoff} times:")
+        print(
+            tabulate(
+                [
+                    (
+                        k,
+                        len(prefixes),
+                        ", ".join(
+                            (
+                                f"[{prefix}](https://obofoundry.org/ontologies/{prefix})"
+                                if links
+                                else prefix
+                            )
+                            for prefix in prefixes
+                        ),
+                    )
+                    for k, prefixes in r.items()
+                ],
+                tablefmt="github",
+                headers=["key", "count", "ontologies"],
+            )
         )
-    )
+    else:
+        print(f"No fields used less than {max_cutoff} times!")
 
     with SCHEMA_PATH.open() as file:
         schema = json.load(file)
@@ -73,8 +77,11 @@ def _check_schema(max_cutoff: int = 3, links: bool = True):
         for prop in schema["properties"]
         if prop not in property_usage and prop not in SKIP_KEYS
     }
-    print("Unused properties:")
-    print(*sorted(unused), sep="\n")
+    if unused:
+        print("Unused properties:")
+        print(*sorted(unused), sep="\n")
+    else:
+        print("No unused properties!")
 
 
 if __name__ == "__main__":

--- a/util/extract-metadata.py
+++ b/util/extract-metadata.py
@@ -1,4 +1,14 @@
-#!/usr/bin/env python3
+#!/usr/bin/env -S uv run --script
+
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#     "python-frontmatter==0.5.0",
+#     "pyyaml",
+#     "ruamel-yaml==0.16.12",
+#     "yamllint==1.25.0",
+# ]
+# ///
 
 import argparse
 import sys

--- a/util/schema/registry_schema.json
+++ b/util/schema/registry_schema.json
@@ -46,9 +46,6 @@
         ]
       }
     },
-    "canonical": {
-      "suggest": false
-    },
     "contact": {
       "level": "error",
       "principle": "http://obofoundry.org/principles/fp-011-locus-of-authority.html",
@@ -89,9 +86,6 @@
       "suggest": false
     },
     "depicted_by": {
-      "suggest": false
-    },
-    "documentation": {
       "suggest": false
     },
     "domain": {
@@ -167,18 +161,12 @@
     "in_foundry_order": {
       "suggest": false
     },
-    "integration_server": {
-      "suggest": false
-    },
     "is_obsolete": {
       "suggest": false,
       "level": "info",
       "description": "'is_obsolete' is an informative field. It is set to true when the ontology is obsolete.",
       "type": "boolean",
       "default": false
-    },
-    "label": {
-      "suggest": false
     },
     "layout": {
       "level": "error",
@@ -381,9 +369,6 @@
       "type": "integer",
       "description": "This encodes the number of the pull request on the OBO Foundry GitHub repository that was originally used to add this ontology. You can curate additional ones by going to the ontology page (e.g., https://github.com/OBOFoundry/OBOFoundry.github.io/commits/master/ontology/clyh.md) and looking the whole way down the list for the first commit. Click on the title for the commit then you will see if there's a PR associated with it."
     },
-    "releases": {
-      "suggest": false
-    },
     "replaced_by": {
       "suggest": false
     },
@@ -498,12 +483,6 @@
           "description"
         ]
       }
-    },
-    "wasDerivedFrom": {
-      "suggest": false
-    },
-    "wikidata_template": {
-      "suggest": false
     }
   },
   "required": [

--- a/util/schema/registry_schema.json
+++ b/util/schema/registry_schema.json
@@ -378,9 +378,6 @@
       "type": "string",
       "format": "uri"
     },
-    "slack": {
-      "suggest": false
-    },
     "taxon": {
       "level": "info",
       "description": "'taxon' is an informative field. The value is the taxonomic identifier of the organism that is the subject of the ontology.",


### PR DESCRIPTION
As a follow-up to #2892, this PR removes the following fields, each of which was used less than five times:

- canonical (not needed because of convention)
- documentation (duplicated homepage)
- integration_server (irrelevant)
- label (duplicate of `title` field)
- releases (trivally computable from `repository` field)
- wasDerivedFrom (only in NCBITaxon)
- wikidata_template (only in UBERON)
- slack (only in UBERON)

This was done by running the script:

```console
$ python -m obofoundry.remove_field canonical documentation integration_server label releases wasDerivedFrom wikidata_template slack
```

If you want to see which fields are not frequently used, run:

```console
$ python utils/check_schema.py --max-cutoff 20
```

| key                |   count | ontologies                                                    |
|--------------------|---------|---------------------------------------------------------------|
| twitter            |      10 | go, hp, uberon, chebi, doid, ddpheno, po, cl, disdriv, ddanat |
| in_foundry         |      11 | obcs, bco, epo, zfs, omit, stato, bcgo, flu, fix, uo, lipro   |
| in_foundry_order   |      11 | pbpko, go, pr, obi, chebi, doid, pato, po, bfo, zfa, xao      |
| funded_by          |       4 | nomen, uberon, eco, kisao                                     |
| pull_request_added |       4 | clyh, t4fs, clao, ngbo                                        |
| issue_requested    |       3 | occo, t4fs, ngbo                                              |
