### PR TITLE
uo: update license to CC BY 4.0 and add usages

### DIFF
--- a/ontology/uo.md
+++ b/ontology/uo.md
@@ -11,8 +11,8 @@ description: Metrical units for use in conjunction with PATO
 domain: phenotype
 homepage: https://github.com/bio-ontology-research-group/unit-ontology
 license:
-  label: CC BY 3.0
-  url: http://creativecommons.org/licenses/by/3.0/
+  label: CC BY 4.0
+  url: https://creativecommons.org/licenses/by/4.0/
 preferredPrefix: UO
 products:
 - id: uo.owl
@@ -23,6 +23,24 @@ publications:
   title: 'The Units Ontology: a tool for integrating units of measurement in science'
 repository: https://github.com/bio-ontology-research-group/unit-ontology
 tracker: https://github.com/bio-ontology-research-group/unit-ontology/issues
+usages:
+- user: http://obi-ontology.org/
+  type: ontology
+  description: The Ontology for Biomedical Investigations (OBI) uses UO terms to specify
+    the units of measurement values recorded in investigations.
+- user: https://www.psidev.info/
+  type: ontology
+  description: The HUPO-PSI mass spectrometry controlled vocabulary (PSI-MS) uses UO
+    terms as the units of the quantitative terms it defines for the mzML and related
+    PSI data standards.
+  publications:
+  - id: https://www.ncbi.nlm.nih.gov/pubmed/23482073
+    title: 'The HUPO proteomics standards initiative- mass spectrometry controlled
+      vocabulary'
+- user: http://stato-ontology.org/
+  type: ontology
+  description: STATO, the statistical methods ontology, uses UO terms to type the units
+    of the statistical measures and parameters it defines.
 activity_status: active
 ---
 

--- a/ontology/uo.md
+++ b/ontology/uo.md
@@ -24,23 +24,18 @@ publications:
 repository: https://github.com/bio-ontology-research-group/unit-ontology
 tracker: https://github.com/bio-ontology-research-group/unit-ontology/issues
 usages:
-- user: http://obi-ontology.org/
+- description: The Ontology for Biomedical Investigations (OBI) uses UO terms to specify the units of measurement values recorded in investigations.
   type: ontology
-  description: The Ontology for Biomedical Investigations (OBI) uses UO terms to specify
-    the units of measurement values recorded in investigations.
-- user: https://www.psidev.info/
-  type: ontology
-  description: The HUPO-PSI mass spectrometry controlled vocabulary (PSI-MS) uses UO
-    terms as the units of the quantitative terms it defines for the mzML and related
-    PSI data standards.
+  user: http://obi-ontology.org/
+- description: The HUPO-PSI mass spectrometry controlled vocabulary (PSI-MS) uses UO terms as the units of the quantitative terms it defines for the mzML and related PSI data standards.
   publications:
   - id: https://www.ncbi.nlm.nih.gov/pubmed/23482073
-    title: 'The HUPO proteomics standards initiative- mass spectrometry controlled
-      vocabulary'
-- user: http://stato-ontology.org/
+    title: The HUPO proteomics standards initiative- mass spectrometry controlled vocabulary
   type: ontology
-  description: STATO, the statistical methods ontology, uses UO terms to type the units
-    of the statistical measures and parameters it defines.
+  user: https://www.psidev.info/
+- description: STATO, the statistical methods ontology, uses UO terms to type the units of the statistical measures and parameters it defines.
+  type: ontology
+  user: http://stato-ontology.org/
 activity_status: active
 ---
 


### PR DESCRIPTION
Two changes to the UO (Units of Measurement Ontology) registry entry. I maintain UO.

### License: CC BY 3.0 → CC BY 4.0

UO's licensing was inconsistent across its own repository: `LICENSE.md` was CC BY 4.0, `README.md` and the ODK config said CC BY 2.0, and this registry entry said CC BY 3.0. We have settled on **CC BY 4.0**, matching `LICENSE.md`, and made every in-repo statement agree.

The ontology header now declares `dcterms:license https://creativecommons.org/licenses/by/4.0/` (it previously declared no license at all, which is why the Open check was erroring). Since `fp_001` compares the ontology license against the registry license and errors on a mismatch, this entry has to move to 4.0 as well.

Companion PR on the ontology side: bio-ontology-research-group/unit-ontology#98

### Adding `usages` for FP09

Plurality of Users has been erroring with "Missing usages". The three users listed all demonstrably reference UO terms — verified by counting `UO:` references in each ontology's current release:

| User | UO references |
|---|---|
| HUPO-PSI mass spectrometry CV (`ms`) | 377 |
| Ontology for Biomedical Investigations (`obi`) | 12 |
| STATO (`stato`) | 6 |

All three also appear in the OBO Foundry's own "Which ontologies use it?" list on the UO dashboard.

### Validation

`util/validate-metadata.py` passes on the modified entry with zero errors and zero warnings, and produces a metadata grid byte-identical to the one from the unmodified entry.

Running the OBO Dashboard code locally against UO's next release with this registry entry takes FP01 Open and FP09 Plurality of Users from ERROR to PASS.