### PR TITLE
Update GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
           git commit -m "🚀 Automatically rebuilt derived files" -a
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        uses: peter-evans/create-pull-request@18f7dc018cc2cd597073088f7c7591b9d1c02672 # v3.14.0
         with:
           commit-message: Update OBO foundry metadata
           title: 'Update OBO foundry metadata'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,25 +15,27 @@ jobs:
     runs-on: ubuntu-latest
     container: obolibrary/odkfull:v1.2.30
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN, instead of your personal token
           fetch-depth: 0 # otherwise, you will failed to push refs to dest repo
 
       - name: "Install uv"
-        uses: "astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57" # v8.0.0
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
 
       - name: Create local changes
         run: |
           python -m pip install -r requirements.txt
           make
+
       - name: Commit files
         run: |
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
           git commit -m "🚀 Automatically rebuilt derived files" -a
+
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           commit-message: Update OBO foundry metadata
           title: 'Update OBO foundry metadata'

--- a/.github/workflows/obo-test.yml
+++ b/.github/workflows/obo-test.yml
@@ -13,17 +13,19 @@ jobs:
     runs-on: ubuntu-latest
     if: github.triggering_actor != 'github-actions[bot]'
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: "Install uv"
-        uses: "astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57" # v8.0.0
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: '3.14'
+
       - name: Install requirements
         run: |
           python3 -m pip install -r requirements.txt
+
       - name: Run tests
         run: |
           make test

--- a/.github/workflows/obo-test.yml
+++ b/.github/workflows/obo-test.yml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: actions/setup-python@v6
         with:
-          python-version: '3.9'
+          python-version: '3.14'
       - name: Install requirements
         run: |
           python3 -m pip install -r requirements.txt

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
-          python-version: 3.14
+          python-version: '3.14'
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -7,18 +7,18 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     if: github.triggering_actor != 'github-actions[bot]'
-    strategy:
-      matrix:
-        python-version: [ "3.8", "3.10" ]
     steps:
-      - uses: actions/checkout@v7
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: 3.14
+
       - name: Install dependencies
         run: |
           pip install --upgrade pip setuptools wheel
           pip install "tox<4.0.0"
+
       - name: Check code quality with flake8
         run: tox -e flake8

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pyyaml==5.4
+pyyaml==6.0.3
 jsonschema==3.0.2
 SPARQLWrapper
 requests==2.31.0

--- a/tox.ini
+++ b/tox.ini
@@ -24,7 +24,7 @@ description = Run the new-style tests
 [testenv:flake8]
 skip_install = true
 deps =
-    flake8<6.0.0
+    flake8
     flake8-docstrings
     black==24.8.0
     flake8-black
@@ -37,7 +37,7 @@ description = Run the flake8 code quality checks
 [testenv:lint]
 usedevelop = true
 deps =
-    black
+    black==24.8.0
     isort
     pyyaml
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -24,7 +24,7 @@ description = Run the new-style tests
 [testenv:flake8]
 skip_install = true
 deps =
-    flake8<5.0.0
+    flake8<6.0.0
     flake8-docstrings
     black==24.8.0
     flake8-black


### PR DESCRIPTION
This PR does the following:

1. Runs `pinact run --update` which pins each dependency in GitHub Actions to promote reproducibility
2. Adds minor spacing to make GitHub Actions configurations more readable
3. Update to running on modern Python 3.14

> [!WARNING]
> to accept this PR, the branch protection rules need to get updated, since there's no longer going to be a py310-tagged run