### PR TITLE
Update site with new Slack Signup form

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -137,7 +137,7 @@
                                 Mail List</a>
                         </li>
                         <li>
-                            <a class="dropdown-item" href="https://join.slack.com/t/obo-communitygroup/shared_invite/zt-3gs80gmrk-9yZT913GViLUg04pgE3wOA">OBO
+                            <a class="dropdown-item" href="https://docs.google.com/forms/d/e/1FAIpQLScJbdW0QcCS3432mHkTiir9D-HwT5g2iaXYiiy2aOOiCFS3RQ/viewform?usp=dialog">OBO
                                 Community Slack channel</a>
                         </li>
                          <li>

--- a/index.html
+++ b/index.html
@@ -30,7 +30,7 @@ title: The OBO Foundry
             <li><a href="docs/COC.html">Code of Conduct</a></li>
             <li>
                 Join the <a href="https://groups.google.com/forum/#!forum/obo-discuss">OBO mailing list</a>
-                and the <a href="https://join.slack.com/t/obo-communitygroup/shared_invite/zt-3gs80gmrk-9yZT913GViLUg04pgE3wOA">OBO Community Slack workspace</a>
+                and the <a href="https://docs.google.com/forms/d/e/1FAIpQLScJbdW0QcCS3432mHkTiir9D-HwT5g2iaXYiiy2aOOiCFS3RQ/viewform?usp=dialog">OBO Community Slack workspace</a>
             </li>
             <li>
                 <a href="docs/OperationsCommittee.html">


### PR DESCRIPTION
Updated the index.html and header.html with new slack signup form. This form was created after there were incidents of impersonators joining the OBO Community Slack (someone impersonated @matentzn). The form will allow us to review requests before sending a dedicated link for them to join the Slack. This workflow should help reduce unwanted impersonations/spammers.