### PR TITLE
Update name of TWG chair in SOP.md from 'Ray' to 'James S'

### DIFF
--- a/docs/SOP.md
+++ b/docs/SOP.md
@@ -170,7 +170,7 @@ The current processes of nomination, acceptance and onboarding are described [he
      1. Get volunteers to sign up to lead upcoming meetings (if needed)
      2. Review [new ontology requests](https://github.com/OBOFoundry/OBOFoundry.github.io/labels/new%20ontology)
      3. Report from Editorial Working Group (EWG) (Darren)
-     4. Report from Technical Working Group (TWG) (Ray)
+     4. Report from Technical Working Group (TWG) (James S)
      5. Review additional [open issues](https://github.com/OBOFoundry/OBOFoundry.github.io/labels/attn%3A%20OFOC%20call) and [pull requests](https://github.com/OBOFoundry/OBOFoundry.github.io/pulls?q=is%3Apr+is%3Aopen+label%3A%22attn%3A+OFOC+call%22) that are labeled "attn: OFOC call"
 
 2. Check the issues labeled ["attn:OFOC call"](https://github.com/OBOFoundry/OBOFoundry.github.io/labels/attn%3A%20OFOC%20call) in the OBO Foundry GitHub repository. Pick one or two open issues you deem important and put them towards the end of the stub agenda, after the Working Group reports and before the review of additional open issues.


### PR DESCRIPTION
In the section for chairing an Ops meeting. An alternative would be to just remove the chair's name completely so that this never needs updating, but I think the benefit of keeping the name (and the VERY occasional need to change it) outweighs the benefit of not having to change at all. That is, some meeting chairs might not know the appropriate name.