### PR TITLE
Update fp-007-relations.md 'Creating New Relations' section

### DIFF
--- a/principles/fp-007-relations.md
+++ b/principles/fp-007-relations.md
@@ -27,12 +27,11 @@ submitted to the [RO tracker](https://github.com/oborel/obo-relations/issues).
 'Reuse' means that the actual existing-relation PURL is used. Ontology developers should be aware that (in rare instances) relations can evolve over time and previous relations might become obsolete. This means developers should monitor the state of the relations they use. The Relations Ontology MUST be the first source for appropriate relations, and ontology developers SHOULD, with due diligence, search RO for needed relations. If a necessary relation cannot be found within RO, then the developers MUST search other OBO ontologies for reasonable candidates using, for example, an ontology search engine such as [Ontobee](https://ontobee.org/) or [OLS](https://www.ebi.ac.uk/ols4/).
 
 ### Creating New Relations
-The appropriate home for a new relation ('R') will depend on multiple factors, including the general applicability of 'R' beyond its use by developers of the 'R'-proposing ontology ('O'), and with consideration of the domain and range for 'R':
-- If both the domain and range of 'R' are classes in the same ontology 'O' as 'R', 'R' MAY be kept in 'O';
-- If either the domain or range of 'R' are classes not in 'O', and 'R' does not seem to be general enough for use by other ontologies, 'R' MAY be kept in 'O';
-- If 'R' seems generally usable (that is, could potentially be used by ontologies other than 'O'), the relation SHOULD be submitted to RO;
-- For any 'R' not submitted to RO, if a suitable RO parent ('P') exists, then 'R' MUST be declared a sub-property of 'P';
-- An effort to specify a domain and range for 'R' SHOULD be made, though caution is advised to ensure that each is neither too broad nor too specific.
+An effort to specify a domain and range for the relation SHOULD be made, though caution is advised to ensure that each is neither too broad nor too specific. The appropriate home for a new relation will depend on multiple factors, including the general applicability of the relation (beyond its immediate use within the context of a given ontology), and in consideration of its domain and range:
+- If both the domain and range are from the same ontology as the relation, the relation MAY be kept in that ontology;
+- If either the domain or range is from a different ontology as the relation, but the relation is not general enough for use by other ontologies, the relation MAY be kept in the originating ontology;
+- If the relation seems appropriate for general usage, the relation SHOULD be submitted to RO;
+- For any relation not submitted to RO, if a suitable RO parent exists, then the relation MUST be declared a sub-property of that parent.
 
 While it is never a bad idea to submit a new relation to RO, if there are any doubts about how to proceed based on the above, a discussion with RO developers SHOULD be made via the [RO issue tracker](https://github.com/oborel/obo-relations/issues) or the [OBO Community  Slack](https://obo-communitygroup.slack.com) using the #relation-ontology channel.
 


### PR DESCRIPTION
The original wording was a bit obtuse, using variables in place of words for the sake of precision. However, that precision came at the cost of ease of reading. This new version makes it easier to read/understand while retaining clarity. Also, while the bulleted list was mostly about where a new relation should live, the last bullet point was about domains and ranges. Considering that domain and range are criteria for where a relation should go, that point was made the first sentence of the section.

Original wording:

The appropriate home for a new relation (‘R’) will depend on multiple factors, including the general applicability of ‘R’ beyond its use by developers of the ‘R’-proposing ontology (‘O’), and with consideration of the domain and range for ‘R’:

-  If both the domain and range of ‘R’ are classes in the same ontology ‘O’ as ‘R’, ‘R’ MAY be kept in ‘O’;
-  If either the domain or range of ‘R’ are classes not in ‘O’, and ‘R’ does not seem to be general enough for use by other ontologies, ‘R’ MAY be kept in ‘O’;
-  If ‘R’ seems generally usable (that is, could potentially be used by ontologies other than ‘O’), the relation SHOULD be submitted to RO;
-  For any ‘R’ not submitted to RO, if a suitable RO parent (‘P’) exists, then ‘R’ MUST be declared a sub-property of ‘P’;
-  An effort to specify a domain and range for ‘R’ SHOULD be made, though caution is advised to ensure that each is neither too broad nor too specific.