### PR TITLE
More accurately capture mailing lists for 6 inactive ontologies

### DIFF
--- a/ontology/adw.md
+++ b/ontology/adw.md
@@ -2,9 +2,7 @@
 layout: ontology_detail
 id: adw
 title: Animal natural history and life history
-contact:
-  email: adw_geeks@umich.edu
-  label: Animal Diversity Web technical staff
+mailing_list: adw_geeks@umich.edu
 domain: organisms
 homepage: http://www.animaldiversity.org
 is_obsolete: true

--- a/ontology/adw.md
+++ b/ontology/adw.md
@@ -2,10 +2,10 @@
 layout: ontology_detail
 id: adw
 title: Animal natural history and life history
-mailing_list: adw_geeks@umich.edu
 domain: organisms
 homepage: http://www.animaldiversity.org
 is_obsolete: true
+mailing_list: adw_geeks@umich.edu
 activity_status: inactive
 ---
 

--- a/ontology/ev.md
+++ b/ontology/ev.md
@@ -2,9 +2,9 @@
 layout: ontology_detail
 id: ev
 title: eVOC (Expressed Sequence Annotation for Humans)
-mailing_list: evoc@sanbi.ac.za
 domain: anatomy and development
 is_obsolete: true
+mailing_list: evoc@sanbi.ac.za
 activity_status: inactive
 ---
 

--- a/ontology/ev.md
+++ b/ontology/ev.md
@@ -2,9 +2,7 @@
 layout: ontology_detail
 id: ev
 title: eVOC (Expressed Sequence Annotation for Humans)
-contact:
-  email: evoc@sanbi.ac.za
-  label: eVOC mailing list
+mailing_list: evoc@sanbi.ac.za
 domain: anatomy and development
 is_obsolete: true
 activity_status: inactive

--- a/ontology/gro.md
+++ b/ontology/gro.md
@@ -2,9 +2,7 @@
 layout: ontology_detail
 id: gro
 title: Cereal Plant Gross Anatomy
-contact:
-  email: po-discuss@plantontology.org
-  label: Plant Ontology Administrators
+mailing_list: po-discuss@plantontology.org
 domain: anatomy and development
 homepage: http://www.gramene.org/plant_ontology/
 is_obsolete: true

--- a/ontology/gro.md
+++ b/ontology/gro.md
@@ -2,10 +2,10 @@
 layout: ontology_detail
 id: gro
 title: Cereal Plant Gross Anatomy
-mailing_list: po-discuss@plantontology.org
 domain: anatomy and development
 homepage: http://www.gramene.org/plant_ontology/
 is_obsolete: true
+mailing_list: po-discuss@plantontology.org
 activity_status: inactive
 ---
 

--- a/ontology/imr.md
+++ b/ontology/imr.md
@@ -2,10 +2,10 @@
 layout: ontology_detail
 id: imr
 title: Molecule role (INOH Protein name/family name ontology)
-mailing_list: curator@inoh.org
 domain: chemistry and biochemistry
 homepage: http://www.inoh.org
 is_obsolete: true
+mailing_list: curator@inoh.org
 activity_status: inactive
 ---
 

--- a/ontology/imr.md
+++ b/ontology/imr.md
@@ -2,9 +2,7 @@
 layout: ontology_detail
 id: imr
 title: Molecule role (INOH Protein name/family name ontology)
-contact:
-  email: curator@inoh.org
-  label: INOH curators
+mailing_list: curator@inoh.org
 domain: chemistry and biochemistry
 homepage: http://www.inoh.org
 is_obsolete: true

--- a/ontology/ipr.md
+++ b/ontology/ipr.md
@@ -2,9 +2,7 @@
 layout: ontology_detail
 id: ipr
 title: Protein Domains
-contact:
-  email: interhelp@ebi.ac.uk
-  label: InterPro Help
+mailing_list: interhelp@ebi.ac.uk
 domain: chemistry and biochemistry
 homepage: http://www.ebi.ac.uk/interpro/index.html
 is_obsolete: true

--- a/ontology/ipr.md
+++ b/ontology/ipr.md
@@ -2,10 +2,10 @@
 layout: ontology_detail
 id: ipr
 title: Protein Domains
-mailing_list: interhelp@ebi.ac.uk
 domain: chemistry and biochemistry
 homepage: http://www.ebi.ac.uk/interpro/index.html
 is_obsolete: true
+mailing_list: interhelp@ebi.ac.uk
 activity_status: inactive
 ---
 

--- a/ontology/sep.md
+++ b/ontology/sep.md
@@ -2,11 +2,11 @@
 layout: ontology_detail
 id: sep
 title: Sample processing and separation techniques
-mailing_list: psidev-gps-dev@lists.sourceforge.net
 description: A structured controlled vocabulary for the annotation of sample processing and separation techniques in scientific experiments.
 domain: investigations
 homepage: http://psidev.info/index.php?q=node/312
 is_obsolete: true
+mailing_list: psidev-gps-dev@lists.sourceforge.net
 page: http://psidev.info/index.php?q=node/312
 products:
 - id: sep.owl

--- a/ontology/sep.md
+++ b/ontology/sep.md
@@ -2,9 +2,7 @@
 layout: ontology_detail
 id: sep
 title: Sample processing and separation techniques
-contact:
-  email: psidev-gps-dev@lists.sourceforge.net
-  label: SEP developers via the PSI and MSI mailing lists
+mailing_list: psidev-gps-dev@lists.sourceforge.net
 description: A structured controlled vocabulary for the annotation of sample processing and separation techniques in scientific experiments.
 domain: investigations
 homepage: http://psidev.info/index.php?q=node/312


### PR DESCRIPTION
In six inactive ontolgies, this PR switches annotating a mailing list as a stub contact to explicitly using the `mailing_list` slot