### PR TITLE
flopo: add usages metadata

### DIFF
--- a/ontology/flopo.md
+++ b/ontology/flopo.md
@@ -24,11 +24,11 @@ taxon:
   id: NCBITaxon:33090
   label: Viridiplantae
 tracker: https://github.com/flora-phenotype-ontology/flopoontology/issues
-activity_status: active
 usages:
-- user: https://www.kaust.edu.sa
-  description: FLOPO integrates qualitative plant trait data extracted from digitized Floras across species and higher taxa of flowering plants.
+- description: FLOPO integrates qualitative plant trait data extracted from digitized Floras across species and higher taxa of flowering plants.
   examples:
-  - url: http://aber-owl.net/ontology/FLOPO
-    description: Browsing FLOPO and querying it with automated reasoning via the AberOWL ontology repository.
+  - description: Browsing FLOPO and querying it with automated reasoning via the AberOWL ontology repository.
+    url: http://aber-owl.net/ontology/FLOPO
+  user: https://www.kaust.edu.sa
+activity_status: active
 ---

--- a/ontology/flopo.md
+++ b/ontology/flopo.md
@@ -25,4 +25,10 @@ taxon:
   label: Viridiplantae
 tracker: https://github.com/flora-phenotype-ontology/flopoontology/issues
 activity_status: active
+usages:
+- user: https://www.kaust.edu.sa
+  description: FLOPO integrates qualitative plant trait data extracted from digitized Floras across species and higher taxa of flowering plants.
+  examples:
+  - url: http://aber-owl.net/ontology/FLOPO
+    description: Browsing FLOPO and querying it with automated reasoning via the AberOWL ontology repository.
 ---


### PR DESCRIPTION
Adds a `usages` block to the FLOPO registry entry (`ontology/flopo.md`), resolving the OBO dashboard **Plurality of Users: Missing usages** check.

FLOPO integrates qualitative plant trait data extracted from digitized Floras across species and higher taxa of flowering plants; the example links its AberOWL entry for browsing and automated reasoning. Submitted from the maintaining org (flora-phenotype-ontology), alongside ontology-side dashboard fixes in flora-phenotype-ontology/flopoontology#12.