### PR TITLE
cicd: bump core actions versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     container: obolibrary/odkfull:v1.2.30
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN, instead of your personal token
           fetch-depth: 0 # otherwise, you will failed to push refs to dest repo

--- a/.github/workflows/obo-test.yml
+++ b/.github/workflows/obo-test.yml
@@ -13,12 +13,12 @@ jobs:
     runs-on: ubuntu-latest
     if: github.triggering_actor != 'github-actions[bot]'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v7
 
       - name: "Install uv"
         uses: "astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57" # v8.0.0
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.9'
       - name: Install requirements

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -11,9 +11,9 @@ jobs:
       matrix:
         python-version: [ "3.8", "3.10" ]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v7
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies


### PR DESCRIPTION
(some of these are pinned to pretty old releases running on deprecated versions of node)